### PR TITLE
fix the names of NIST SP 800-53 standards to be the correct names of the publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,20 @@ dependencies:
 For more information on the opencontrol.yaml visit the [Compliance Masonry CLI](https://github.com/opencontrol/compliance-masonry#creating-an-opencontrol-project).
 
 
-## Using the NIST 800-53 standards
-On 1-APR-2018, the NIST 800-53 standard files were updated to allow OpenControl content authors to specify which revision of NIST 800-53 should be used. There are now three options:
+## Using the NIST SP 800-53 standards
+On 1-APR-2018, the NIST SP 800-53 standard files were updated to allow OpenControl content authors to specify which revision of NIST SP 800-53 should be used. There are now three options:
 
-- NIST-800-53 rev3: Legacy NIST 800-53 revision 3 content [[nist-800-53-rev3.yaml](https://github.com/opencontrol/standards/blob/master/nist-800-53-rev3.yaml)]
-- NIST-800-53 rev4: NIST 800-53 revision 4 content [[nist-800-53-rev4.yaml](https://github.com/opencontrol/standards/blob/master/nist-800-53-rev3.yaml)]
-- NIST-800-53: Special target that will always point to latest NIST revision upon ratification from NIST. Currently this is rev4, and will automatically  transition to rev5 when available. [[nist-800-53-latest.yaml](https://github.com/shawndwells/standards/blob/master/nist-800-53-latest.yaml)]
+- `NIST SP 800-53 Rev. 3`: Legacy NIST SP 800-53 revision 3 content [[nist-800-53-rev3.yaml](https://github.com/opencontrol/standards/blob/master/nist-800-53-rev3.yaml)]
+- `NIST SP 800-53 Rev. 4`: NIST SP 800-53 revision 4 content [[nist-800-53-rev4.yaml](https://github.com/opencontrol/standards/blob/master/nist-800-53-rev3.yaml)]
+- `NIST SP 800-53`: Special target that will always point to latest NIST revision upon ratification from NIST. Currently this is Rev. 4, and will automatically transition to Rev. 5 when available. [[nist-800-53-latest.yaml](https://github.com/shawndwells/standards/blob/master/nist-800-53-latest.yaml)]
 
 ### Sample component.yaml
-When creating OpenControl content for components, the ``standard_key`` should be updated to reflect which NIST 800-53 content should be used.
+When creating OpenControl content for components, the ``standard_key`` should be updated to reflect which NIST SP 800-53 content should be used.
 
-For example, for NIST 800-53 rev4:
+For example, for NIST SP 800-53 Rev. 4:
 `````
 - control_key: AC-2 (2)
-  standard_key: NIST-800-53 rev4
+  standard_key: NIST SP 800-53 Rev. 4
   covered_by: []
   implementation_status: Implemented
   narrative:
@@ -36,7 +36,7 @@ And for your content to automatically use the latest revision, use:
 
 `````
 - control_key: AC-2 (2)
-  standard_key: NIST-800-53
+  standard_key: NIST SP 800-53
   covered_by: []
   implementation_status: Not applicable
   narrative:

--- a/nist-800-53-latest.yaml
+++ b/nist-800-53-latest.yaml
@@ -1,4 +1,4 @@
-name: NIST-800-53
+name: NIST SP 800-53 Rev. 4
 AC-1:
   family: AC
   name: Access Control Policy And Procedures

--- a/nist-800-53-rev3.yaml
+++ b/nist-800-53-rev3.yaml
@@ -1,4 +1,4 @@
-name: NIST-800-53 rev3
+name: NIST SP 800-53 Rev. 3
 AC-1:
   family: AC
   name: Access Control Policy And Procedures

--- a/nist-800-53-rev4.yaml
+++ b/nist-800-53-rev4.yaml
@@ -1,4 +1,4 @@
-name: NIST-800-53 rev4
+name: NIST SP 800-53 Rev. 4
 AC-1:
   family: AC
   name: Access Control Policy And Procedures

--- a/utils/README.md
+++ b/utils/README.md
@@ -13,7 +13,7 @@ To run the ``parser.go`` script:
 $ go run utils/parser.go <output>
 ``
 
-For example, when NIST 800-53 rev5 comes out:
+For example, when NIST SP 800-53 Rev. 5 comes out:
 ``
 $ go run utils/parser.go nist-800-53-rev5.yaml
 ``

--- a/utils/parser.go
+++ b/utils/parser.go
@@ -122,7 +122,7 @@ func main() {
 		}
 	}
 
-	standard := Standard{Name: "NIST-800-53", Controls: controls}
+	standard := Standard{Name: "NIST SP 800-53 Rev. 4", Controls: controls}
 
 	y, err := yaml.Marshal(&standard)
 	if err != nil {


### PR DESCRIPTION
"NIST-800-53-rev4" is a kind of fine abbreviation, but it's not the correct title of the publication, which is "NIST SP 800-53 Rev. 4". Maybe the `name` isn't supposed to be used for display purposes, but there's no other place to store the actual name of a standard, so it would make sense to get this field right.

Unfortunately, changing the `name` value within these standards will break OpenControl systems using Compliance Masonry that refer to these standards because Compliance Masonry compares the `standard_key` that appears in components against the standard's `name` field.

Nevertheless, the name is wrong. The OpenControl schema is unclear on the matter and currently suggests by a parallel with the component key that a standard's "key" is its filename if the YAML file doesn't contain a `key` itself. (`key: Key of the component (defaults to the filename if not present)`) One way to look at it, then, is that Compliance Masonry isn't complying with the schema.

Either:

a) Compliance Masonry should be updated to not use the `name` as a `key` and the OpenControl schema should be updated to have the `standard_key` in controls match against a new `key` field rather than `name` in standards, or
b) A new (e.g.) `title` field should be added to the schema to store the actual name of the standards for display purposes.