### PR TITLE
Improve command-line arguments handling of ./utils/

### DIFF
--- a/utils/parser.go
+++ b/utils/parser.go
@@ -69,6 +69,10 @@ type XMLReference struct {
 }
 
 func main() {
+	if len(os.Args) == 1 {
+		panic("Expecting command-line argument: output-file.yaml")
+	}
+
 	resp, err := http.Get(standardURL)
 	if err != nil {
 		panic(err)

--- a/utils/parser.go
+++ b/utils/parser.go
@@ -2,17 +2,15 @@ package main
 
 import (
 	"encoding/xml"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"regexp"
 	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 )
-
-const standardURL = "http://nvd.nist.gov/static/feeds/xml/sp80053/rev4/800-53-controls.xml"
 
 type XMLStandard struct {
 	Controls []XMLControl `xml:"control"`
@@ -69,11 +67,14 @@ type XMLReference struct {
 }
 
 func main() {
-	if len(os.Args) == 1 {
+	standardURL := flag.String("source", "http://nvd.nist.gov/static/feeds/xml/sp80053/rev4/800-53-controls.xml", "url to fetch controls from")
+	flag.Parse()
+
+	if len(flag.Args()) == 0 {
 		panic("Expecting command-line argument: output-file.yaml")
 	}
 
-	resp, err := http.Get(standardURL)
+	resp, err := http.Get(*standardURL)
 	if err != nil {
 		panic(err)
 	}
@@ -133,7 +134,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := ioutil.WriteFile(os.Args[1], y, 0644); err != nil {
+	if err := ioutil.WriteFile(flag.Arg(0), y, 0644); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
## Firstly
Addressing:
```
$ go run utils/parser.go
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
main.main()
	standards/utils/parser.go:137 +0x14f1
exit status 2
```

## Secondly
Let the source URL to be command-line parameter

Also, replase os.Args() with flag.Args() that are slightly more powerful.