### PR TITLE
Remove unnecessary quotes and double quotes

### DIFF
--- a/nist-800-53-latest.yaml
+++ b/nist-800-53-latest.yaml
@@ -35,36 +35,36 @@ AC-2:
 AC-2 (1):
   family: AC
   name: Automated System Account Management
-  description: '"The organization employs automated mechanisms to support the management
-    of information system accounts."'
+  description: The organization employs automated mechanisms to support the management
+    of information system accounts.
 AC-2 (2):
   family: AC
   name: Removal Of Temporary / Emergency Accounts
-  description: '"The information system automatically [Selection: removes; disables]
+  description: 'The information system automatically [Selection: removes; disables]
     temporary and emergency accounts after [Assignment: organization-defined time
-    period for each type of account]."'
+    period for each type of account].'
 AC-2 (3):
   family: AC
   name: Disable Inactive Accounts
-  description: '"The information system automatically disables inactive accounts after
-    [Assignment: organization-defined time period]."'
+  description: 'The information system automatically disables inactive accounts after
+    [Assignment: organization-defined time period].'
 AC-2 (4):
   family: AC
   name: Automated Audit Actions
-  description: '"The information system automatically audits account creation, modification,
+  description: 'The information system automatically audits account creation, modification,
     enabling, disabling, and removal actions, and notifies [Assignment: organization-defined
-    personnel or roles]."'
+    personnel or roles].'
 AC-2 (5):
   family: AC
   name: Inactivity Logout
-  description: '"The organization requires that users log out when [Assignment: organization-defined
-    time-period of expected inactivity or description of when to log out]."'
+  description: 'The organization requires that users log out when [Assignment: organization-defined
+    time-period of expected inactivity or description of when to log out].'
 AC-2 (6):
   family: AC
   name: Dynamic Privilege Management
-  description: '"The information system implements the following dynamic privilege
+  description: 'The information system implements the following dynamic privilege
     management capabilities: [Assignment: organization-defined list of dynamic privilege
-    management capabilities]."'
+    management capabilities].'
 AC-2 (7):
   family: AC
   name: Role-Based Schemes
@@ -76,25 +76,25 @@ AC-2 (7):
 AC-2 (8):
   family: AC
   name: Dynamic Account Creation
-  description: '"The information system creates [Assignment: organization-defined
-    information system accounts] dynamically."'
+  description: 'The information system creates [Assignment: organization-defined information
+    system accounts] dynamically.'
 AC-2 (9):
   family: AC
   name: Restrictions On Use Of Shared / Group Accounts
-  description: '"The organization only permits the use of shared/group accounts that
+  description: 'The organization only permits the use of shared/group accounts that
     meet [Assignment: organization-defined conditions for establishing shared/group
-    accounts]."'
+    accounts].'
 AC-2 (10):
   family: AC
   name: Shared / Group Account Credential Termination
-  description: '"The information system terminates shared/group account credentials
-    when members leave the group."'
+  description: The information system terminates shared/group account credentials
+    when members leave the group.
 AC-2 (11):
   family: AC
   name: Usage Conditions
-  description: '"The information system enforces [Assignment: organization-defined
+  description: 'The information system enforces [Assignment: organization-defined
     circumstances and/or usage conditions] for [Assignment: organization-defined information
-    system accounts]."'
+    system accounts].'
 AC-2 (12):
   family: AC
   name: Account Monitoring / Atypical Usage
@@ -105,9 +105,8 @@ AC-2 (12):
 AC-2 (13):
   family: AC
   name: Disable Accounts For High-Risk Individuals
-  description: '"The organization disables accounts of users posing a significant
-    risk within [Assignment: organization-defined time period] of discovery of the
-    risk."'
+  description: 'The organization disables accounts of users posing a significant risk
+    within [Assignment: organization-defined time period] of discovery of the risk.'
 AC-3:
   family: AC
   name: Access Enforcement
@@ -117,12 +116,12 @@ AC-3:
 AC-3 (1):
   family: AC
   name: Restricted Access To Privileged Functions
-  description: '"[Withdrawn: Incorporated into AC-6]."'
+  description: '[Withdrawn: Incorporated into AC-6].'
 AC-3 (2):
   family: AC
   name: Dual Authorization
-  description: '"The information system enforces dual authorization for [Assignment:
-    organization-defined privileged commands and/or other organization-defined actions]."'
+  description: 'The information system enforces dual authorization for [Assignment:
+    organization-defined privileged commands and/or other organization-defined actions].'
 AC-3 (3):
   family: AC
   name: Mandatory Access Control
@@ -149,25 +148,25 @@ AC-3 (4):
 AC-3 (5):
   family: AC
   name: Security-Relevant Information
-  description: '"The information system prevents access to [Assignment: organization-defined
-    security-relevant information] except during secure, non-operable system states."'
+  description: 'The information system prevents access to [Assignment: organization-defined
+    security-relevant information] except during secure, non-operable system states.'
 AC-3 (6):
   family: AC
   name: Protection Of User And System Information
-  description: '"[Withdrawn: Incorporated into MP-4 and SC-28]."'
+  description: '[Withdrawn: Incorporated into MP-4 and SC-28].'
 AC-3 (7):
   family: AC
   name: Role-Based Access Control
-  description: '"The information system enforces a role-based access control policy
+  description: 'The information system enforces a role-based access control policy
     over defined subjects and objects and controls access based upon [Assignment:
-    organization-defined roles and users authorized to assume such roles]."'
+    organization-defined roles and users authorized to assume such roles].'
 AC-3 (8):
   family: AC
   name: Revocation Of Access Authorizations
-  description: '"The information system enforces the revocation of access authorizations
+  description: 'The information system enforces the revocation of access authorizations
     resulting from changes to the security attributes of subjects and objects based
     on [Assignment: organization-defined rules governing the timing of revocations
-    of access authorizations]."'
+    of access authorizations].'
 AC-3 (9):
   family: AC
   name: Controlled Release
@@ -178,8 +177,8 @@ AC-3 (9):
 AC-3 (10):
   family: AC
   name: Audited Override Of Access Control Mechanisms
-  description: '"The organization employs an audited override of automated access
-    control mechanisms under [Assignment: organization-defined conditions]."'
+  description: 'The organization employs an audited override of automated access control
+    mechanisms under [Assignment: organization-defined conditions].'
 AC-4:
   family: AC
   name: Information Flow Enforcement
@@ -189,141 +188,141 @@ AC-4:
 AC-4 (1):
   family: AC
   name: Object Security Attributes
-  description: '"The information system uses [Assignment: organization-defined security
+  description: 'The information system uses [Assignment: organization-defined security
     attributes] associated with [Assignment: organization-defined information, source,
     and destination objects] to enforce [Assignment: organization-defined information
-    flow control policies] as a basis for flow control decisions."'
+    flow control policies] as a basis for flow control decisions.'
 AC-4 (2):
   family: AC
   name: Processing Domains
-  description: '"The information system uses protected processing domains to enforce
+  description: 'The information system uses protected processing domains to enforce
     [Assignment: organization-defined information flow control policies] as a basis
-    for flow control decisions."'
+    for flow control decisions.'
 AC-4 (3):
   family: AC
   name: Dynamic Information Flow Control
-  description: '"The information system enforces dynamic information flow control
-    based on [Assignment: organization-defined policies]."'
+  description: 'The information system enforces dynamic information flow control based
+    on [Assignment: organization-defined policies].'
 AC-4 (4):
   family: AC
   name: Content Check Encrypted Information
-  description: '"The information system prevents encrypted information from bypassing
+  description: 'The information system prevents encrypted information from bypassing
     content-checking mechanisms by [Selection (one or more): decrypting the information;
     blocking the flow of the encrypted information; terminating communications sessions
     attempting to pass encrypted information; [Assignment: organization-defined procedure
-    or method]]."'
+    or method]].'
 AC-4 (5):
   family: AC
   name: Embedded Data Types
-  description: '"The information system enforces [Assignment: organization-defined
-    limitations] on embedding data types within other data types."'
+  description: 'The information system enforces [Assignment: organization-defined
+    limitations] on embedding data types within other data types.'
 AC-4 (6):
   family: AC
   name: Metadata
-  description: '"The information system enforces information flow control based on
-    [Assignment: organization-defined metadata]."'
+  description: 'The information system enforces information flow control based on
+    [Assignment: organization-defined metadata].'
 AC-4 (7):
   family: AC
   name: One-Way Flow Mechanisms
-  description: '"The information system enforces [Assignment: organization-defined
-    one-way information flows] using hardware mechanisms."'
+  description: 'The information system enforces [Assignment: organization-defined
+    one-way information flows] using hardware mechanisms.'
 AC-4 (8):
   family: AC
   name: Security Policy Filters
-  description: '"The information system enforces information flow control using [Assignment:
+  description: 'The information system enforces information flow control using [Assignment:
     organization-defined security policy filters] as a basis for flow control decisions
-    for [Assignment: organization-defined information flows]."'
+    for [Assignment: organization-defined information flows].'
 AC-4 (9):
   family: AC
   name: Human Reviews
-  description: '"The information system enforces the use of human reviews for [Assignment:
+  description: 'The information system enforces the use of human reviews for [Assignment:
     organization-defined information flows] under the following conditions: [Assignment:
-    organization-defined conditions]."'
+    organization-defined conditions].'
 AC-4 (10):
   family: AC
   name: Enable / Disable Security Policy Filters
-  description: '"The information system provides the capability for privileged administrators
+  description: 'The information system provides the capability for privileged administrators
     to enable/disable [Assignment: organization-defined security policy filters] under
-    the following conditions: [Assignment: organization-defined conditions]."'
+    the following conditions: [Assignment: organization-defined conditions].'
 AC-4 (11):
   family: AC
   name: Configuration Of Security Policy Filters
-  description: '"The information system provides the capability for privileged administrators
+  description: 'The information system provides the capability for privileged administrators
     to configure [Assignment: organization-defined security policy filters] to support
-    different security policies."'
+    different security policies.'
 AC-4 (12):
   family: AC
   name: Data Type Identifiers
-  description: '"The information system, when transferring information between different
+  description: 'The information system, when transferring information between different
     security domains, uses [Assignment: organization-defined data type identifiers]
-    to validate data essential for information flow decisions."'
+    to validate data essential for information flow decisions.'
 AC-4 (13):
   family: AC
   name: Decomposition Into Policy-Relevant Subcomponents
-  description: '"The information system, when transferring information between different
+  description: 'The information system, when transferring information between different
     security domains, decomposes information into [Assignment: organization-defined
-    policy-relevant subcomponents] for submission to policy enforcement mechanisms."'
+    policy-relevant subcomponents] for submission to policy enforcement mechanisms.'
 AC-4 (14):
   family: AC
   name: Security Policy Filter Constraints
-  description: '"The information system, when transferring information between different
+  description: 'The information system, when transferring information between different
     security domains, implements [Assignment: organization-defined security policy
-    filters] requiring fully enumerated formats that restrict data structure and content."'
+    filters] requiring fully enumerated formats that restrict data structure and content.'
 AC-4 (15):
   family: AC
   name: Detection Of Unsanctioned Information
-  description: '"The information system, when transferring information between different
+  description: 'The information system, when transferring information between different
     security domains, examines the information for the presence of [Assignment: organized-defined
     unsanctioned information] and prohibits the transfer of such information in accordance
-    with the [Assignment: organization-defined security policy]."'
+    with the [Assignment: organization-defined security policy].'
 AC-4 (16):
   family: AC
   name: Information Transfers On Interconnected Systems
-  description: '"[Withdrawn: Incorporated into AC-4]."'
+  description: '[Withdrawn: Incorporated into AC-4].'
 AC-4 (17):
   family: AC
   name: Domain Authentication
-  description: '"The information system uniquely identifies and authenticates source
+  description: 'The information system uniquely identifies and authenticates source
     and destination points by [Selection (one or more): organization, system, application,
-    individual] for information transfer."'
+    individual] for information transfer.'
 AC-4 (18):
   family: AC
   name: Security Attribute Binding
-  description: '"The information system binds security attributes to information using
+  description: 'The information system binds security attributes to information using
     [Assignment: organization-defined binding techniques] to facilitate information
-    flow policy enforcement."'
+    flow policy enforcement.'
 AC-4 (19):
   family: AC
   name: Validation Of Metadata
-  description: '"The information system, when transferring information between different
+  description: The information system, when transferring information between different
     security domains, applies the same security policy filtering to metadata as it
-    applies to data payloads."'
+    applies to data payloads.
 AC-4 (20):
   family: AC
   name: Approved Solutions
-  description: '"The organization employs [Assignment: organization-defined solutions
+  description: 'The organization employs [Assignment: organization-defined solutions
     in approved configurations] to control the flow of [Assignment: organization-defined
-    information] across security domains."'
+    information] across security domains.'
 AC-4 (21):
   family: AC
   name: Physical / Logical Separation Of Information Flows
-  description: '"The information system separates information flows logically or physically
+  description: 'The information system separates information flows logically or physically
     using [Assignment: organization-defined mechanisms and/or techniques] to accomplish
-    [Assignment: organization-defined required separations by types of information]."'
+    [Assignment: organization-defined required separations by types of information].'
 AC-4 (22):
   family: AC
   name: Access Only
-  description: '"The information system provides access from a single device to computing
+  description: The information system provides access from a single device to computing
     platforms, applications, or data residing on multiple different security domains,
-    while preventing any information flow between the different security domains."'
+    while preventing any information flow between the different security domains.
 AC-5:
   family: AC
   name: Separation Of Duties
   description: |-
-    The organization:
+    "The organization:
       a.  Separates [Assignment: organization-defined duties of individuals];
       b.  Documents separation of duties of individuals; and
-      c.  Defines information system access authorizations to support separation of duties.
+      c.  Defines information system access authorizations to support separation of duties."
 AC-6:
   family: AC
   name: Least Privilege
@@ -334,38 +333,38 @@ AC-6:
 AC-6 (1):
   family: AC
   name: Authorize Access To Security Functions
-  description: '"The organization explicitly authorizes access to [Assignment: organization-defined
+  description: 'The organization explicitly authorizes access to [Assignment: organization-defined
     security functions (deployed in hardware, software, and firmware) and security-relevant
-    information]."'
+    information].'
 AC-6 (2):
   family: AC
   name: Non-Privileged Access For Nonsecurity Functions
-  description: '"The organization requires that users of information system accounts,
+  description: 'The organization requires that users of information system accounts,
     or roles, with access to [Assignment: organization-defined security functions
     or security-relevant information], use non-privileged accounts or roles, when
-    accessing nonsecurity functions."'
+    accessing nonsecurity functions.'
 AC-6 (3):
   family: AC
   name: Network Access To Privileged Commands
-  description: '"The organization authorizes network access to [Assignment: organization-defined
+  description: 'The organization authorizes network access to [Assignment: organization-defined
     privileged commands] only for [Assignment: organization-defined compelling operational
     needs] and documents the rationale for such access in the security plan for the
-    information system."'
+    information system.'
 AC-6 (4):
   family: AC
   name: Separate Processing Domains
-  description: '"The information system provides separate processing domains to enable
-    finer-grained allocation of user privileges."'
+  description: The information system provides separate processing domains to enable
+    finer-grained allocation of user privileges.
 AC-6 (5):
   family: AC
   name: Privileged Accounts
-  description: '"The organization restricts privileged accounts on the information
-    system to [Assignment: organization-defined personnel or roles]."'
+  description: 'The organization restricts privileged accounts on the information
+    system to [Assignment: organization-defined personnel or roles].'
 AC-6 (6):
   family: AC
   name: Privileged Access By Non-Organizational Users
-  description: '"The organization prohibits privileged access to the information system
-    by non-organizational users."'
+  description: The organization prohibits privileged access to the information system
+    by non-organizational users.
 AC-6 (7):
   family: AC
   name: Review Of User Privileges
@@ -376,18 +375,18 @@ AC-6 (7):
 AC-6 (8):
   family: AC
   name: Privilege Levels For Code Execution
-  description: '"The information system prevents [Assignment: organization-defined
-    software] from executing at higher privilege levels than users executing the software."'
+  description: 'The information system prevents [Assignment: organization-defined
+    software] from executing at higher privilege levels than users executing the software.'
 AC-6 (9):
   family: AC
   name: Auditing Use Of Privileged Functions
-  description: '"The information system audits the execution of privileged functions."'
+  description: The information system audits the execution of privileged functions.
 AC-6 (10):
   family: AC
   name: Prohibit Non-Privileged Users From Executing Privileged Functions
-  description: '"The information system prevents non-privileged users from executing
+  description: The information system prevents non-privileged users from executing
     privileged functions to include disabling, circumventing, or altering implemented
-    security safeguards/countermeasures."'
+    security safeguards/countermeasures.
 AC-7:
   family: AC
   name: Unsuccessful Logon Attempts
@@ -398,14 +397,14 @@ AC-7:
 AC-7 (1):
   family: AC
   name: Automatic Account Lock
-  description: '"[Withdrawn: Incorporated into AC-7]."'
+  description: '[Withdrawn: Incorporated into AC-7].'
 AC-7 (2):
   family: AC
   name: Purge / Wipe Mobile Device
-  description: '"The information system purges/wipes information from [Assignment:
+  description: 'The information system purges/wipes information from [Assignment:
     organization-defined mobile devices] based on [Assignment: organization-defined
     purging/wiping requirements/techniques] after [Assignment: organization-defined
-    number] consecutive, unsuccessful device logon attempts."'
+    number] consecutive, unsuccessful device logon attempts.'
 AC-8:
   family: AC
   name: System Use Notification
@@ -429,27 +428,27 @@ AC-9:
 AC-9 (1):
   family: AC
   name: Unsuccessful Logons
-  description: '"The information system notifies the user, upon successful logon/access,
+  description: The information system notifies the user, upon successful logon/access,
     of the number of unsuccessful logon/access attempts since the last successful
-    logon/access."'
+    logon/access.
 AC-9 (2):
   family: AC
   name: Successful / Unsuccessful Logons
-  description: '"The information system notifies the user of the number of [Selection:
+  description: 'The information system notifies the user of the number of [Selection:
     successful logons/accesses; unsuccessful logon/access attempts; both] during [Assignment:
-    organization-defined time period]."'
+    organization-defined time period].'
 AC-9 (3):
   family: AC
   name: Notification Of Account Changes
-  description: '"The information system notifies the user of changes to [Assignment:
-    organization-defined security-related characteristics/parameters of the user�s
-    account] during [Assignment: organization-defined time period]."'
+  description: 'The information system notifies the user of changes to [Assignment:
+    organization-defined security-related characteristics/parameters of the user''s
+    account] during [Assignment: organization-defined time period].'
 AC-9 (4):
   family: AC
   name: Additional Logon Information
-  description: '"The information system notifies the user, upon successful logon (access),
+  description: 'The information system notifies the user, upon successful logon (access),
     of the following additional information: [Assignment: organization-defined information
-    to be included in addition to the date and time of the last logon (access)]."'
+    to be included in addition to the date and time of the last logon (access)].'
 AC-10:
   family: AC
   name: Concurrent Session Control
@@ -466,8 +465,8 @@ AC-11:
 AC-11 (1):
   family: AC
   name: Pattern-Hiding Displays
-  description: '"The information system conceals, via the session lock, information
-    previously visible on the display with a publicly viewable image."'
+  description: The information system conceals, via the session lock, information
+    previously visible on the display with a publicly viewable image.
 AC-12:
   family: AC
   name: Session Termination
@@ -495,7 +494,7 @@ AC-14:
 AC-14 (1):
   family: AC
   name: Necessary Uses
-  description: '"[Withdrawn: Incorporated into AC-14]."'
+  description: '[Withdrawn: Incorporated into AC-14].'
 AC-15:
   family: AC
   name: Automated Marking
@@ -512,65 +511,65 @@ AC-16:
 AC-16 (1):
   family: AC
   name: Dynamic Attribute Association
-  description: '"The information system dynamically associates security attributes
+  description: 'The information system dynamically associates security attributes
     with [Assignment: organization-defined subjects and objects] in accordance with
     [Assignment: organization-defined security policies] as information is created
-    and combined."'
+    and combined.'
 AC-16 (2):
   family: AC
   name: Attribute Value Changes By Authorized Individuals
-  description: '"The information system provides authorized individuals (or processes
+  description: The information system provides authorized individuals (or processes
     acting on behalf of individuals) the capability to define or change the value
-    of associated security attributes."'
+    of associated security attributes.
 AC-16 (3):
   family: AC
   name: Maintenance Of Attribute Associations By Information System
-  description: '"The information system maintains the association and integrity of
+  description: 'The information system maintains the association and integrity of
     [Assignment: organization-defined security attributes] to [Assignment: organization-defined
-    subjects and objects]."'
+    subjects and objects].'
 AC-16 (4):
   family: AC
   name: Association Of Attributes By Authorized Individuals
-  description: '"The information system supports the association of [Assignment: organization-defined
+  description: 'The information system supports the association of [Assignment: organization-defined
     security attributes] with [Assignment: organization-defined subjects and objects]
-    by authorized individuals (or processes acting on behalf of individuals)."'
+    by authorized individuals (or processes acting on behalf of individuals).'
 AC-16 (5):
   family: AC
   name: Attribute Displays For Output Devices
-  description: '"The information system displays security attributes in human-readable
+  description: 'The information system displays security attributes in human-readable
     form on each object that the system transmits to output devices to identify [Assignment:
     organization-identified special dissemination, handling, or distribution instructions]
-    using [Assignment: organization-identified human-readable, standard naming conventions]."'
+    using [Assignment: organization-identified human-readable, standard naming conventions].'
 AC-16 (6):
   family: AC
   name: Maintenance Of Attribute Association By Organization
-  description: '"The organization allows personnel to associate, and maintain the
-    association of [Assignment: organization-defined security attributes] with [Assignment:
-    organization-defined subjects and objects] in accordance with [Assignment: organization-defined
-    security policies]."'
+  description: 'The organization allows personnel to associate, and maintain the association
+    of [Assignment: organization-defined security attributes] with [Assignment: organization-defined
+    subjects and objects] in accordance with [Assignment: organization-defined security
+    policies].'
 AC-16 (7):
   family: AC
   name: Consistent Attribute Interpretation
-  description: '"The organization provides a consistent interpretation of security
-    attributes transmitted between distributed information system components."'
+  description: The organization provides a consistent interpretation of security attributes
+    transmitted between distributed information system components.
 AC-16 (8):
   family: AC
   name: Association Techniques / Technologies
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     techniques or technologies] with [Assignment: organization-defined level of assurance]
-    in associating security attributes to information."'
+    in associating security attributes to information.'
 AC-16 (9):
   family: AC
   name: Attribute Reassignment
-  description: '"The organization ensures that security attributes associated with
+  description: 'The organization ensures that security attributes associated with
     information are reassigned only via re-grading mechanisms validated using [Assignment:
-    organization-defined techniques or procedures]."'
+    organization-defined techniques or procedures].'
 AC-16 (10):
   family: AC
   name: Attribute Configuration By Authorized Individuals
-  description: '"The information system provides authorized individuals the capability
+  description: The information system provides authorized individuals the capability
     to define or change the type and value of security attributes available for association
-    with subjects and objects."'
+    with subjects and objects.
 AC-17:
   family: AC
   name: Remote Access
@@ -581,17 +580,17 @@ AC-17:
 AC-17 (1):
   family: AC
   name: Automated Monitoring / Control
-  description: '"The information system monitors and controls remote access methods."'
+  description: The information system monitors and controls remote access methods.
 AC-17 (2):
   family: AC
   name: Protection Of Confidentiality / Integrity Using Encryption
-  description: '"The information system implements cryptographic mechanisms to protect
-    the confidentiality and integrity of remote access sessions."'
+  description: The information system implements cryptographic mechanisms to protect
+    the confidentiality and integrity of remote access sessions.
 AC-17 (3):
   family: AC
   name: Managed Access Control Points
-  description: '"The information system routes all remote accesses through [Assignment:
-    organization-defined number] managed network access control points."'
+  description: 'The information system routes all remote accesses through [Assignment:
+    organization-defined number] managed network access control points.'
 AC-17 (4):
   family: AC
   name: Privileged Commands / Access
@@ -602,26 +601,26 @@ AC-17 (4):
 AC-17 (5):
   family: AC
   name: Monitoring For Unauthorized Connections
-  description: '"[Withdrawn: Incorporated into SI-4]."'
+  description: '[Withdrawn: Incorporated into SI-4].'
 AC-17 (6):
   family: AC
   name: Protection Of Information
-  description: '"The organization ensures that users protect information about remote
-    access mechanisms from unauthorized use and disclosure."'
+  description: The organization ensures that users protect information about remote
+    access mechanisms from unauthorized use and disclosure.
 AC-17 (7):
   family: AC
   name: Additional Protection For Security Function Access
-  description: '"[Withdrawn: Incorporated into AC-3 (10)]."'
+  description: '[Withdrawn: Incorporated into AC-3 (10)].'
 AC-17 (8):
   family: AC
   name: Disable Nonsecure Network Protocols
-  description: '"[Withdrawn: Incorporated into CM-7]."'
+  description: '[Withdrawn: Incorporated into CM-7].'
 AC-17 (9):
   family: AC
   name: Disconnect / Disable Access
-  description: '"The organization provides the capability to expeditiously disconnect
+  description: 'The organization provides the capability to expeditiously disconnect
     or disable remote access to the information system within [Assignment: organization-defined
-    time period]."'
+    time period].'
 AC-18:
   family: AC
   name: Wireless Access
@@ -632,29 +631,29 @@ AC-18:
 AC-18 (1):
   family: AC
   name: Authentication And Encryption
-  description: '"The information system protects wireless access to the system using
-    authentication of [Selection (one or more): users; devices] and encryption."'
+  description: 'The information system protects wireless access to the system using
+    authentication of [Selection (one or more): users; devices] and encryption.'
 AC-18 (2):
   family: AC
   name: Monitoring Unauthorized Connections
-  description: '"[Withdrawn: Incorporated into SI-4]."'
+  description: '[Withdrawn: Incorporated into SI-4].'
 AC-18 (3):
   family: AC
   name: Disable Wireless Networking
-  description: '"The organization disables, when not intended for use, wireless networking
+  description: The organization disables, when not intended for use, wireless networking
     capabilities internally embedded within information system components prior to
-    issuance and deployment."'
+    issuance and deployment.
 AC-18 (4):
   family: AC
   name: Restrict Configurations By Users
-  description: '"The organization identifies and explicitly authorizes users allowed
-    to independently configure wireless networking capabilities."'
+  description: The organization identifies and explicitly authorizes users allowed
+    to independently configure wireless networking capabilities.
 AC-18 (5):
   family: AC
   name: Antennas / Transmission Power Levels
-  description: '"The organization selects radio antennas and calibrates transmission
+  description: The organization selects radio antennas and calibrates transmission
     power levels to reduce the probability that usable signals can be received outside
-    of organization-controlled boundaries."'
+    of organization-controlled boundaries.
 AC-19:
   family: AC
   name: Access Control For Mobile Devices
@@ -665,15 +664,15 @@ AC-19:
 AC-19 (1):
   family: AC
   name: Use Of  Writable / Portable Storage Devices
-  description: '"[Withdrawn: Incorporated into MP-7]."'
+  description: '[Withdrawn: Incorporated into MP-7].'
 AC-19 (2):
   family: AC
   name: Use Of Personally Owned Portable Storage Devices
-  description: '"[Withdrawn: Incorporated into MP-7]."'
+  description: '[Withdrawn: Incorporated into MP-7].'
 AC-19 (3):
   family: AC
   name: Use Of Portable Storage Devices With No Identifiable Owner
-  description: '"[Withdrawn: Incorporated into MP-7]."'
+  description: '[Withdrawn: Incorporated into MP-7].'
 AC-19 (4):
   family: AC
   name: Restrictions For Classified Information
@@ -689,9 +688,9 @@ AC-19 (4):
 AC-19 (5):
   family: AC
   name: Full Device / Container-Based  Encryption
-  description: '"The organization employs [Selection: full-device encryption; container
+  description: 'The organization employs [Selection: full-device encryption; container
     encryption] to protect the confidentiality and integrity of information on [Assignment:
-    organization-defined mobile devices]."'
+    organization-defined mobile devices].'
 AC-20:
   family: AC
   name: Use Of External Information Systems
@@ -709,19 +708,19 @@ AC-20 (1):
 AC-20 (2):
   family: AC
   name: Portable Storage Devices
-  description: '"The organization [Selection: restricts; prohibits] the use of organization-controlled
-    portable storage devices by authorized individuals on external information systems."'
+  description: 'The organization [Selection: restricts; prohibits] the use of organization-controlled
+    portable storage devices by authorized individuals on external information systems.'
 AC-20 (3):
   family: AC
   name: Non-Organizationally Owned Systems / Components / Devices
-  description: '"The organization [Selection: restricts; prohibits] the use of non-organizationally
+  description: 'The organization [Selection: restricts; prohibits] the use of non-organizationally
     owned information systems, system components, or devices to process, store, or
-    transmit organizational information."'
+    transmit organizational information.'
 AC-20 (4):
   family: AC
   name: Network Accessible Storage Devices
-  description: '"The organization prohibits the use of [Assignment: organization-defined
-    network accessible storage devices] in external information systems."'
+  description: 'The organization prohibits the use of [Assignment: organization-defined
+    network accessible storage devices] in external information systems.'
 AC-21:
   family: AC
   name: Information Sharing
@@ -732,14 +731,14 @@ AC-21:
 AC-21 (1):
   family: AC
   name: Automated Decision Support
-  description: '"The information system enforces information-sharing decisions by
-    authorized users based on access authorizations of sharing partners and access
-    restrictions on information to be shared."'
+  description: The information system enforces information-sharing decisions by authorized
+    users based on access authorizations of sharing partners and access restrictions
+    on information to be shared.
 AC-21 (2):
   family: AC
   name: Information Search And Retrieval
-  description: '"The information system implements information search and retrieval
-    services that enforce [Assignment: organization-defined information sharing restrictions]."'
+  description: 'The information system implements information search and retrieval
+    services that enforce [Assignment: organization-defined information sharing restrictions].'
 AC-22:
   family: AC
   name: Publicly Accessible Content
@@ -763,16 +762,16 @@ AC-24:
 AC-24 (1):
   family: AC
   name: Transmit Access Authorization Information
-  description: '"The information system transmits [Assignment: organization-defined
+  description: 'The information system transmits [Assignment: organization-defined
     access authorization information] using [Assignment: organization-defined security
     safeguards] to [Assignment: organization-defined information systems] that enforce
-    access control decisions."'
+    access control decisions.'
 AC-24 (2):
   family: AC
   name: No User Or Process Identity
-  description: '"The information system enforces access control decisions based on
+  description: 'The information system enforces access control decisions based on
     [Assignment: organization-defined security attributes] that do not include the
-    identity of the user or process acting on behalf of the user."'
+    identity of the user or process acting on behalf of the user.'
 AC-25:
   family: AC
   name: Reference Monitor
@@ -802,13 +801,13 @@ AT-2:
 AT-2 (1):
   family: AT
   name: Practical Exercises
-  description: '"The organization includes practical exercises in security awareness
-    training that simulate actual cyber attacks."'
+  description: The organization includes practical exercises in security awareness
+    training that simulate actual cyber attacks.
 AT-2 (2):
   family: AT
   name: Insider Threat
-  description: '"The organization includes security awareness training on recognizing
-    and reporting potential indicators of insider threat."'
+  description: The organization includes security awareness training on recognizing
+    and reporting potential indicators of insider threat.
 AT-3:
   family: AT
   name: Role-Based Security Training
@@ -820,26 +819,26 @@ AT-3:
 AT-3 (1):
   family: AT
   name: Environmental Controls
-  description: '"The organization provides [Assignment: organization-defined personnel
+  description: 'The organization provides [Assignment: organization-defined personnel
     or roles] with initial and [Assignment: organization-defined frequency] training
-    in the employment and operation of environmental controls."'
+    in the employment and operation of environmental controls.'
 AT-3 (2):
   family: AT
   name: Physical Security Controls
-  description: '"The organization provides [Assignment: organization-defined personnel
+  description: 'The organization provides [Assignment: organization-defined personnel
     or roles] with initial and [Assignment: organization-defined frequency] training
-    in the employment and operation of physical security controls."'
+    in the employment and operation of physical security controls.'
 AT-3 (3):
   family: AT
   name: Practical Exercises
-  description: '"The organization includes practical exercises in security training
-    that reinforce training objectives."'
+  description: The organization includes practical exercises in security training
+    that reinforce training objectives.
 AT-3 (4):
   family: AT
   name: Suspicious Communications And Anomalous System Behavior
-  description: '"The organization provides training to its personnel on [Assignment:
+  description: 'The organization provides training to its personnel on [Assignment:
     organization-defined indicators of malicious code] to recognize suspicious communications
-    and anomalous behavior in organizational information systems."'
+    and anomalous behavior in organizational information systems.'
 AT-4:
   family: AT
   name: Security Training Records
@@ -874,20 +873,20 @@ AU-2:
 AU-2 (1):
   family: AU
   name: Compilation Of Audit Records From Multiple Sources
-  description: '"[Withdrawn: Incorporated into AU-12]."'
+  description: '[Withdrawn: Incorporated into AU-12].'
 AU-2 (2):
   family: AU
   name: Selection Of Audit Events By Component
-  description: '"[Withdrawn: Incorporated into AU-12]."'
+  description: '[Withdrawn: Incorporated into AU-12].'
 AU-2 (3):
   family: AU
   name: Reviews And Updates
-  description: '"The organization reviews and updates the audited events [Assignment:
-    organization-defined frequency]."'
+  description: 'The organization reviews and updates the audited events [Assignment:
+    organization-defined frequency].'
 AU-2 (4):
   family: AU
   name: Privileged Functions
-  description: '"[Withdrawn: Incorporated into AC-6 (9)]."'
+  description: '[Withdrawn: Incorporated into AC-6 (9)].'
 AU-3:
   family: AU
   name: Content Of Audit Records
@@ -898,15 +897,15 @@ AU-3:
 AU-3 (1):
   family: AU
   name: Additional Audit Information
-  description: '"The information system generates audit records containing the following
+  description: 'The information system generates audit records containing the following
     additional information: [Assignment: organization-defined additional, more detailed
-    information]."'
+    information].'
 AU-3 (2):
   family: AU
   name: Centralized Management Of Planned Audit Record Content
-  description: '"The information system provides centralized management and configuration
+  description: 'The information system provides centralized management and configuration
     of the content to be captured in audit records generated by [Assignment: organization-defined
-    information system components]."'
+    information system components].'
 AU-4:
   family: AU
   name: Audit Storage Capacity
@@ -915,8 +914,8 @@ AU-4:
 AU-4 (1):
   family: AU
   name: Transfer To Alternate Storage
-  description: '"The information system off-loads audit records [Assignment: organization-defined
-    frequency] onto a different system or media than the system being audited."'
+  description: 'The information system off-loads audit records [Assignment: organization-defined
+    frequency] onto a different system or media than the system being audited.'
 AU-5:
   family: AU
   name: Response To Audit Processing Failures
@@ -927,30 +926,30 @@ AU-5:
 AU-5 (1):
   family: AU
   name: Audit Storage Capacity
-  description: '"The information system provides a warning to [Assignment: organization-defined
+  description: 'The information system provides a warning to [Assignment: organization-defined
     personnel, roles, and/or locations] within [Assignment: organization-defined time
     period] when allocated audit record storage volume reaches [Assignment: organization-defined
-    percentage] of repository maximum audit record storage capacity."'
+    percentage] of repository maximum audit record storage capacity.'
 AU-5 (2):
   family: AU
   name: Real-Time Alerts
-  description: '"The information system provides an alert in [Assignment: organization-defined
+  description: 'The information system provides an alert in [Assignment: organization-defined
     real-time period] to [Assignment: organization-defined personnel, roles, and/or
     locations] when the following audit failure events occur: [Assignment: organization-defined
-    audit failure events requiring real-time alerts]."'
+    audit failure events requiring real-time alerts].'
 AU-5 (3):
   family: AU
   name: Configurable Traffic Volume Thresholds
-  description: '"The information system enforces configurable network communications
+  description: 'The information system enforces configurable network communications
     traffic volume thresholds reflecting limits on auditing capacity and [Selection:
-    rejects; delays] network traffic above those thresholds."'
+    rejects; delays] network traffic above those thresholds.'
 AU-5 (4):
   family: AU
   name: Shutdown On Failure
-  description: '"The information system invokes a [Selection: full system shutdown;
+  description: 'The information system invokes a [Selection: full system shutdown;
     partial system shutdown; degraded operational mode with limited mission/business
     functionality available] in the event of [Assignment: organization-defined audit
-    failures], unless an alternate audit capability exists."'
+    failures], unless an alternate audit capability exists.'
 AU-6:
   family: AU
   name: Audit Review, Analysis, And Reporting
@@ -961,61 +960,60 @@ AU-6:
 AU-6 (1):
   family: AU
   name: Process Integration
-  description: '"The organization employs automated mechanisms to integrate audit
-    review, analysis, and reporting processes to support organizational processes
-    for investigation and response to suspicious activities."'
+  description: The organization employs automated mechanisms to integrate audit review,
+    analysis, and reporting processes to support organizational processes for investigation
+    and response to suspicious activities.
 AU-6 (2):
   family: AU
   name: Automated Security Alerts
-  description: '"[Withdrawn: Incorporated into SI-4]."'
+  description: '[Withdrawn: Incorporated into SI-4].'
 AU-6 (3):
   family: AU
   name: Correlate Audit Repositories
-  description: '"The organization analyzes and correlates audit records across different
-    repositories to gain organization-wide situational awareness."'
+  description: The organization analyzes and correlates audit records across different
+    repositories to gain organization-wide situational awareness.
 AU-6 (4):
   family: AU
   name: Central Review And Analysis
-  description: '"The information system provides the capability to centrally review
-    and analyze audit records from multiple components within the system."'
+  description: The information system provides the capability to centrally review
+    and analyze audit records from multiple components within the system.
 AU-6 (5):
   family: AU
   name: Integration / Scanning And Monitoring Capabilities
-  description: '"The organization integrates analysis of audit records with analysis
+  description: 'The organization integrates analysis of audit records with analysis
     of [Selection (one or more): vulnerability scanning information; performance data;
     information system monitoring information; [Assignment: organization-defined data/information
     collected from other sources]] to further enhance the ability to identify inappropriate
-    or unusual activity."'
+    or unusual activity.'
 AU-6 (6):
   family: AU
   name: Correlation With Physical Monitoring
-  description: '"The organization correlates information from audit records with information
+  description: The organization correlates information from audit records with information
     obtained from monitoring physical access to further enhance the ability to identify
-    suspicious, inappropriate, unusual, or malevolent activity."'
+    suspicious, inappropriate, unusual, or malevolent activity.
 AU-6 (7):
   family: AU
   name: Permitted Actions
-  description: '"The organization specifies the permitted actions for each [Selection
+  description: 'The organization specifies the permitted actions for each [Selection
     (one or more): information system process; role; user] associated with the review,
-    analysis, and reporting of audit information."'
+    analysis, and reporting of audit information.'
 AU-6 (8):
   family: AU
   name: Full Text Analysis Of Privileged Commands
-  description: '"The organization performs a full text analysis of audited privileged
+  description: The organization performs a full text analysis of audited privileged
     commands in a physically distinct component or subsystem of the information system,
-    or other information system that is dedicated to that analysis."'
+    or other information system that is dedicated to that analysis.
 AU-6 (9):
   family: AU
   name: Correlation With Information From Nontechnical Sources
-  description: '"The organization correlates information from nontechnical sources
-    with audit information to enhance organization-wide situational awareness."'
+  description: The organization correlates information from nontechnical sources with
+    audit information to enhance organization-wide situational awareness.
 AU-6 (10):
   family: AU
   name: Audit Level Adjustment
-  description: '"The organization adjusts the level of audit review, analysis, and
-    reporting within the information system when there is a change in risk based on
-    law enforcement information, intelligence information, or other credible sources
-    of information."'
+  description: The organization adjusts the level of audit review, analysis, and reporting
+    within the information system when there is a change in risk based on law enforcement
+    information, intelligence information, or other credible sources of information.
 AU-7:
   family: AU
   name: Audit Reduction And Report Generation
@@ -1026,15 +1024,15 @@ AU-7:
 AU-7 (1):
   family: AU
   name: Automatic Processing
-  description: '"The information system provides the capability to process audit records
+  description: 'The information system provides the capability to process audit records
     for events of interest based on [Assignment: organization-defined audit fields
-    within audit records]."'
+    within audit records].'
 AU-7 (2):
   family: AU
   name: Automatic Sort And Search
-  description: '"The information system provides the capability to sort and search
+  description: 'The information system provides the capability to sort and search
     audit records for events of interest based on the content of [Assignment: organization-defined
-    audit fields within audit records]."'
+    audit fields within audit records].'
 AU-8:
   family: AU
   name: Time Stamps
@@ -1052,9 +1050,9 @@ AU-8 (1):
 AU-8 (2):
   family: AU
   name: Secondary Authoritative Time Source
-  description: '"The information system identifies a secondary authoritative time
-    source that is located in a different geographic region than the primary authoritative
-    time source."'
+  description: The information system identifies a secondary authoritative time source
+    that is located in a different geographic region than the primary authoritative
+    time source.
 AU-9:
   family: AU
   name: Protection Of Audit Information
@@ -1063,34 +1061,34 @@ AU-9:
 AU-9 (1):
   family: AU
   name: Hardware Write-Once Media
-  description: '"The information system writes audit trails to hardware-enforced,
-    write-once media."'
+  description: The information system writes audit trails to hardware-enforced, write-once
+    media.
 AU-9 (2):
   family: AU
   name: Audit Backup On Separate Physical Systems / Components
-  description: '"The information system backs up audit records [Assignment: organization-defined
+  description: 'The information system backs up audit records [Assignment: organization-defined
     frequency] onto a physically different system or system component than the system
-    or component being audited."'
+    or component being audited.'
 AU-9 (3):
   family: AU
   name: Cryptographic Protection
-  description: '"The information system implements cryptographic mechanisms to protect
-    the integrity of audit information and audit tools."'
+  description: The information system implements cryptographic mechanisms to protect
+    the integrity of audit information and audit tools.
 AU-9 (4):
   family: AU
   name: Access By Subset Of Privileged Users
-  description: '"The organization authorizes access to management of audit functionality
-    to only [Assignment: organization-defined subset of privileged users]."'
+  description: 'The organization authorizes access to management of audit functionality
+    to only [Assignment: organization-defined subset of privileged users].'
 AU-9 (5):
   family: AU
   name: Dual Authorization
-  description: '"The organization enforces dual authorization for [Selection (one
-    or more): movement; deletion] of [Assignment: organization-defined audit information]."'
+  description: 'The organization enforces dual authorization for [Selection (one or
+    more): movement; deletion] of [Assignment: organization-defined audit information].'
 AU-9 (6):
   family: AU
   name: Read Only Access
-  description: '"The organization authorizes read-only access to audit information
-    to [Assignment: organization-defined subset of privileged users]."'
+  description: 'The organization authorizes read-only access to audit information
+    to [Assignment: organization-defined subset of privileged users].'
 AU-10:
   family: AU
   name: Non-Repudiation
@@ -1114,8 +1112,8 @@ AU-10 (2):
 AU-10 (3):
   family: AU
   name: Chain Of Custody
-  description: '"The information system maintains reviewer/releaser identity and credentials
-    within the established chain of custody for all information reviewed or released."'
+  description: The information system maintains reviewer/releaser identity and credentials
+    within the established chain of custody for all information reviewed or released.
 AU-10 (4):
   family: AU
   name: Validate Binding Of Information Reviewer Identity
@@ -1126,7 +1124,7 @@ AU-10 (4):
 AU-10 (5):
   family: AU
   name: Digital Signatures
-  description: '"[Withdrawn: Incorporated into SI-7]."'
+  description: '[Withdrawn: Incorporated into SI-7].'
 AU-11:
   family: AU
   name: Audit Record Retention
@@ -1137,9 +1135,9 @@ AU-11:
 AU-11 (1):
   family: AU
   name: Long-Term Retrieval Capability
-  description: '"The organization employs [Assignment: organization-defined measures]
+  description: 'The organization employs [Assignment: organization-defined measures]
     to ensure that long-term audit records generated by the information system can
-    be retrieved."'
+    be retrieved.'
 AU-12:
   family: AU
   name: Audit Generation
@@ -1151,23 +1149,23 @@ AU-12:
 AU-12 (1):
   family: AU
   name: System-Wide / Time-Correlated Audit Trail
-  description: '"The information system compiles audit records from [Assignment: organization-defined
+  description: 'The information system compiles audit records from [Assignment: organization-defined
     information system components] into a system-wide (logical or physical) audit
     trail that is time-correlated to within [Assignment: organization-defined level
     of tolerance for the relationship between time stamps of individual records in
-    the audit trail]."'
+    the audit trail].'
 AU-12 (2):
   family: AU
   name: Standardized Formats
-  description: '"The information system produces a system-wide (logical or physical)
-    audit trail composed of audit records in a standardized format."'
+  description: The information system produces a system-wide (logical or physical)
+    audit trail composed of audit records in a standardized format.
 AU-12 (3):
   family: AU
   name: Changes By Authorized Individuals
-  description: '"The information system provides the capability for [Assignment: organization-defined
+  description: 'The information system provides the capability for [Assignment: organization-defined
     individuals or roles] to change the auditing to be performed on [Assignment: organization-defined
     information system components] based on [Assignment: organization-defined selectable
-    event criteria] within [Assignment: organization-defined time thresholds]."'
+    event criteria] within [Assignment: organization-defined time thresholds].'
 AU-13:
   family: AU
   name: Monitoring For Information Disclosure
@@ -1177,13 +1175,13 @@ AU-13:
 AU-13 (1):
   family: AU
   name: Use Of Automated Tools
-  description: '"The organization employs automated mechanisms to determine if organizational
-    information has been disclosed in an unauthorized manner."'
+  description: The organization employs automated mechanisms to determine if organizational
+    information has been disclosed in an unauthorized manner.
 AU-13 (2):
   family: AU
   name: Review Of Monitored Sites
-  description: '"The organization reviews the open source information sites being
-    monitored [Assignment: organization-defined frequency]."'
+  description: 'The organization reviews the open source information sites being monitored
+    [Assignment: organization-defined frequency].'
 AU-14:
   family: AU
   name: Session Audit
@@ -1192,18 +1190,18 @@ AU-14:
 AU-14 (1):
   family: AU
   name: System Start-Up
-  description: '"The information system initiates session audits at system start-up."'
+  description: The information system initiates session audits at system start-up.
 AU-14 (2):
   family: AU
   name: Capture/Record And Log Content
-  description: '"The information system provides the capability for authorized users
-    to capture/record and log content related to a user session."'
+  description: The information system provides the capability for authorized users
+    to capture/record and log content related to a user session.
 AU-14 (3):
   family: AU
   name: Remote Viewing / Listening
-  description: '"The information system provides the capability for authorized users
+  description: The information system provides the capability for authorized users
     to remotely view/hear all content related to an established user session in real
-    time."'
+    time.
 AU-15:
   family: AU
   name: Alternate Audit Capability
@@ -1219,14 +1217,14 @@ AU-16:
 AU-16 (1):
   family: AU
   name: Identity Preservation
-  description: '"The organization requires that the identity of individuals be preserved
-    in cross-organizational audit trails."'
+  description: The organization requires that the identity of individuals be preserved
+    in cross-organizational audit trails.
 AU-16 (2):
   family: AU
   name: Sharing Of Audit Information
-  description: '"The organization provides cross-organizational audit information
-    to [Assignment: organization-defined organizations] based on [Assignment: organization-defined
-    cross-organizational sharing agreements]."'
+  description: 'The organization provides cross-organizational audit information to
+    [Assignment: organization-defined organizations] based on [Assignment: organization-defined
+    cross-organizational sharing agreements].'
 CA-1:
   family: CA
   name: Security Assessment And Authorization Policy And Procedures
@@ -1253,23 +1251,23 @@ CA-2:
 CA-2 (1):
   family: CA
   name: Independent Assessors
-  description: '"The organization employs assessors or assessment teams with [Assignment:
-    organization-defined level of independence] to conduct security control assessments."'
+  description: 'The organization employs assessors or assessment teams with [Assignment:
+    organization-defined level of independence] to conduct security control assessments.'
 CA-2 (2):
   family: CA
   name: Specialized Assessments
-  description: '"The organization includes as part of security control assessments,
+  description: 'The organization includes as part of security control assessments,
     [Assignment: organization-defined frequency], [Selection: announced; unannounced],
     [Selection (one or more): in-depth monitoring; vulnerability scanning; malicious
     user testing; insider threat assessment; performance/load testing; [Assignment:
-    organization-defined other forms of security assessment]]."'
+    organization-defined other forms of security assessment]].'
 CA-2 (3):
   family: CA
   name: External Organizations
-  description: '"The organization accepts the results of an assessment of [Assignment:
+  description: 'The organization accepts the results of an assessment of [Assignment:
     organization-defined information system] performed by [Assignment: organization-defined
     external organization] when the assessment meets [Assignment: organization-defined
-    requirements]."'
+    requirements].'
 CA-3:
   family: CA
   name: System Interconnections
@@ -1281,33 +1279,33 @@ CA-3:
 CA-3 (1):
   family: CA
   name: Unclassified National Security System Connections
-  description: '"The organization prohibits the direct connection of an [Assignment:
+  description: 'The organization prohibits the direct connection of an [Assignment:
     organization-defined unclassified, national security system] to an external network
-    without the use of [Assignment: organization-defined boundary protection device]."'
+    without the use of [Assignment: organization-defined boundary protection device].'
 CA-3 (2):
   family: CA
   name: Classified National Security System Connections
-  description: '"The organization prohibits the direct connection of a classified,
+  description: 'The organization prohibits the direct connection of a classified,
     national security system to an external network without the use of [Assignment:
-    organization-defined boundary protection device]."'
+    organization-defined boundary protection device].'
 CA-3 (3):
   family: CA
   name: Unclassified Non-National Security System Connections
-  description: '"The organization prohibits the direct connection of an [Assignment:
+  description: 'The organization prohibits the direct connection of an [Assignment:
     organization-defined unclassified, non-national security system] to an external
     network without the use of [Assignment; organization-defined boundary protection
-    device]."'
+    device].'
 CA-3 (4):
   family: CA
   name: Connections To Public Networks
-  description: '"The organization prohibits the direct connection of an [Assignment:
-    organization-defined information system] to a public network."'
+  description: 'The organization prohibits the direct connection of an [Assignment:
+    organization-defined information system] to a public network.'
 CA-3 (5):
   family: CA
   name: Restrictions On External System Connections
-  description: '"The organization employs [Selection: allow-all, deny-by-exception;
+  description: 'The organization employs [Selection: allow-all, deny-by-exception;
     deny-all, permit-by-exception] policy for allowing [Assignment: organization-defined
-    information systems] to connect to external information systems."'
+    information systems] to connect to external information systems.'
 CA-4:
   family: CA
   name: Security Certification
@@ -1322,9 +1320,9 @@ CA-5:
 CA-5 (1):
   family: CA
   name: Automation Support For Accuracy / Currency
-  description: '"The organization employs automated mechanisms to help ensure that
-    the plan of action and milestones for the information system is accurate, up to
-    date, and readily available."'
+  description: The organization employs automated mechanisms to help ensure that the
+    plan of action and milestones for the information system is accurate, up to date,
+    and readily available.
 CA-6:
   family: CA
   name: Security Authorization
@@ -1348,20 +1346,20 @@ CA-7:
 CA-7 (1):
   family: CA
   name: Independent Assessment
-  description: '"The organization employs assessors or assessment teams with [Assignment:
+  description: 'The organization employs assessors or assessment teams with [Assignment:
     organization-defined level of independence] to monitor the security controls in
-    the information system on an ongoing basis."'
+    the information system on an ongoing basis.'
 CA-7 (2):
   family: CA
   name: Types Of Assessments
-  description: '"[Withdrawn: Incorporated into CA-2]."'
+  description: '[Withdrawn: Incorporated into CA-2].'
 CA-7 (3):
   family: CA
   name: Trend Analyses
-  description: '"The organization employs trend analyses to determine if security
-    control implementations, the frequency of continuous monitoring activities, and/or
-    the types of activities used in the continuous monitoring process need to be modified
-    based on empirical data."'
+  description: The organization employs trend analyses to determine if security control
+    implementations, the frequency of continuous monitoring activities, and/or the
+    types of activities used in the continuous monitoring process need to be modified
+    based on empirical data.
 CA-8:
   family: CA
   name: Penetration Testing
@@ -1371,14 +1369,14 @@ CA-8:
 CA-8 (1):
   family: CA
   name: Independent Penetration Agent Or Team
-  description: '"The organization employs an independent penetration agent or penetration
-    team to perform penetration testing on the information system or system components."'
+  description: The organization employs an independent penetration agent or penetration
+    team to perform penetration testing on the information system or system components.
 CA-8 (2):
   family: CA
   name: Red Team Exercises
-  description: '"The organization employs [Assignment: organization-defined red team
+  description: 'The organization employs [Assignment: organization-defined red team
     exercises] to simulate attempts by adversaries to compromise organizational information
-    systems in accordance with [Assignment: organization-defined rules of engagement]."'
+    systems in accordance with [Assignment: organization-defined rules of engagement].'
 CA-9:
   family: CA
   name: Internal System Connections
@@ -1389,8 +1387,8 @@ CA-9:
 CA-9 (1):
   family: CA
   name: Security Compliance Checks
-  description: '"The information system performs security compliance checks on constituent
-    system components prior to the establishment of the internal connection."'
+  description: The information system performs security compliance checks on constituent
+    system components prior to the establishment of the internal connection.
 CM-1:
   family: CM
   name: Configuration Management Policy And Procedures
@@ -1418,28 +1416,28 @@ CM-2 (1):
 CM-2 (2):
   family: CM
   name: Automation Support For Accuracy / Currency
-  description: '"The organization employs automated mechanisms to maintain an up-to-date,
+  description: The organization employs automated mechanisms to maintain an up-to-date,
     complete, accurate, and readily available baseline configuration of the information
-    system."'
+    system.
 CM-2 (3):
   family: CM
   name: Retention Of Previous Configurations
-  description: '"The organization retains [Assignment: organization-defined previous
-    versions of baseline configurations of the information system] to support rollback."'
+  description: 'The organization retains [Assignment: organization-defined previous
+    versions of baseline configurations of the information system] to support rollback.'
 CM-2 (4):
   family: CM
   name: Unauthorized Software
-  description: '"[Withdrawn: Incorporated into CM-7]."'
+  description: '[Withdrawn: Incorporated into CM-7].'
 CM-2 (5):
   family: CM
   name: Authorized Software
-  description: '"[Withdrawn: Incorporated into CM-7]."'
+  description: '[Withdrawn: Incorporated into CM-7].'
 CM-2 (6):
   family: CM
   name: Development And Test Environments
-  description: '"The organization maintains a baseline configuration for information
+  description: The organization maintains a baseline configuration for information
     system development and test environments that is managed separately from the operational
-    baseline configuration."'
+    baseline configuration.
 CM-2 (7):
   family: CM
   name: Configure Systems, Components, Or Devices For High-Risk Areas
@@ -1473,32 +1471,32 @@ CM-3 (1):
 CM-3 (2):
   family: CM
   name: Test / Validate / Document Changes
-  description: '"The organization tests, validates, and documents changes to the information
-    system before implementing the changes on the operational system."'
+  description: The organization tests, validates, and documents changes to the information
+    system before implementing the changes on the operational system.
 CM-3 (3):
   family: CM
   name: Automated Change Implementation
-  description: '"The organization employs automated mechanisms to implement changes
+  description: The organization employs automated mechanisms to implement changes
     to the current information system baseline and deploys the updated baseline across
-    the installed base."'
+    the installed base.
 CM-3 (4):
   family: CM
   name: Security Representative
-  description: '"The organization requires an information security representative
-    to be a member of the [Assignment: organization-defined configuration change control
-    element]."'
+  description: 'The organization requires an information security representative to
+    be a member of the [Assignment: organization-defined configuration change control
+    element].'
 CM-3 (5):
   family: CM
   name: Automated Security Response
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     security responses] automatically if baseline configurations are changed in an
-    unauthorized manner."'
+    unauthorized manner.'
 CM-3 (6):
   family: CM
   name: Cryptography Management
-  description: '"The organization ensures that cryptographic mechanisms used to provide
+  description: 'The organization ensures that cryptographic mechanisms used to provide
     [Assignment: organization-defined security safeguards] are under configuration
-    management."'
+    management.'
 CM-4:
   family: CM
   name: Security Impact Analysis
@@ -1507,17 +1505,17 @@ CM-4:
 CM-4 (1):
   family: CM
   name: Separate Test Environments
-  description: '"The organization analyzes changes to the information system in a
-    separate test environment before implementation in an operational environment,
-    looking for security impacts due to flaws, weaknesses, incompatibility, or intentional
-    malice."'
+  description: The organization analyzes changes to the information system in a separate
+    test environment before implementation in an operational environment, looking
+    for security impacts due to flaws, weaknesses, incompatibility, or intentional
+    malice.
 CM-4 (2):
   family: CM
   name: Verification Of Security Functions
-  description: '"The organization, after the information system is changed, checks
-    the security functions to verify that the functions are implemented correctly,
-    operating as intended, and producing the desired outcome with regard to meeting
-    the security requirements for the system."'
+  description: The organization, after the information system is changed, checks the
+    security functions to verify that the functions are implemented correctly, operating
+    as intended, and producing the desired outcome with regard to meeting the security
+    requirements for the system.
 CM-5:
   family: CM
   name: Access Restrictions For Change
@@ -1526,27 +1524,27 @@ CM-5:
 CM-5 (1):
   family: CM
   name: Automated Access Enforcement / Auditing
-  description: '"The information system enforces access restrictions and supports
-    auditing of the enforcement actions."'
+  description: The information system enforces access restrictions and supports auditing
+    of the enforcement actions.
 CM-5 (2):
   family: CM
   name: Review System Changes
-  description: '"The organization reviews information system changes [Assignment:
-    organization-defined frequency] and [Assignment: organization-defined circumstances]
-    to determine whether unauthorized changes have occurred."'
+  description: 'The organization reviews information system changes [Assignment: organization-defined
+    frequency] and [Assignment: organization-defined circumstances] to determine whether
+    unauthorized changes have occurred.'
 CM-5 (3):
   family: CM
   name: Signed Components
-  description: '"The information system prevents the installation of [Assignment:
-    organization-defined software and firmware components] without verification that
-    the component has been digitally signed using a certificate that is recognized
-    and approved by the organization."'
+  description: 'The information system prevents the installation of [Assignment: organization-defined
+    software and firmware components] without verification that the component has
+    been digitally signed using a certificate that is recognized and approved by the
+    organization.'
 CM-5 (4):
   family: CM
   name: Dual Authorization
-  description: '"The organization enforces dual authorization for implementing changes
+  description: 'The organization enforces dual authorization for implementing changes
     to [Assignment: organization-defined information system components and system-level
-    information]."'
+    information].'
 CM-5 (5):
   family: CM
   name: Limit Production / Operational Privileges
@@ -1557,12 +1555,12 @@ CM-5 (5):
 CM-5 (6):
   family: CM
   name: Limit Library Privileges
-  description: '"The organization limits privileges to change software resident within
-    software libraries."'
+  description: The organization limits privileges to change software resident within
+    software libraries.
 CM-5 (7):
   family: CM
   name: Automatic Implementation Of Security Safeguards
-  description: '"[Withdrawn: Incorporated into SI-7]."'
+  description: '[Withdrawn: Incorporated into SI-7].'
 CM-6:
   family: CM
   name: Configuration Settings
@@ -1575,23 +1573,23 @@ CM-6:
 CM-6 (1):
   family: CM
   name: Automated Central Management / Application / Verification
-  description: '"The organization employs automated mechanisms to centrally manage,
+  description: 'The organization employs automated mechanisms to centrally manage,
     apply, and verify configuration settings for [Assignment: organization-defined
-    information system components]."'
+    information system components].'
 CM-6 (2):
   family: CM
   name: Respond To Unauthorized Changes
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to respond to unauthorized changes to [Assignment: organization-defined
-    configuration settings]."'
+    configuration settings].'
 CM-6 (3):
   family: CM
   name: Unauthorized Change Detection
-  description: '"[Withdrawn: Incorporated into SI-7]."'
+  description: '[Withdrawn: Incorporated into SI-7].'
 CM-6 (4):
   family: CM
   name: Conformance Demonstration
-  description: '"[Withdrawn: Incorporated into CM-4]."'
+  description: '[Withdrawn: Incorporated into CM-4].'
 CM-7:
   family: CM
   name: Least Functionality
@@ -1609,15 +1607,15 @@ CM-7 (1):
 CM-7 (2):
   family: CM
   name: Prevent Program Execution
-  description: '"The information system prevents program execution in accordance with
+  description: 'The information system prevents program execution in accordance with
     [Selection (one or more): [Assignment: organization-defined policies regarding
     software program usage and restrictions]; rules authorizing the terms and conditions
-    of software program usage]."'
+    of software program usage].'
 CM-7 (3):
   family: CM
   name: Registration Compliance
-  description: '"The organization ensures compliance with [Assignment: organization-defined
-    registration requirements for functions, ports, protocols, and services]."'
+  description: 'The organization ensures compliance with [Assignment: organization-defined
+    registration requirements for functions, ports, protocols, and services].'
 CM-7 (4):
   family: CM
   name: Unauthorized Software / Blacklisting
@@ -1648,15 +1646,14 @@ CM-8:
 CM-8 (1):
   family: CM
   name: Updates During Installations / Removals
-  description: '"The organization updates the inventory of information system components
+  description: The organization updates the inventory of information system components
     as an integral part of component installations, removals, and information system
-    updates."'
+    updates.
 CM-8 (2):
   family: CM
   name: Automated Maintenance
-  description: '"The organization employs automated mechanisms to help maintain an
-    up-to-date, complete, accurate, and readily available inventory of information
-    system components."'
+  description: The organization employs automated mechanisms to help maintain an up-to-date,
+    complete, accurate, and readily available inventory of information system components.
 CM-8 (3):
   family: CM
   name: Automated Unauthorized Component Detection
@@ -1667,31 +1664,31 @@ CM-8 (3):
 CM-8 (4):
   family: CM
   name: Accountability Information
-  description: '"The organization includes in the information system component inventory
+  description: 'The organization includes in the information system component inventory
     information, a means for identifying by [Selection (one or more): name; position;
-    role], individuals responsible/accountable for administering those components."'
+    role], individuals responsible/accountable for administering those components.'
 CM-8 (5):
   family: CM
   name: No Duplicate Accounting Of Components
-  description: '"The organization verifies that all components within the authorization
+  description: The organization verifies that all components within the authorization
     boundary of the information system are not duplicated in other information system
-    component inventories."'
+    component inventories.
 CM-8 (6):
   family: CM
   name: Assessed Configurations / Approved Deviations
-  description: '"The organization includes assessed component configurations and any
+  description: The organization includes assessed component configurations and any
     approved deviations to current deployed configurations in the information system
-    component inventory."'
+    component inventory.
 CM-8 (7):
   family: CM
   name: Centralized Repository
-  description: '"The organization provides a centralized repository for the inventory
-    of information system components."'
+  description: The organization provides a centralized repository for the inventory
+    of information system components.
 CM-8 (8):
   family: CM
   name: Automated Location Tracking
-  description: '"The organization employs automated mechanisms to support tracking
-    of information system components by geographic location."'
+  description: The organization employs automated mechanisms to support tracking of
+    information system components by geographic location.
 CM-8 (9):
   family: CM
   name: Assignment Of Components To Systems
@@ -1711,9 +1708,9 @@ CM-9:
 CM-9 (1):
   family: CM
   name: Assignment Of Responsibility
-  description: '"The organization assigns responsibility for developing the configuration
+  description: The organization assigns responsibility for developing the configuration
     management process to organizational personnel that are not directly involved
-    in information system development."'
+    in information system development.
 CM-10:
   family: CM
   name: Software Usage Restrictions
@@ -1725,8 +1722,8 @@ CM-10:
 CM-10 (1):
   family: CM
   name: Open Source Software
-  description: '"The organization establishes the following restrictions on the use
-    of open source software: [Assignment: organization-defined restrictions]."'
+  description: 'The organization establishes the following restrictions on the use
+    of open source software: [Assignment: organization-defined restrictions].'
 CM-11:
   family: CM
   name: User-Installed Software
@@ -1738,13 +1735,13 @@ CM-11:
 CM-11 (1):
   family: CM
   name: Alerts For Unauthorized Installations
-  description: '"The information system alerts [Assignment: organization-defined personnel
-    or roles] when the unauthorized installation of software is detected."'
+  description: 'The information system alerts [Assignment: organization-defined personnel
+    or roles] when the unauthorized installation of software is detected.'
 CM-11 (2):
   family: CM
   name: Prohibit Installation Without Privileged Status
-  description: '"The information system prohibits user installation of software without
-    explicit privileged status."'
+  description: The information system prohibits user installation of software without
+    explicit privileged status.
 CP-1:
   family: CP
   name: Contingency Planning Policy And Procedures
@@ -1777,51 +1774,51 @@ CP-2:
 CP-2 (1):
   family: CP
   name: Coordinate With Related Plans
-  description: '"The organization coordinates contingency plan development with organizational
-    elements responsible for related plans."'
+  description: The organization coordinates contingency plan development with organizational
+    elements responsible for related plans.
 CP-2 (2):
   family: CP
   name: Capacity Planning
-  description: '"The organization conducts capacity planning so that necessary capacity
+  description: The organization conducts capacity planning so that necessary capacity
     for information processing, telecommunications, and environmental support exists
-    during contingency operations."'
+    during contingency operations.
 CP-2 (3):
   family: CP
   name: Resume Essential Missions / Business Functions
-  description: '"The organization plans for the resumption of essential missions and
+  description: 'The organization plans for the resumption of essential missions and
     business functions within [Assignment: organization-defined time period] of contingency
-    plan activation."'
+    plan activation.'
 CP-2 (4):
   family: CP
   name: Resume All Missions / Business Functions
-  description: '"The organization plans for the resumption of all missions and business
+  description: 'The organization plans for the resumption of all missions and business
     functions within [Assignment: organization-defined time period] of contingency
-    plan activation."'
+    plan activation.'
 CP-2 (5):
   family: CP
   name: Continue  Essential Missions / Business Functions
-  description: '"The organization plans for the continuance of essential missions
-    and business functions with little or no loss of operational continuity and sustains
+  description: The organization plans for the continuance of essential missions and
+    business functions with little or no loss of operational continuity and sustains
     that continuity until full information system restoration at primary processing
-    and/or storage sites."'
+    and/or storage sites.
 CP-2 (6):
   family: CP
   name: Alternate Processing / Storage Site
-  description: '"The organization plans for the transfer of essential missions and
-    business functions to alternate processing and/or storage sites with little or
-    no loss of operational continuity and sustains that continuity through information
-    system restoration to primary processing and/or storage sites."'
+  description: The organization plans for the transfer of essential missions and business
+    functions to alternate processing and/or storage sites with little or no loss
+    of operational continuity and sustains that continuity through information system
+    restoration to primary processing and/or storage sites.
 CP-2 (7):
   family: CP
   name: Coordinate  With External Service Providers
-  description: '"The organization coordinates its contingency plan with the contingency
+  description: The organization coordinates its contingency plan with the contingency
     plans of external service providers to ensure that contingency requirements can
-    be satisfied."'
+    be satisfied.
 CP-2 (8):
   family: CP
   name: Identify Critical Assets
-  description: '"The organization identifies critical information system assets supporting
-    essential missions and business functions."'
+  description: The organization identifies critical information system assets supporting
+    essential missions and business functions.
 CP-3:
   family: CP
   name: Contingency Training
@@ -1833,13 +1830,13 @@ CP-3:
 CP-3 (1):
   family: CP
   name: Simulated Events
-  description: '"The organization incorporates simulated events into contingency training
-    to facilitate effective response by personnel in crisis situations."'
+  description: The organization incorporates simulated events into contingency training
+    to facilitate effective response by personnel in crisis situations.
 CP-3 (2):
   family: CP
   name: Automated Training Environments
-  description: '"The organization employs automated mechanisms to provide a more thorough
-    and realistic contingency training environment."'
+  description: The organization employs automated mechanisms to provide a more thorough
+    and realistic contingency training environment.
 CP-4:
   family: CP
   name: Contingency Plan Testing
@@ -1851,8 +1848,8 @@ CP-4:
 CP-4 (1):
   family: CP
   name: Coordinate With Related Plans
-  description: '"The organization coordinates contingency plan testing with organizational
-    elements responsible for related plans."'
+  description: The organization coordinates contingency plan testing with organizational
+    elements responsible for related plans.
 CP-4 (2):
   family: CP
   name: Alternate Processing Site
@@ -1863,13 +1860,13 @@ CP-4 (2):
 CP-4 (3):
   family: CP
   name: Automated Testing
-  description: '"The organization employs automated mechanisms to more thoroughly
-    and effectively test the contingency plan."'
+  description: The organization employs automated mechanisms to more thoroughly and
+    effectively test the contingency plan.
 CP-4 (4):
   family: CP
   name: Full Recovery / Reconstitution
-  description: '"The organization includes a full recovery and reconstitution of the
-    information system to a known state as part of contingency plan testing."'
+  description: The organization includes a full recovery and reconstitution of the
+    information system to a known state as part of contingency plan testing.
 CP-5:
   family: CP
   name: Contingency Plan Update
@@ -1884,19 +1881,19 @@ CP-6:
 CP-6 (1):
   family: CP
   name: Separation From Primary Site
-  description: '"The organization identifies an alternate storage site that is separated
-    from the primary storage site to reduce susceptibility to the same threats."'
+  description: The organization identifies an alternate storage site that is separated
+    from the primary storage site to reduce susceptibility to the same threats.
 CP-6 (2):
   family: CP
   name: Recovery Time / Point Objectives
-  description: '"The organization configures the alternate storage site to facilitate
-    recovery operations in accordance with recovery time and recovery point objectives."'
+  description: The organization configures the alternate storage site to facilitate
+    recovery operations in accordance with recovery time and recovery point objectives.
 CP-6 (3):
   family: CP
   name: Accessibility
-  description: '"The organization identifies potential accessibility problems to the
+  description: The organization identifies potential accessibility problems to the
     alternate storage site in the event of an area-wide disruption or disaster and
-    outlines explicit mitigation actions."'
+    outlines explicit mitigation actions.
 CP-7:
   family: CP
   name: Alternate Processing Site
@@ -1908,36 +1905,35 @@ CP-7:
 CP-7 (1):
   family: CP
   name: Separation From Primary Site
-  description: '"The organization identifies an alternate processing site that is
-    separated from the primary processing site to reduce susceptibility to the same
-    threats."'
+  description: The organization identifies an alternate processing site that is separated
+    from the primary processing site to reduce susceptibility to the same threats.
 CP-7 (2):
   family: CP
   name: Accessibility
-  description: '"The organization identifies potential accessibility problems to the
+  description: The organization identifies potential accessibility problems to the
     alternate processing site in the event of an area-wide disruption or disaster
-    and outlines explicit mitigation actions."'
+    and outlines explicit mitigation actions.
 CP-7 (3):
   family: CP
   name: Priority Of Service
-  description: '"The organization develops alternate processing site agreements that
+  description: The organization develops alternate processing site agreements that
     contain priority-of-service provisions in accordance with organizational availability
-    requirements (including recovery time objectives)."'
+    requirements (including recovery time objectives).
 CP-7 (4):
   family: CP
   name: Preparation For Use
-  description: '"The organization prepares the alternate processing site so that the
+  description: The organization prepares the alternate processing site so that the
     site is ready to be used as the operational site supporting essential missions
-    and business functions."'
+    and business functions.
 CP-7 (5):
   family: CP
   name: Equivalent Information Security Safeguards
-  description: '"[Withdrawn: Incorporated into CP-7]."'
+  description: '[Withdrawn: Incorporated into CP-7].'
 CP-7 (6):
   family: CP
   name: Inability To Return To Primary Site
-  description: '"The organization plans and prepares for circumstances that preclude
-    returning to the primary processing site."'
+  description: The organization plans and prepares for circumstances that preclude
+    returning to the primary processing site.
 CP-8:
   family: CP
   name: Telecommunications Services
@@ -1957,15 +1953,15 @@ CP-8 (1):
 CP-8 (2):
   family: CP
   name: Single Points Of Failure
-  description: '"The organization obtains alternate telecommunications services to
-    reduce the likelihood of sharing a single point of failure with primary telecommunications
-    services."'
+  description: The organization obtains alternate telecommunications services to reduce
+    the likelihood of sharing a single point of failure with primary telecommunications
+    services.
 CP-8 (3):
   family: CP
   name: Separation Of Primary / Alternate Providers
-  description: '"The organization obtains alternate telecommunications services from
+  description: The organization obtains alternate telecommunications services from
     providers that are separated from primary service providers to reduce susceptibility
-    to the same threats."'
+    to the same threats.
 CP-8 (4):
   family: CP
   name: Provider Contingency Plan
@@ -1977,8 +1973,8 @@ CP-8 (4):
 CP-8 (5):
   family: CP
   name: Alternate Telecommunication Service Testing
-  description: '"The organization tests alternate telecommunication services [Assignment:
-    organization-defined frequency]."'
+  description: 'The organization tests alternate telecommunication services [Assignment:
+    organization-defined frequency].'
 CP-9:
   family: CP
   name: Information System Backup
@@ -1991,41 +1987,41 @@ CP-9:
 CP-9 (1):
   family: CP
   name: Testing For Reliability / Integrity
-  description: '"The organization tests backup information [Assignment: organization-defined
-    frequency] to verify media reliability and information integrity."'
+  description: 'The organization tests backup information [Assignment: organization-defined
+    frequency] to verify media reliability and information integrity.'
 CP-9 (2):
   family: CP
   name: Test Restoration Using Sampling
-  description: '"The organization uses a sample of backup information in the restoration
-    of selected information system functions as part of contingency plan testing."'
+  description: The organization uses a sample of backup information in the restoration
+    of selected information system functions as part of contingency plan testing.
 CP-9 (3):
   family: CP
   name: Separate Storage For Critical Information
-  description: '"The organization stores backup copies of [Assignment: organization-defined
+  description: 'The organization stores backup copies of [Assignment: organization-defined
     critical information system software and other security-related information] in
     a separate facility or in a fire-rated container that is not collocated with the
-    operational system."'
+    operational system.'
 CP-9 (4):
   family: CP
   name: Protection From Unauthorized Modification
-  description: '"[Withdrawn: Incorporated into CP-9]."'
+  description: '[Withdrawn: Incorporated into CP-9].'
 CP-9 (5):
   family: CP
   name: Transfer To Alternate Storage Site
-  description: '"The organization transfers information system backup information
-    to the alternate storage site [Assignment: organization-defined time period and
-    transfer rate consistent with the recovery time and recovery point objectives]."'
+  description: 'The organization transfers information system backup information to
+    the alternate storage site [Assignment: organization-defined time period and transfer
+    rate consistent with the recovery time and recovery point objectives].'
 CP-9 (6):
   family: CP
   name: Redundant Secondary System
-  description: '"The organization accomplishes information system backup by maintaining
+  description: The organization accomplishes information system backup by maintaining
     a redundant secondary system that is not collocated with the primary system and
-    that can be activated without loss of information or disruption to operations."'
+    that can be activated without loss of information or disruption to operations.
 CP-9 (7):
   family: CP
   name: Dual Authorization
-  description: '"The organization enforces dual authorization for the deletion or
-    destruction of [Assignment: organization-defined backup information]."'
+  description: 'The organization enforces dual authorization for the deletion or destruction
+    of [Assignment: organization-defined backup information].'
 CP-10:
   family: CP
   name: Information System Recovery And Reconstitution
@@ -2034,32 +2030,32 @@ CP-10:
 CP-10 (1):
   family: CP
   name: Contingency Plan Testing
-  description: '"[Withdrawn: Incorporated into CP-4]."'
+  description: '[Withdrawn: Incorporated into CP-4].'
 CP-10 (2):
   family: CP
   name: Transaction Recovery
-  description: '"The information system implements transaction recovery for systems
-    that are transaction-based."'
+  description: The information system implements transaction recovery for systems
+    that are transaction-based.
 CP-10 (3):
   family: CP
   name: Compensating Security Controls
-  description: '"[Withdrawn: Addressed through tailoring procedures]."'
+  description: '[Withdrawn: Addressed through tailoring procedures].'
 CP-10 (4):
   family: CP
   name: Restore Within Time Period
-  description: '"The organization provides the capability to restore information system
+  description: 'The organization provides the capability to restore information system
     components within [Assignment: organization-defined restoration time-periods]
     from configuration-controlled and integrity-protected information representing
-    a known, operational state for the components."'
+    a known, operational state for the components.'
 CP-10 (5):
   family: CP
   name: Failover Capability
-  description: '"[Withdrawn: Incorporated into SI-13]."'
+  description: '[Withdrawn: Incorporated into SI-13].'
 CP-10 (6):
   family: CP
   name: Component Protection
-  description: '"The organization protects backup and restoration hardware, firmware,
-    and software."'
+  description: The organization protects backup and restoration hardware, firmware,
+    and software.
 CP-11:
   family: CP
   name: Alternate Communications Protocols
@@ -2098,74 +2094,74 @@ IA-2:
 IA-2 (1):
   family: IA
   name: Network Access To Privileged Accounts
-  description: '"The information system implements multifactor authentication for
-    network access to privileged accounts."'
+  description: The information system implements multifactor authentication for network
+    access to privileged accounts.
 IA-2 (2):
   family: IA
   name: Network Access To Non-Privileged Accounts
-  description: '"The information system implements multifactor authentication for
-    network access to non-privileged accounts."'
+  description: The information system implements multifactor authentication for network
+    access to non-privileged accounts.
 IA-2 (3):
   family: IA
   name: Local Access To Privileged Accounts
-  description: '"The information system implements multifactor authentication for
-    local access to privileged accounts."'
+  description: The information system implements multifactor authentication for local
+    access to privileged accounts.
 IA-2 (4):
   family: IA
   name: Local Access To Non-Privileged Accounts
-  description: '"The information system implements multifactor authentication for
-    local access to non-privileged accounts."'
+  description: The information system implements multifactor authentication for local
+    access to non-privileged accounts.
 IA-2 (5):
   family: IA
   name: Group Authentication
-  description: '"The organization requires individuals to be authenticated with an
-    individual authenticator when a group authenticator is employed."'
+  description: The organization requires individuals to be authenticated with an individual
+    authenticator when a group authenticator is employed.
 IA-2 (6):
   family: IA
   name: Network Access To Privileged Accounts - Separate Device
-  description: '"The information system implements multifactor authentication for
-    network access to privileged accounts such that one of the factors is provided
-    by a device separate from the system gaining access and the device meets [Assignment:
-    organization-defined strength of mechanism requirements]."'
+  description: 'The information system implements multifactor authentication for network
+    access to privileged accounts such that one of the factors is provided by a device
+    separate from the system gaining access and the device meets [Assignment: organization-defined
+    strength of mechanism requirements].'
 IA-2 (7):
   family: IA
   name: Network Access To Non-Privileged Accounts - Separate Device
-  description: '"The information system implements multifactor authentication for
-    network access to non-privileged accounts such that one of the factors is provided
-    by a device separate from the system gaining access and the device meets [Assignment:
-    organization-defined strength of mechanism requirements]."'
+  description: 'The information system implements multifactor authentication for network
+    access to non-privileged accounts such that one of the factors is provided by
+    a device separate from the system gaining access and the device meets [Assignment:
+    organization-defined strength of mechanism requirements].'
 IA-2 (8):
   family: IA
   name: Network Access To Privileged Accounts - Replay Resistant
-  description: '"The information system implements replay-resistant authentication
-    mechanisms for network access to privileged accounts."'
+  description: The information system implements replay-resistant authentication mechanisms
+    for network access to privileged accounts.
 IA-2 (9):
   family: IA
   name: Network Access To Non-Privileged Accounts - Replay Resistant
-  description: '"The information system implements replay-resistant authentication
-    mechanisms for network access to non-privileged accounts."'
+  description: The information system implements replay-resistant authentication mechanisms
+    for network access to non-privileged accounts.
 IA-2 (10):
   family: IA
   name: Single Sign-On
-  description: '"The information system provides a single sign-on capability for [Assignment:
-    organization-defined information system accounts and services]."'
+  description: 'The information system provides a single sign-on capability for [Assignment:
+    organization-defined information system accounts and services].'
 IA-2 (11):
   family: IA
   name: Remote Access  - Separate Device
-  description: '"The information system implements multifactor authentication for
-    remote access to privileged and non-privileged accounts such that one of the factors
+  description: 'The information system implements multifactor authentication for remote
+    access to privileged and non-privileged accounts such that one of the factors
     is provided by a device separate from the system gaining access and the device
-    meets [Assignment: organization-defined strength of mechanism requirements]."'
+    meets [Assignment: organization-defined strength of mechanism requirements].'
 IA-2 (12):
   family: IA
   name: Acceptance Of Piv Credentials
-  description: '"The information system accepts and electronically verifies Personal
-    Identity Verification (PIV) credentials."'
+  description: The information system accepts and electronically verifies Personal
+    Identity Verification (PIV) credentials.
 IA-2 (13):
   family: IA
   name: Out-Of-Band Authentication
-  description: '"The information system implements [Assignment: organization-defined
-    out-of-band authentication] under [Assignment: organization-defined conditions]."'
+  description: 'The information system implements [Assignment: organization-defined
+    out-of-band authentication] under [Assignment: organization-defined conditions].'
 IA-3:
   family: IA
   name: Device Identification And Authentication
@@ -2175,14 +2171,14 @@ IA-3:
 IA-3 (1):
   family: IA
   name: Cryptographic Bidirectional Authentication
-  description: '"The information system authenticates [Assignment: organization-defined
+  description: 'The information system authenticates [Assignment: organization-defined
     specific devices and/or types of devices] before establishing [Selection (one
     or more): local; remote; network] connection using bidirectional authentication
-    that is cryptographically based."'
+    that is cryptographically based.'
 IA-3 (2):
   family: IA
   name: Cryptographic Bidirectional Network Authentication
-  description: '"[Withdrawn: Incorporated into IA-3 (1)]."'
+  description: '[Withdrawn: Incorporated into IA-3 (1)].'
 IA-3 (3):
   family: IA
   name: Dynamic Address Allocation
@@ -2193,9 +2189,9 @@ IA-3 (3):
 IA-3 (4):
   family: IA
   name: Device Attestation
-  description: '"The organization ensures that device identification and authentication
+  description: 'The organization ensures that device identification and authentication
     based on attestation is handled by [Assignment: organization-defined configuration
-    management process]."'
+    management process].'
 IA-4:
   family: IA
   name: Identifier Management
@@ -2209,40 +2205,39 @@ IA-4:
 IA-4 (1):
   family: IA
   name: Prohibit Account Identifiers As Public Identifiers
-  description: '"The organization prohibits the use of information system account
-    identifiers that are the same as public identifiers for individual electronic
-    mail accounts."'
+  description: The organization prohibits the use of information system account identifiers
+    that are the same as public identifiers for individual electronic mail accounts.
 IA-4 (2):
   family: IA
   name: Supervisor Authorization
-  description: '"The organization requires that the registration process to receive
-    an individual identifier includes supervisor authorization."'
+  description: The organization requires that the registration process to receive
+    an individual identifier includes supervisor authorization.
 IA-4 (3):
   family: IA
   name: Multiple Forms Of Certification
-  description: '"The organization requires multiple forms of certification of individual
-    identification be presented to the registration authority."'
+  description: The organization requires multiple forms of certification of individual
+    identification be presented to the registration authority.
 IA-4 (4):
   family: IA
   name: Identify User Status
-  description: '"The organization manages individual identifiers by uniquely identifying
+  description: 'The organization manages individual identifiers by uniquely identifying
     each individual as [Assignment: organization-defined characteristic identifying
-    individual status]."'
+    individual status].'
 IA-4 (5):
   family: IA
   name: Dynamic Management
-  description: '"The information system dynamically manages identifiers."'
+  description: The information system dynamically manages identifiers.
 IA-4 (6):
   family: IA
   name: Cross-Organization Management
-  description: '"The organization coordinates with [Assignment: organization-defined
-    external organizations] for cross-organization management of identifiers."'
+  description: 'The organization coordinates with [Assignment: organization-defined
+    external organizations] for cross-organization management of identifiers.'
 IA-4 (7):
   family: IA
   name: In-Person Registration
-  description: '"The organization requires that the registration process to receive
+  description: The organization requires that the registration process to receive
     an individual identifier be conducted in person before a designated registration
-    authority."'
+    authority.
 IA-5:
   family: IA
   name: Authenticator Management
@@ -2281,75 +2276,74 @@ IA-5 (2):
 IA-5 (3):
   family: IA
   name: In-Person Or Trusted Third-Party Registration
-  description: '"The organization requires that the registration process to receive
+  description: 'The organization requires that the registration process to receive
     [Assignment: organization-defined types of and/or specific authenticators] be
     conducted [Selection: in person; by a trusted third party] before [Assignment:
     organization-defined registration authority] with authorization by [Assignment:
-    organization-defined personnel or roles]."'
+    organization-defined personnel or roles].'
 IA-5 (4):
   family: IA
   name: Automated Support  For Password Strength Determination
-  description: '"The organization employs automated tools to determine if password
+  description: 'The organization employs automated tools to determine if password
     authenticators are sufficiently strong to satisfy [Assignment: organization-defined
-    requirements]."'
+    requirements].'
 IA-5 (5):
   family: IA
   name: Change Authenticators Prior To Delivery
-  description: '"The organization requires developers/installers of information system
+  description: The organization requires developers/installers of information system
     components to provide unique authenticators or change default authenticators prior
-    to delivery/installation."'
+    to delivery/installation.
 IA-5 (6):
   family: IA
   name: Protection Of Authenticators
-  description: '"The organization protects authenticators commensurate with the security
-    category of the information to which use of the authenticator permits access."'
+  description: The organization protects authenticators commensurate with the security
+    category of the information to which use of the authenticator permits access.
 IA-5 (7):
   family: IA
   name: No Embedded Unencrypted Static Authenticators
-  description: '"The organization ensures that unencrypted static authenticators are
-    not embedded in applications or access scripts or stored on function keys."'
+  description: The organization ensures that unencrypted static authenticators are
+    not embedded in applications or access scripts or stored on function keys.
 IA-5 (8):
   family: IA
   name: Multiple Information System Accounts
-  description: '"The organization implements [Assignment: organization-defined security
+  description: 'The organization implements [Assignment: organization-defined security
     safeguards] to manage the risk of compromise due to individuals having accounts
-    on multiple information systems."'
+    on multiple information systems.'
 IA-5 (9):
   family: IA
   name: Cross-Organization Credential Management
-  description: '"The organization coordinates with [Assignment: organization-defined
-    external organizations] for cross-organization management of credentials."'
+  description: 'The organization coordinates with [Assignment: organization-defined
+    external organizations] for cross-organization management of credentials.'
 IA-5 (10):
   family: IA
   name: Dynamic Credential Association
-  description: '"The information system dynamically provisions identities."'
+  description: The information system dynamically provisions identities.
 IA-5 (11):
   family: IA
   name: Hardware Token-Based Authentication
-  description: '"The information system, for hardware token-based authentication,
-    employs mechanisms that satisfy [Assignment: organization-defined token quality
-    requirements]."'
+  description: 'The information system, for hardware token-based authentication, employs
+    mechanisms that satisfy [Assignment: organization-defined token quality requirements].'
 IA-5 (12):
   family: IA
   name: Biometric-Based Authentication
-  description: '"The information system, for biometric-based authentication, employs
-    mechanisms that satisfy [Assignment: organization-defined biometric quality requirements]."'
+  description: 'The information system, for biometric-based authentication, employs
+    mechanisms that satisfy [Assignment: organization-defined biometric quality requirements].'
 IA-5 (13):
   family: IA
   name: Expiration Of Cached Authenticators
-  description: '"The information system prohibits the use of cached authenticators
-    after [Assignment: organization-defined time period]."'
+  description: 'The information system prohibits the use of cached authenticators
+    after [Assignment: organization-defined time period].'
 IA-5 (14):
   family: IA
   name: Managing Content Of Pki Trust Stores
-  description: '"The organization, for PKI-based authentication, employs a deliberate
+  description: The organization, for PKI-based authentication, employs a deliberate
     organization-wide methodology for managing the content of PKI trust stores installed
-    across all platforms including networks, operating systems, browsers, and applications."'
+    across all platforms including networks, operating systems, browsers, and applications.
 IA-5 (15):
   family: IA
   name: Ficam-Approved Products And Services
-  description: '"The organization uses only FICAM-approved path discovery and validation
-    products and services."'
+  description: The organization uses only FICAM-approved path discovery and validation
+    products and services.
 IA-6:
   family: IA
   name: Authenticator Feedback
@@ -2371,27 +2365,27 @@ IA-8:
 IA-8 (1):
   family: IA
   name: Acceptance Of Piv Credentials From Other Agencies
-  description: '"The information system accepts and electronically verifies Personal
-    Identity Verification (PIV) credentials from other federal agencies."'
+  description: The information system accepts and electronically verifies Personal
+    Identity Verification (PIV) credentials from other federal agencies.
 IA-8 (2):
   family: IA
   name: Acceptance Of Third-Party Credentials
-  description: '"The information system accepts only FICAM-approved third-party credentials."'
+  description: The information system accepts only FICAM-approved third-party credentials.
 IA-8 (3):
   family: IA
   name: Use Of Ficam-Approved Products
-  description: '"The organization employs only FICAM-approved information system components
+  description: 'The organization employs only FICAM-approved information system components
     in [Assignment: organization-defined information systems] to accept third-party
-    credentials."'
+    credentials.'
 IA-8 (4):
   family: IA
   name: Use Of Ficam-Issued Profiles
-  description: '"The information system conforms to FICAM-issued profiles."'
+  description: The information system conforms to FICAM-issued profiles.
 IA-8 (5):
   family: IA
   name: Acceptance Of Piv-I Credentials
-  description: '"The information system accepts and electronically verifies Personal
-    Identity Verification-I (PIV-I) credentials."'
+  description: The information system accepts and electronically verifies Personal
+    Identity Verification-I (PIV-I) credentials.
 IA-9:
   family: IA
   name: Service Identification And Authentication
@@ -2401,14 +2395,14 @@ IA-9:
 IA-9 (1):
   family: IA
   name: Information Exchange
-  description: '"The organization ensures that service providers receive, validate,
-    and transmit identification and authentication information."'
+  description: The organization ensures that service providers receive, validate,
+    and transmit identification and authentication information.
 IA-9 (2):
   family: IA
   name: Transmission Of Decisions
-  description: '"The organization ensures that identification and authentication decisions
+  description: 'The organization ensures that identification and authentication decisions
     are transmitted between [Assignment: organization-defined services] consistent
-    with organizational policies."'
+    with organizational policies.'
 IA-10:
   family: IA
   name: Adaptive Identification And Authentication
@@ -2443,13 +2437,13 @@ IR-2:
 IR-2 (1):
   family: IR
   name: Simulated Events
-  description: '"The organization incorporates simulated events into incident response
-    training to facilitate effective response by personnel in crisis situations."'
+  description: The organization incorporates simulated events into incident response
+    training to facilitate effective response by personnel in crisis situations.
 IR-2 (2):
   family: IR
   name: Automated Training Environments
-  description: '"The organization employs automated mechanisms to provide a more thorough
-    and realistic incident response training environment."'
+  description: The organization employs automated mechanisms to provide a more thorough
+    and realistic incident response training environment.
 IR-3:
   family: IR
   name: Incident Response Testing
@@ -2459,13 +2453,13 @@ IR-3:
 IR-3 (1):
   family: IR
   name: Automated Testing
-  description: '"The organization employs automated mechanisms to more thoroughly
-    and effectively test the incident response capability."'
+  description: The organization employs automated mechanisms to more thoroughly and
+    effectively test the incident response capability.
 IR-3 (2):
   family: IR
   name: Coordination With Related Plans
-  description: '"The organization coordinates incident response testing with organizational
-    elements responsible for related plans."'
+  description: The organization coordinates incident response testing with organizational
+    elements responsible for related plans.
 IR-4:
   family: IR
   name: Incident Handling
@@ -2477,61 +2471,61 @@ IR-4:
 IR-4 (1):
   family: IR
   name: Automated Incident Handling Processes
-  description: '"The organization employs automated mechanisms to support the incident
-    handling process."'
+  description: The organization employs automated mechanisms to support the incident
+    handling process.
 IR-4 (2):
   family: IR
   name: Dynamic Reconfiguration
-  description: '"The organization includes dynamic reconfiguration of [Assignment:
+  description: 'The organization includes dynamic reconfiguration of [Assignment:
     organization-defined information system components] as part of the incident response
-    capability."'
+    capability.'
 IR-4 (3):
   family: IR
   name: Continuity Of Operations
-  description: '"The organization identifies [Assignment: organization-defined classes
+  description: 'The organization identifies [Assignment: organization-defined classes
     of incidents] and [Assignment: organization-defined actions to take in response
     to classes of incidents] to ensure continuation of organizational missions and
-    business functions."'
+    business functions.'
 IR-4 (4):
   family: IR
   name: Information Correlation
-  description: '"The organization correlates incident information and individual incident
+  description: The organization correlates incident information and individual incident
     responses to achieve an organization-wide perspective on incident awareness and
-    response."'
+    response.
 IR-4 (5):
   family: IR
   name: Automatic Disabling Of Information System
-  description: '"The organization implements a configurable capability to automatically
+  description: 'The organization implements a configurable capability to automatically
     disable the information system if [Assignment: organization-defined security violations]
-    are detected."'
+    are detected.'
 IR-4 (6):
   family: IR
   name: Insider Threats - Specific Capabilities
-  description: '"The organization implements incident handling capability for insider
-    threats."'
+  description: The organization implements incident handling capability for insider
+    threats.
 IR-4 (7):
   family: IR
   name: Insider Threats - Intra-Organization Coordination
-  description: '"The organization coordinates incident handling capability for insider
+  description: 'The organization coordinates incident handling capability for insider
     threats across [Assignment: organization-defined components or elements of the
-    organization]."'
+    organization].'
 IR-4 (8):
   family: IR
   name: Correlation With External Organizations
-  description: '"The organization coordinates with [Assignment: organization-defined
+  description: 'The organization coordinates with [Assignment: organization-defined
     external organizations] to correlate and share [Assignment: organization-defined
     incident information] to achieve a cross-organization perspective on incident
-    awareness and more effective incident responses."'
+    awareness and more effective incident responses.'
 IR-4 (9):
   family: IR
   name: Dynamic Response Capability
-  description: '"The organization employs [Assignment: organization-defined dynamic
-    response capabilities] to effectively respond to security incidents."'
+  description: 'The organization employs [Assignment: organization-defined dynamic
+    response capabilities] to effectively respond to security incidents.'
 IR-4 (10):
   family: IR
   name: Supply Chain Coordination
-  description: '"The organization coordinates incident handling activities involving
-    supply chain events with other organizations involved in the supply chain."'
+  description: The organization coordinates incident handling activities involving
+    supply chain events with other organizations involved in the supply chain.
 IR-5:
   family: IR
   name: Incident Monitoring
@@ -2540,8 +2534,8 @@ IR-5:
 IR-5 (1):
   family: IR
   name: Automated Tracking / Data Collection / Analysis
-  description: '"The organization employs automated mechanisms to assist in the tracking
-    of security incidents and in the collection and analysis of incident information."'
+  description: The organization employs automated mechanisms to assist in the tracking
+    of security incidents and in the collection and analysis of incident information.
 IR-6:
   family: IR
   name: Incident Reporting
@@ -2552,20 +2546,20 @@ IR-6:
 IR-6 (1):
   family: IR
   name: Automated Reporting
-  description: '"The organization employs automated mechanisms to assist in the reporting
-    of security incidents."'
+  description: The organization employs automated mechanisms to assist in the reporting
+    of security incidents.
 IR-6 (2):
   family: IR
   name: Vulnerabilities Related To Incidents
-  description: '"The organization reports information system vulnerabilities associated
+  description: 'The organization reports information system vulnerabilities associated
     with reported security incidents to [Assignment: organization-defined personnel
-    or roles]."'
+    or roles].'
 IR-6 (3):
   family: IR
   name: Coordination With Supply Chain
-  description: '"The organization provides security incident information to other
-    organizations involved in the supply chain for information systems or information
-    system components related to the incident."'
+  description: The organization provides security incident information to other organizations
+    involved in the supply chain for information systems or information system components
+    related to the incident.
 IR-7:
   family: IR
   name: Incident Response Assistance
@@ -2576,8 +2570,8 @@ IR-7:
 IR-7 (1):
   family: IR
   name: Automation Support For Availability Of Information / Support
-  description: '"The organization employs automated mechanisms to increase the availability
-    of incident response-related information and support."'
+  description: The organization employs automated mechanisms to increase the availability
+    of incident response-related information and support.
 IR-7 (2):
   family: IR
   name: Coordination With External Providers
@@ -2618,25 +2612,25 @@ IR-9:
 IR-9 (1):
   family: IR
   name: Responsible Personnel
-  description: '"The organization assigns [Assignment: organization-defined personnel
-    or roles] with responsibility for responding to information spills."'
+  description: 'The organization assigns [Assignment: organization-defined personnel
+    or roles] with responsibility for responding to information spills.'
 IR-9 (2):
   family: IR
   name: Training
-  description: '"The organization provides information spillage response training
-    [Assignment: organization-defined frequency]."'
+  description: 'The organization provides information spillage response training [Assignment:
+    organization-defined frequency].'
 IR-9 (3):
   family: IR
   name: Post-Spill Operations
-  description: '"The organization implements [Assignment: organization-defined procedures]
+  description: 'The organization implements [Assignment: organization-defined procedures]
     to ensure that organizational personnel impacted by information spills can continue
     to carry out assigned tasks while contaminated systems are undergoing corrective
-    actions."'
+    actions.'
 IR-9 (4):
   family: IR
   name: Exposure To Unauthorized Personnel
-  description: '"The organization employs [Assignment: organization-defined security
-    safeguards] for personnel exposed to information not within assigned access authorizations."'
+  description: 'The organization employs [Assignment: organization-defined security
+    safeguards] for personnel exposed to information not within assigned access authorizations.'
 IR-10:
   family: IR
   name: Integrated Information Security Analysis Team
@@ -2667,7 +2661,7 @@ MA-2:
 MA-2 (1):
   family: MA
   name: Record Content
-  description: '"[Withdrawn: Incorporated into MA-2]."'
+  description: '[Withdrawn: Incorporated into MA-2].'
 MA-2 (2):
   family: MA
   name: Automated Maintenance Activities
@@ -2683,13 +2677,13 @@ MA-3:
 MA-3 (1):
   family: MA
   name: Inspect Tools
-  description: '"The organization inspects the maintenance tools carried into a facility
-    by maintenance personnel for improper or unauthorized modifications."'
+  description: The organization inspects the maintenance tools carried into a facility
+    by maintenance personnel for improper or unauthorized modifications.
 MA-3 (2):
   family: MA
   name: Inspect Media
-  description: '"The organization checks media containing diagnostic and test programs
-    for malicious code before the media are used in the information system."'
+  description: The organization checks media containing diagnostic and test programs
+    for malicious code before the media are used in the information system.
 MA-3 (3):
   family: MA
   name: Prevent Unauthorized Removal
@@ -2702,8 +2696,8 @@ MA-3 (3):
 MA-3 (4):
   family: MA
   name: Restricted Tool Use
-  description: '"The information system restricts the use of maintenance tools to
-    authorized personnel only."'
+  description: The information system restricts the use of maintenance tools to authorized
+    personnel only.
 MA-4:
   family: MA
   name: Nonlocal Maintenance
@@ -2724,9 +2718,9 @@ MA-4 (1):
 MA-4 (2):
   family: MA
   name: Document Nonlocal Maintenance
-  description: '"The organization documents in the security plan for the information
+  description: The organization documents in the security plan for the information
     system, the policies and procedures for the establishment and use of nonlocal
-    maintenance and diagnostic connections."'
+    maintenance and diagnostic connections.
 MA-4 (3):
   family: MA
   name: Comparable Security / Sanitization
@@ -2753,13 +2747,13 @@ MA-4 (5):
 MA-4 (6):
   family: MA
   name: Cryptographic Protection
-  description: '"The information system implements cryptographic mechanisms to protect
-    the integrity and confidentiality of nonlocal maintenance and diagnostic communications."'
+  description: The information system implements cryptographic mechanisms to protect
+    the integrity and confidentiality of nonlocal maintenance and diagnostic communications.
 MA-4 (7):
   family: MA
   name: Remote Disconnect Verification
-  description: '"The information system implements remote disconnect verification
-    at the termination of nonlocal maintenance and diagnostic sessions."'
+  description: The information system implements remote disconnect verification at
+    the termination of nonlocal maintenance and diagnostic sessions.
 MA-5:
   family: MA
   name: Maintenance Personnel
@@ -2780,17 +2774,17 @@ MA-5 (1):
 MA-5 (2):
   family: MA
   name: Security Clearances For Classified Systems
-  description: '"The organization ensures that personnel performing maintenance and
+  description: The organization ensures that personnel performing maintenance and
     diagnostic activities on an information system processing, storing, or transmitting
     classified information possess security clearances and formal access approvals
     for at least the highest classification level and for all compartments of information
-    on the system."'
+    on the system.
 MA-5 (3):
   family: MA
   name: Citizenship Requirements For Classified Systems
-  description: '"The organization ensures that personnel performing maintenance and
+  description: The organization ensures that personnel performing maintenance and
     diagnostic activities on an information system processing, storing, or transmitting
-    classified information are U.S. citizens."'
+    classified information are U.S. citizens.
 MA-5 (4):
   family: MA
   name: Foreign Nationals
@@ -2801,9 +2795,9 @@ MA-5 (4):
 MA-5 (5):
   family: MA
   name: Nonsystem-Related Maintenance
-  description: '"The organization ensures that non-escorted personnel performing maintenance
+  description: The organization ensures that non-escorted personnel performing maintenance
     activities not directly associated with the information system but in the physical
-    proximity of the system, have required access authorizations."'
+    proximity of the system, have required access authorizations.
 MA-6:
   family: MA
   name: Timely Maintenance
@@ -2813,20 +2807,18 @@ MA-6:
 MA-6 (1):
   family: MA
   name: Preventive Maintenance
-  description: '"The organization performs preventive maintenance on [Assignment:
-    organization-defined information system components] at [Assignment: organization-defined
-    time intervals]."'
+  description: 'The organization performs preventive maintenance on [Assignment: organization-defined
+    information system components] at [Assignment: organization-defined time intervals].'
 MA-6 (2):
   family: MA
   name: Predictive Maintenance
-  description: '"The organization performs predictive maintenance on [Assignment:
-    organization-defined information system components] at [Assignment: organization-defined
-    time intervals]."'
+  description: 'The organization performs predictive maintenance on [Assignment: organization-defined
+    information system components] at [Assignment: organization-defined time intervals].'
 MA-6 (3):
   family: MA
   name: Automated Support For Predictive Maintenance
-  description: '"The organization employs automated mechanisms to transfer predictive
-    maintenance data to a computerized maintenance management system."'
+  description: The organization employs automated mechanisms to transfer predictive
+    maintenance data to a computerized maintenance management system.
 MP-1:
   family: MP
   name: Media Protection Policy And Procedures
@@ -2847,11 +2839,11 @@ MP-2:
 MP-2 (1):
   family: MP
   name: Automated Restricted Access
-  description: '"[Withdrawn: Incorporated into MP-4 (2)]."'
+  description: '[Withdrawn: Incorporated into MP-4 (2)].'
 MP-2 (2):
   family: MP
   name: Cryptographic Protection
-  description: '"[Withdrawn: Incorporated into SC-28 (1)]."'
+  description: '[Withdrawn: Incorporated into SC-28 (1)].'
 MP-3:
   family: MP
   name: Media Marking
@@ -2869,12 +2861,12 @@ MP-4:
 MP-4 (1):
   family: MP
   name: Cryptographic Protection
-  description: '"[Withdrawn: Incorporated into SC-28 (1)]."'
+  description: '[Withdrawn: Incorporated into SC-28 (1)].'
 MP-4 (2):
   family: MP
   name: Automated Restricted Access
-  description: '"The organization employs automated mechanisms to restrict access
-    to media storage areas and to audit access attempts and access granted."'
+  description: The organization employs automated mechanisms to restrict access to
+    media storage areas and to audit access attempts and access granted.
 MP-5:
   family: MP
   name: Media Transport
@@ -2887,22 +2879,22 @@ MP-5:
 MP-5 (1):
   family: MP
   name: Protection Outside Of Controlled Areas
-  description: '"[Withdrawn: Incorporated into MP-5]."'
+  description: '[Withdrawn: Incorporated into MP-5].'
 MP-5 (2):
   family: MP
   name: Documentation Of Activities
-  description: '"[Withdrawn: Incorporated into MP-5]."'
+  description: '[Withdrawn: Incorporated into MP-5].'
 MP-5 (3):
   family: MP
   name: Custodians
-  description: '"The organization employs an identified custodian during transport
-    of information system media outside of controlled areas."'
+  description: The organization employs an identified custodian during transport of
+    information system media outside of controlled areas.
 MP-5 (4):
   family: MP
   name: Cryptographic Protection
-  description: '"The information system implements cryptographic mechanisms to protect
+  description: The information system implements cryptographic mechanisms to protect
     the confidentiality and integrity of information stored on digital media during
-    transport outside of controlled areas."'
+    transport outside of controlled areas.
 MP-6:
   family: MP
   name: Media Sanitization
@@ -2913,45 +2905,45 @@ MP-6:
 MP-6 (1):
   family: MP
   name: Review / Approve / Track / Document / Verify
-  description: '"The organization reviews, approves, tracks, documents, and verifies
-    media sanitization and disposal actions."'
+  description: The organization reviews, approves, tracks, documents, and verifies
+    media sanitization and disposal actions.
 MP-6 (2):
   family: MP
   name: Equipment Testing
-  description: '"The organization tests sanitization equipment and procedures [Assignment:
+  description: 'The organization tests sanitization equipment and procedures [Assignment:
     organization-defined frequency] to verify that the intended sanitization is being
-    achieved."'
+    achieved.'
 MP-6 (3):
   family: MP
   name: Nondestructive Techniques
-  description: '"The organization applies nondestructive sanitization techniques to
+  description: 'The organization applies nondestructive sanitization techniques to
     portable storage devices prior to connecting such devices to the information system
     under the following circumstances: [Assignment: organization-defined circumstances
-    requiring sanitization of portable storage devices]."'
+    requiring sanitization of portable storage devices].'
 MP-6 (4):
   family: MP
   name: Controlled Unclassified Information
-  description: '"[Withdrawn: Incorporated into MP-6]."'
+  description: '[Withdrawn: Incorporated into MP-6].'
 MP-6 (5):
   family: MP
   name: Classified Information
-  description: '"[Withdrawn: Incorporated into MP-6]."'
+  description: '[Withdrawn: Incorporated into MP-6].'
 MP-6 (6):
   family: MP
   name: Media Destruction
-  description: '"[Withdrawn: Incorporated into MP-6]."'
+  description: '[Withdrawn: Incorporated into MP-6].'
 MP-6 (7):
   family: MP
   name: Dual Authorization
-  description: '"The organization enforces dual authorization for the sanitization
-    of [Assignment: organization-defined information system media]."'
+  description: 'The organization enforces dual authorization for the sanitization
+    of [Assignment: organization-defined information system media].'
 MP-6 (8):
   family: MP
   name: Remote Purging / Wiping Of Information
-  description: '"The organization provides the capability to purge/wipe information
+  description: 'The organization provides the capability to purge/wipe information
     from [Assignment: organization-defined information systems, system components,
     or devices] either remotely or under the following conditions: [Assignment: organization-defined
-    conditions]."'
+    conditions].'
 MP-7:
   family: MP
   name: Media Use
@@ -2962,13 +2954,13 @@ MP-7:
 MP-7 (1):
   family: MP
   name: Prohibit Use Without Owner
-  description: '"The organization prohibits the use of portable storage devices in
-    organizational information systems when such devices have no identifiable owner."'
+  description: The organization prohibits the use of portable storage devices in organizational
+    information systems when such devices have no identifiable owner.
 MP-7 (2):
   family: MP
   name: Prohibit Use Of Sanitization-Resistant Media
-  description: '"The organization prohibits the use of sanitization-resistant media
-    in organizational information systems."'
+  description: The organization prohibits the use of sanitization-resistant media
+    in organizational information systems.
 MP-8:
   family: MP
   name: Media Downgrading
@@ -2981,26 +2973,26 @@ MP-8:
 MP-8 (1):
   family: MP
   name: Documentation Of Process
-  description: '"The organization documents information system media downgrading actions."'
+  description: The organization documents information system media downgrading actions.
 MP-8 (2):
   family: MP
   name: Equipment Testing
-  description: '"The organization employs [Assignment: organization-defined tests]
+  description: 'The organization employs [Assignment: organization-defined tests]
     of downgrading equipment and procedures to verify correct performance [Assignment:
-    organization-defined frequency]."'
+    organization-defined frequency].'
 MP-8 (3):
   family: MP
   name: Controlled Unclassified Information
-  description: '"The organization downgrades information system media containing [Assignment:
+  description: 'The organization downgrades information system media containing [Assignment:
     organization-defined Controlled Unclassified Information (CUI)] prior to public
     release in accordance with applicable federal and organizational standards and
-    policies."'
+    policies.'
 MP-8 (4):
   family: MP
   name: Classified Information
-  description: '"The organization downgrades information system media containing classified
+  description: The organization downgrades information system media containing classified
     information prior to release to individuals without required access authorizations
-    in accordance with NSA standards and policies."'
+    in accordance with NSA standards and policies.
 PE-1:
   family: PE
   name: Physical And Environmental Protection Policy And Procedures
@@ -3024,22 +3016,22 @@ PE-2:
 PE-2 (1):
   family: PE
   name: Access By Position / Role
-  description: '"The organization authorizes physical access to the facility where
-    the information system resides based on position or role."'
+  description: The organization authorizes physical access to the facility where the
+    information system resides based on position or role.
 PE-2 (2):
   family: PE
   name: Two Forms Of Identification
-  description: '"The organization requires two forms of identification from [Assignment:
+  description: 'The organization requires two forms of identification from [Assignment:
     organization-defined list of acceptable forms of identification] for visitor access
-    to the facility where the information system resides."'
+    to the facility where the information system resides.'
 PE-2 (3):
   family: PE
   name: Restrict Unescorted Access
-  description: '"The organization restricts unescorted access to the facility where
+  description: 'The organization restricts unescorted access to the facility where
     the information system resides to personnel with [Selection (one or more): security
     clearances for all information contained within the system; formal access authorizations
     for all information contained within the system; need for access to all information
-    contained within the system; [Assignment: organization-defined credentials]]."'
+    contained within the system; [Assignment: organization-defined credentials]].'
 PE-3:
   family: PE
   name: Physical Access Control
@@ -3057,41 +3049,41 @@ PE-3:
 PE-3 (1):
   family: PE
   name: Information System Access
-  description: '"The organization enforces physical access authorizations to the information
+  description: 'The organization enforces physical access authorizations to the information
     system in addition to the physical access controls for the facility at [Assignment:
     organization-defined physical spaces containing one or more components of the
-    information system]."'
+    information system].'
 PE-3 (2):
   family: PE
   name: Facility / Information System Boundaries
-  description: '"The organization performs security checks [Assignment: organization-defined
+  description: 'The organization performs security checks [Assignment: organization-defined
     frequency] at the physical boundary of the facility or information system for
-    unauthorized exfiltration of information or removal of information system components."'
+    unauthorized exfiltration of information or removal of information system components.'
 PE-3 (3):
   family: PE
   name: Continuous Guards / Alarms / Monitoring
-  description: '"The organization employs guards and/or alarms to monitor every physical
+  description: The organization employs guards and/or alarms to monitor every physical
     access point to the facility where the information system resides 24 hours per
-    day, 7 days per week."'
+    day, 7 days per week.
 PE-3 (4):
   family: PE
   name: Lockable Casings
-  description: '"The organization uses lockable physical casings to protect [Assignment:
+  description: 'The organization uses lockable physical casings to protect [Assignment:
     organization-defined information system components] from unauthorized physical
-    access."'
+    access.'
 PE-3 (5):
   family: PE
   name: Tamper Protection
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to [Selection (one or more): detect; prevent] physical tampering or
     alteration of [Assignment: organization-defined hardware components] within the
-    information system."'
+    information system.'
 PE-3 (6):
   family: PE
   name: Facility Penetration Testing
-  description: '"The organization employs a penetration testing process that includes
+  description: 'The organization employs a penetration testing process that includes
     [Assignment: organization-defined frequency], unannounced attempts to bypass or
-    circumvent security controls associated with physical access points to the facility."'
+    circumvent security controls associated with physical access points to the facility.'
 PE-4:
   family: PE
   name: Access Control For Transmission Medium
@@ -3120,9 +3112,9 @@ PE-5 (2):
 PE-5 (3):
   family: PE
   name: Marking Output Devices
-  description: '"The organization marks [Assignment: organization-defined information
+  description: 'The organization marks [Assignment: organization-defined information
     system output devices] indicating the appropriate security marking of the information
-    permitted to be output from the device."'
+    permitted to be output from the device.'
 PE-6:
   family: PE
   name: Monitoring Physical Access
@@ -3134,27 +3126,27 @@ PE-6:
 PE-6 (1):
   family: PE
   name: Intrusion Alarms / Surveillance Equipment
-  description: '"The organization monitors physical intrusion alarms and surveillance
-    equipment."'
+  description: The organization monitors physical intrusion alarms and surveillance
+    equipment.
 PE-6 (2):
   family: PE
   name: Automated Intrusion Recognition / Responses
-  description: '"The organization employs automated mechanisms to recognize [Assignment:
+  description: 'The organization employs automated mechanisms to recognize [Assignment:
     organization-defined classes/types of intrusions] and initiate [Assignment: organization-defined
-    response actions]."'
+    response actions].'
 PE-6 (3):
   family: PE
   name: Video Surveillance
-  description: '"The organization employs video surveillance of [Assignment: organization-defined
+  description: 'The organization employs video surveillance of [Assignment: organization-defined
     operational areas] and retains video recordings for [Assignment: organization-defined
-    time period]."'
+    time period].'
 PE-6 (4):
   family: PE
   name: Monitoring Physical Access To Information Systems
-  description: '"The organization monitors physical access to the information system
+  description: 'The organization monitors physical access to the information system
     in addition to the physical access monitoring of the facility as [Assignment:
     organization-defined physical spaces containing one or more components of the
-    information system]."'
+    information system].'
 PE-7:
   family: PE
   name: Visitor Control
@@ -3169,12 +3161,12 @@ PE-8:
 PE-8 (1):
   family: PE
   name: Automated Records Maintenance / Review
-  description: '"The organization employs automated mechanisms to facilitate the maintenance
-    and review of visitor access records."'
+  description: The organization employs automated mechanisms to facilitate the maintenance
+    and review of visitor access records.
 PE-8 (2):
   family: PE
   name: Physical Access Records
-  description: '"[Withdrawn: Incorporated into PE-2]."'
+  description: '[Withdrawn: Incorporated into PE-2].'
 PE-9:
   family: PE
   name: Power Equipment And Cabling
@@ -3183,13 +3175,13 @@ PE-9:
 PE-9 (1):
   family: PE
   name: Redundant Cabling
-  description: '"The organization employs redundant power cabling paths that are physically
-    separated by [Assignment: organization-defined distance]."'
+  description: 'The organization employs redundant power cabling paths that are physically
+    separated by [Assignment: organization-defined distance].'
 PE-9 (2):
   family: PE
   name: Automatic Voltage Controls
-  description: '"The organization employs automatic voltage controls for [Assignment:
-    organization-defined critical information system components]."'
+  description: 'The organization employs automatic voltage controls for [Assignment:
+    organization-defined critical information system components].'
 PE-10:
   family: PE
   name: Emergency Shutoff
@@ -3201,7 +3193,7 @@ PE-10:
 PE-10 (1):
   family: PE
   name: Accidental / Unauthorized Activation
-  description: '"[Withdrawn: Incorporated into PE-10]."'
+  description: '[Withdrawn: Incorporated into PE-10].'
 PE-11:
   family: PE
   name: Emergency Power
@@ -3212,9 +3204,9 @@ PE-11:
 PE-11 (1):
   family: PE
   name: Long-Term Alternate Power Supply - Minimal Operational Capability
-  description: '"The organization provides a long-term alternate power supply for
-    the information system that is capable of maintaining minimally required operational
-    capability in the event of an extended loss of the primary power source."'
+  description: The organization provides a long-term alternate power supply for the
+    information system that is capable of maintaining minimally required operational
+    capability in the event of an extended loss of the primary power source.
 PE-11 (2):
   family: PE
   name: Long-Term Alternate Power Supply - Self-Contained
@@ -3232,8 +3224,8 @@ PE-12:
 PE-12 (1):
   family: PE
   name: Essential Missions / Business Functions
-  description: '"The organization provides emergency lighting for all areas within
-    the facility supporting essential missions and business functions."'
+  description: The organization provides emergency lighting for all areas within the
+    facility supporting essential missions and business functions.
 PE-13:
   family: PE
   name: Fire Protection
@@ -3243,29 +3235,29 @@ PE-13:
 PE-13 (1):
   family: PE
   name: Detection Devices / Systems
-  description: '"The organization employs fire detection devices/systems for the information
+  description: 'The organization employs fire detection devices/systems for the information
     system that activate automatically and notify [Assignment: organization-defined
     personnel or roles] and [Assignment: organization-defined emergency responders]
-    in the event of a fire."'
+    in the event of a fire.'
 PE-13 (2):
   family: PE
   name: Suppression Devices / Systems
-  description: '"The organization employs fire suppression devices/systems for the
+  description: 'The organization employs fire suppression devices/systems for the
     information system that provide automatic notification of any activation to Assignment:
     organization-defined personnel or roles] and [Assignment: organization-defined
-    emergency responders]."'
+    emergency responders].'
 PE-13 (3):
   family: PE
   name: Automatic Fire Suppression
-  description: '"The organization employs an automatic fire suppression capability
-    for the information system when the facility is not staffed on a continuous basis."'
+  description: The organization employs an automatic fire suppression capability for
+    the information system when the facility is not staffed on a continuous basis.
 PE-13 (4):
   family: PE
   name: Inspections
-  description: '"The organization ensures that the facility undergoes [Assignment:
+  description: 'The organization ensures that the facility undergoes [Assignment:
     organization-defined frequency] inspections by authorized and qualified inspectors
     and resolves identified deficiencies within [Assignment: organization-defined
-    time period]."'
+    time period].'
 PE-14:
   family: PE
   name: Temperature And Humidity Controls
@@ -3276,15 +3268,14 @@ PE-14:
 PE-14 (1):
   family: PE
   name: Automatic Controls
-  description: '"The organization employs automatic temperature and humidity controls
+  description: The organization employs automatic temperature and humidity controls
     in the facility to prevent fluctuations potentially harmful to the information
-    system."'
+    system.
 PE-14 (2):
   family: PE
   name: Monitoring With Alarms / Notifications
-  description: '"The organization employs temperature and humidity monitoring that
-    provides an alarm or notification of changes potentially harmful to personnel
-    or equipment."'
+  description: The organization employs temperature and humidity monitoring that provides
+    an alarm or notification of changes potentially harmful to personnel or equipment.
 PE-15:
   family: PE
   name: Water Damage Protection
@@ -3294,9 +3285,9 @@ PE-15:
 PE-15 (1):
   family: PE
   name: Automation Support
-  description: '"The organization employs automated mechanisms to detect the presence
+  description: 'The organization employs automated mechanisms to detect the presence
     of water in the vicinity of the information system and alerts [Assignment: organization-defined
-    personnel or roles]."'
+    personnel or roles].'
 PE-16:
   family: PE
   name: Delivery And Removal
@@ -3320,10 +3311,10 @@ PE-18:
 PE-18 (1):
   family: PE
   name: Facility Site
-  description: '"The organization plans the location or site of the facility where
-    the information system resides with regard to physical and environmental hazards
-    and for existing facilities, considers the physical and environmental hazards
-    in its risk mitigation strategy."'
+  description: The organization plans the location or site of the facility where the
+    information system resides with regard to physical and environmental hazards and
+    for existing facilities, considers the physical and environmental hazards in its
+    risk mitigation strategy.
 PE-19:
   family: PE
   name: Information Leakage
@@ -3332,10 +3323,10 @@ PE-19:
 PE-19 (1):
   family: PE
   name: National Emissions / Tempest Policies And Procedures
-  description: '"The organization ensures that information system components, associated
+  description: The organization ensures that information system components, associated
     data communications, and networks are protected in accordance with national emissions
     and TEMPEST policies and procedures based on the security category or classification
-    of the information."'
+    of the information.
 PE-20:
   family: PE
   name: Asset Monitoring And Tracking
@@ -3376,18 +3367,18 @@ PL-2:
 PL-2 (1):
   family: PL
   name: Concept Of Operations
-  description: '"[Withdrawn: Incorporated into PL-7]."'
+  description: '[Withdrawn: Incorporated into PL-7].'
 PL-2 (2):
   family: PL
   name: Functional Architecture
-  description: '"[Withdrawn: Incorporated into PL-8]."'
+  description: '[Withdrawn: Incorporated into PL-8].'
 PL-2 (3):
   family: PL
   name: Plan / Coordinate With Other Organizational Entities
-  description: '"The organization plans and coordinates security-related activities
+  description: 'The organization plans and coordinates security-related activities
     affecting the information system with [Assignment: organization-defined individuals
     or groups] before conducting such activities in order to reduce the impact on
-    other organizational entities."'
+    other organizational entities.'
 PL-3:
   family: PL
   name: System Security Plan Update
@@ -3404,9 +3395,9 @@ PL-4:
 PL-4 (1):
   family: PL
   name: Social Media And Networking Restrictions
-  description: '"The organization includes in the rules of behavior, explicit restrictions
+  description: The organization includes in the rules of behavior, explicit restrictions
     on the use of social media/networking sites and posting organizational information
-    on public websites."'
+    on public websites.
 PL-5:
   family: PL
   name: Privacy Impact Assessment
@@ -3443,9 +3434,9 @@ PL-8 (1):
 PL-8 (2):
   family: PL
   name: Supplier Diversity
-  description: '"The organization requires that [Assignment: organization-defined
-    security safeguards] allocated to [Assignment: organization-defined locations
-    and architectural layers] are obtained from different suppliers."'
+  description: 'The organization requires that [Assignment: organization-defined security
+    safeguards] allocated to [Assignment: organization-defined locations and architectural
+    layers] are obtained from different suppliers.'
 PL-9:
   family: PL
   name: Central Management
@@ -3594,17 +3585,17 @@ PS-3:
 PS-3 (1):
   family: PS
   name: Classified Information
-  description: '"The organization ensures that individuals accessing an information
+  description: The organization ensures that individuals accessing an information
     system processing, storing, or transmitting classified information are cleared
     and indoctrinated to the highest classification level of the information to which
-    they have access on the system."'
+    they have access on the system.
 PS-3 (2):
   family: PS
   name: Formal Indoctrination
-  description: '"The organization ensures that individuals accessing an information
+  description: The organization ensures that individuals accessing an information
     system processing, storing, or transmitting types of classified information which
     require formal indoctrination, are formally indoctrinated for all of the relevant
-    types of information to which they have access on the system."'
+    types of information to which they have access on the system.
 PS-3 (3):
   family: PS
   name: Information With Special Protection Measures
@@ -3633,8 +3624,8 @@ PS-4 (1):
 PS-4 (2):
   family: PS
   name: Automated Notification
-  description: '"The organization employs automated mechanisms to notify [Assignment:
-    organization-defined personnel or roles] upon termination of an individual."'
+  description: 'The organization employs automated mechanisms to notify [Assignment:
+    organization-defined personnel or roles] upon termination of an individual.'
 PS-5:
   family: PS
   name: Personnel Transfer
@@ -3657,7 +3648,7 @@ PS-6:
 PS-6 (1):
   family: PS
   name: Information Requiring Special Protection
-  description: '"[Withdrawn: Incorporated into PS-3]."'
+  description: '[Withdrawn: Incorporated into PS-3].'
 PS-6 (2):
   family: PS
   name: Classified Information Requiring Special Protection
@@ -3739,56 +3730,56 @@ RA-5:
 RA-5 (1):
   family: RA
   name: Update Tool Capability
-  description: '"The organization employs vulnerability scanning tools that include
+  description: The organization employs vulnerability scanning tools that include
     the capability to readily update the information system vulnerabilities to be
-    scanned."'
+    scanned.
 RA-5 (2):
   family: RA
   name: Update By Frequency / Prior To New Scan / When Identified
-  description: '"The organization updates the information system vulnerabilities scanned
+  description: 'The organization updates the information system vulnerabilities scanned
     [Selection (one or more): [Assignment: organization-defined frequency]; prior
-    to a new scan; when new vulnerabilities are identified and reported]."'
+    to a new scan; when new vulnerabilities are identified and reported].'
 RA-5 (3):
   family: RA
   name: Breadth / Depth Of Coverage
-  description: '"The organization employs vulnerability scanning procedures that can
+  description: The organization employs vulnerability scanning procedures that can
     identify the breadth and depth of coverage (i.e., information system components
-    scanned and vulnerabilities checked)."'
+    scanned and vulnerabilities checked).
 RA-5 (4):
   family: RA
   name: Discoverable Information
-  description: '"The organization determines what information about the information
+  description: 'The organization determines what information about the information
     system is discoverable by adversaries and subsequently takes [Assignment: organization-defined
-    corrective actions]."'
+    corrective actions].'
 RA-5 (5):
   family: RA
   name: Privileged Access
-  description: '"The information system implements privileged access authorization
+  description: 'The information system implements privileged access authorization
     to [Assignment: organization-identified information system components] for selected
-    [Assignment: organization-defined vulnerability scanning activities]."'
+    [Assignment: organization-defined vulnerability scanning activities].'
 RA-5 (6):
   family: RA
   name: Automated Trend Analyses
-  description: '"The organization employs automated mechanisms to compare the results
-    of vulnerability scans over time to determine trends in information system vulnerabilities."'
+  description: The organization employs automated mechanisms to compare the results
+    of vulnerability scans over time to determine trends in information system vulnerabilities.
 RA-5 (7):
   family: RA
   name: Automated Detection And Notification Of Unauthorized Components
-  description: '"[Withdrawn: Incorporated into CM-8]."'
+  description: '[Withdrawn: Incorporated into CM-8].'
 RA-5 (8):
   family: RA
   name: Review Historic Audit Logs
-  description: '"The organization reviews historic audit logs to determine if a vulnerability
-    identified in the information system has been previously exploited."'
+  description: The organization reviews historic audit logs to determine if a vulnerability
+    identified in the information system has been previously exploited.
 RA-5 (9):
   family: RA
   name: Penetration Testing And Analyses
-  description: '"[Withdrawn: Incorporated into CA-8]."'
+  description: '[Withdrawn: Incorporated into CA-8].'
 RA-5 (10):
   family: RA
   name: Correlate Scanning Information
-  description: '"The organization correlates the output from vulnerability scanning
-    tools to determine the presence of multi-vulnerability/multi-hop attack vectors."'
+  description: The organization correlates the output from vulnerability scanning
+    tools to determine the presence of multi-vulnerability/multi-hop attack vectors.
 RA-6:
   family: RA
   name: Technical Surveillance Countermeasures Survey
@@ -3839,31 +3830,31 @@ SA-4:
 SA-4 (1):
   family: SA
   name: Functional Properties Of Security Controls
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to provide a description of the
-    functional properties of the security controls to be employed."'
+    functional properties of the security controls to be employed.
 SA-4 (2):
   family: SA
   name: Design / Implementation Information For Security Controls
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to provide design and implementation
     information for the security controls to be employed that includes: [Selection
     (one or more): security-relevant external system interfaces; high-level design;
     low-level design; source code or hardware schematics; [Assignment: organization-defined
     design/implementation information]] at [Assignment: organization-defined level
-    of detail]."'
+    of detail].'
 SA-4 (3):
   family: SA
   name: Development Methods / Techniques / Practices
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to demonstrate the use of a system
     development life cycle that includes [Assignment: organization-defined state-of-the-practice
     system/security engineering methods, software development methods, testing/evaluation/validation
-    techniques, and quality control processes]."'
+    techniques, and quality control processes].'
 SA-4 (4):
   family: SA
   name: Assignment Of Components To Systems
-  description: '"[Withdrawn: Incorporated into CM-8 (9)]."'
+  description: '[Withdrawn: Incorporated into CM-8 (9)].'
 SA-4 (5):
   family: SA
   name: System / Component / Service Configurations
@@ -3888,23 +3879,23 @@ SA-4 (7):
 SA-4 (8):
   family: SA
   name: Continuous Monitoring Plan
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to produce a plan for the continuous
     monitoring of security control effectiveness that contains [Assignment: organization-defined
-    level of detail]."'
+    level of detail].'
 SA-4 (9):
   family: SA
   name: Functions / Ports / Protocols / Services In Use
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to identify early in the system
     development life cycle, the functions, ports, protocols, and services intended
-    for organizational use."'
+    for organizational use.
 SA-4 (10):
   family: SA
   name: Use Of Approved Piv Products
-  description: '"The organization employs only information technology products on
-    the FIPS 201-approved products list for Personal Identity Verification (PIV) capability
-    implemented within organizational information systems."'
+  description: The organization employs only information technology products on the
+    FIPS 201-approved products list for Personal Identity Verification (PIV) capability
+    implemented within organizational information systems.
 SA-5:
   family: SA
   name: Information System Documentation
@@ -3924,23 +3915,23 @@ SA-5:
 SA-5 (1):
   family: SA
   name: Functional Properties Of Security Controls
-  description: '"[Withdrawn: Incorporated into SA-4 (1)]."'
+  description: '[Withdrawn: Incorporated into SA-4 (1)].'
 SA-5 (2):
   family: SA
   name: Security-Relevant External System Interfaces
-  description: '"[Withdrawn: Incorporated into SA-4 (2)]."'
+  description: '[Withdrawn: Incorporated into SA-4 (2)].'
 SA-5 (3):
   family: SA
   name: High-Level Design
-  description: '"[Withdrawn: Incorporated into SA-4 (2)]."'
+  description: '[Withdrawn: Incorporated into SA-4 (2)].'
 SA-5 (4):
   family: SA
   name: Low-Level Design
-  description: '"[Withdrawn: Incorporated into SA-4 (2)]."'
+  description: '[Withdrawn: Incorporated into SA-4 (2)].'
 SA-5 (5):
   family: SA
   name: Source Code
-  description: '"[Withdrawn: Incorporated into SA-4 (2)]."'
+  description: '[Withdrawn: Incorporated into SA-4 (2)].'
 SA-6:
   family: SA
   name: Software Usage Restrictions
@@ -3973,28 +3964,28 @@ SA-9 (1):
 SA-9 (2):
   family: SA
   name: Identification Of Functions / Ports / Protocols / Services
-  description: '"The organization requires providers of [Assignment: organization-defined
+  description: 'The organization requires providers of [Assignment: organization-defined
     external information system services] to identify the functions, ports, protocols,
-    and other services required for the use of such services."'
+    and other services required for the use of such services.'
 SA-9 (3):
   family: SA
   name: Establish / Maintain Trust Relationship With Providers
-  description: '"The organization establishes, documents, and maintains trust relationships
+  description: 'The organization establishes, documents, and maintains trust relationships
     with external service providers based on [Assignment: organization-defined security
-    requirements, properties, factors, or conditions defining acceptable trust relationships]."'
+    requirements, properties, factors, or conditions defining acceptable trust relationships].'
 SA-9 (4):
   family: SA
   name: Consistent Interests Of Consumers And Providers
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to ensure that the interests of [Assignment: organization-defined
-    external service providers] are consistent with and reflect organizational interests."'
+    external service providers] are consistent with and reflect organizational interests.'
 SA-9 (5):
   family: SA
   name: Processing, Storage, And Service Location
-  description: '"The organization restricts the location of [Selection (one or more):
+  description: 'The organization restricts the location of [Selection (one or more):
     information processing; information/data; information system services] to [Assignment:
     organization-defined locations] based on [Assignment: organization-defined requirements
-    or conditions]."'
+    or conditions].'
 SA-10:
   family: SA
   name: Developer Configuration Management
@@ -4058,16 +4049,16 @@ SA-11:
 SA-11 (1):
   family: SA
   name: Static Code Analysis
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to employ static code analysis
-    tools to identify common flaws and document the results of the analysis."'
+    tools to identify common flaws and document the results of the analysis.
 SA-11 (2):
   family: SA
   name: Threat And Vulnerability Analyses
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to perform threat and vulnerability
     analyses and subsequent testing/evaluation of the as-built system, component,
-    or service."'
+    or service.
 SA-11 (3):
   family: SA
   name: Independent Verification Of Assessment Plans / Evidence
@@ -4078,35 +4069,35 @@ SA-11 (3):
 SA-11 (4):
   family: SA
   name: Manual Code Reviews
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to perform a manual code review
     of [Assignment: organization-defined specific code] using [Assignment: organization-defined
-    processes, procedures, and/or techniques]."'
+    processes, procedures, and/or techniques].'
 SA-11 (5):
   family: SA
   name: Penetration Testing
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to perform penetration testing
     at [Assignment: organization-defined breadth/depth] and with [Assignment: organization-defined
-    constraints]."'
+    constraints].'
 SA-11 (6):
   family: SA
   name: Attack Surface Reviews
-  description: '"The organization requires the developer of the information system,
-    system component, or information system service to perform attack surface reviews."'
+  description: The organization requires the developer of the information system,
+    system component, or information system service to perform attack surface reviews.
 SA-11 (7):
   family: SA
   name: Verify Scope Of Testing / Evaluation
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to verify that the scope of security
     testing/evaluation provides complete coverage of required security controls at
-    [Assignment: organization-defined depth of testing/evaluation]."'
+    [Assignment: organization-defined depth of testing/evaluation].'
 SA-11 (8):
   family: SA
   name: Dynamic Code Analysis
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to employ dynamic code analysis
-    tools to identify common flaws and document the results of the analysis."'
+    tools to identify common flaws and document the results of the analysis.
 SA-12:
   family: SA
   name: Supply Chain Protection
@@ -4117,91 +4108,91 @@ SA-12:
 SA-12 (1):
   family: SA
   name: Acquisition Strategies / Tools / Methods
-  description: '"The organization employs [Assignment: organization-defined tailored
+  description: 'The organization employs [Assignment: organization-defined tailored
     acquisition strategies, contract tools, and procurement methods] for the purchase
     of the information system, system component, or information system service from
-    suppliers."'
+    suppliers.'
 SA-12 (2):
   family: SA
   name: Supplier Reviews
-  description: '"The organization conducts a supplier review prior to entering into
+  description: The organization conducts a supplier review prior to entering into
     a contractual agreement to acquire the information system, system component, or
-    information system service."'
+    information system service.
 SA-12 (3):
   family: SA
   name: Trusted Shipping And Warehousing
-  description: '"[Withdrawn: Incorporated into SA-12 (1)]."'
+  description: '[Withdrawn: Incorporated into SA-12 (1)].'
 SA-12 (4):
   family: SA
   name: Diversity Of Suppliers
-  description: '"[Withdrawn: Incorporated into SA-12 (13)]."'
+  description: '[Withdrawn: Incorporated into SA-12 (13)].'
 SA-12 (5):
   family: SA
   name: Limitation Of Harm
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to limit harm from potential adversaries identifying and targeting
-    the organizational supply chain."'
+    the organizational supply chain.'
 SA-12 (6):
   family: SA
   name: Minimizing Procurement Time
-  description: '"[Withdrawn: Incorporated into SA-12 (1)]."'
+  description: '[Withdrawn: Incorporated into SA-12 (1)].'
 SA-12 (7):
   family: SA
   name: Assessments Prior To Selection / Acceptance / Update
-  description: '"The organization conducts an assessment of the information system,
+  description: The organization conducts an assessment of the information system,
     system component, or information system service prior to selection, acceptance,
-    or update."'
+    or update.
 SA-12 (8):
   family: SA
   name: Use Of All-Source Intelligence
-  description: '"The organization uses all-source intelligence analysis of suppliers
+  description: The organization uses all-source intelligence analysis of suppliers
     and potential suppliers of the information system, system component, or information
-    system service."'
+    system service.
 SA-12 (9):
   family: SA
   name: Operations Security
-  description: '"The organization employs [Assignment: organization-defined Operations
+  description: 'The organization employs [Assignment: organization-defined Operations
     Security (OPSEC) safeguards] in accordance with classification guides to protect
     supply chain-related information for the information system, system component,
-    or information system service."'
+    or information system service.'
 SA-12 (10):
   family: SA
   name: Validate As Genuine And Not Altered
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to validate that the information system or system component received
-    is genuine and has not been altered."'
+    is genuine and has not been altered.'
 SA-12 (11):
   family: SA
   name: Penetration Testing / Analysis Of Elements, Processes, And Actors
-  description: '"The organization employs [Selection (one or more): organizational
+  description: 'The organization employs [Selection (one or more): organizational
     analysis, independent third-party analysis, organizational penetration testing,
     independent third-party penetration testing] of [Assignment: organization-defined
     supply chain elements, processes, and actors] associated with the information
-    system, system component, or information system service."'
+    system, system component, or information system service.'
 SA-12 (12):
   family: SA
   name: Inter-Organizational Agreements
-  description: '"The organization establishes inter-organizational agreements and
-    procedures with entities involved in the supply chain for the information system,
-    system component, or information system service."'
+  description: The organization establishes inter-organizational agreements and procedures
+    with entities involved in the supply chain for the information system, system
+    component, or information system service.
 SA-12 (13):
   family: SA
   name: Critical Information System Components
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to ensure an adequate supply of [Assignment: organization-defined
-    critical information system components]."'
+    critical information system components].'
 SA-12 (14):
   family: SA
   name: Identity And Traceability
-  description: '"The organization establishes and retains unique identification of
+  description: 'The organization establishes and retains unique identification of
     [Assignment: organization-defined supply chain elements, processes, and actors]
-    for the information system, system component, or information system service."'
+    for the information system, system component, or information system service.'
 SA-12 (15):
   family: SA
   name: Processes To Address Weaknesses Or Deficiencies
-  description: '"The organization establishes a process to address weaknesses or deficiencies
+  description: The organization establishes a process to address weaknesses or deficiencies
     in supply chain elements identified during independent or organizational assessments
-    of such elements."'
+    of such elements.
 SA-13:
   family: SA
   name: Trustworthiness
@@ -4220,7 +4211,7 @@ SA-14:
 SA-14 (1):
   family: SA
   name: Critical Components With  No Viable Alternative Sourcing
-  description: '"[Withdrawn: Incorporated into SA-20]."'
+  description: '[Withdrawn: Incorporated into SA-20].'
 SA-15:
   family: SA
   name: Development Process, Standards, And Tools
@@ -4242,16 +4233,16 @@ SA-15 (1):
 SA-15 (2):
   family: SA
   name: Security Tracking Tools
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to select and employ a security
-    tracking tool for use during the development process."'
+    tracking tool for use during the development process.
 SA-15 (3):
   family: SA
   name: Criticality Analysis
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to perform a criticality analysis
     at [Assignment: organization-defined breadth/depth] and at [Assignment: organization-defined
-    decision points in the system development life cycle]."'
+    decision points in the system development life cycle].'
 SA-15 (4):
   family: SA
   name: Threat Modeling / Vulnerability Analysis
@@ -4263,15 +4254,15 @@ SA-15 (4):
 SA-15 (5):
   family: SA
   name: Attack Surface Reduction
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to reduce attack surfaces to [Assignment:
-    organization-defined thresholds]."'
+    organization-defined thresholds].'
 SA-15 (6):
   family: SA
   name: Continuous Improvement
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to implement an explicit process
-    to continuously improve the development process."'
+    to continuously improve the development process.
 SA-15 (7):
   family: SA
   name: Automated Vulnerability Analysis
@@ -4284,28 +4275,28 @@ SA-15 (7):
 SA-15 (8):
   family: SA
   name: Reuse Of Threat / Vulnerability Information
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to use threat modeling and vulnerability
     analyses from similar systems, components, or services to inform the current development
-    process."'
+    process.
 SA-15 (9):
   family: SA
   name: Use Of Live Data
-  description: '"The organization approves, documents, and controls the use of live
+  description: The organization approves, documents, and controls the use of live
     data in development and test environments for the information system, system component,
-    or information system service."'
+    or information system service.
 SA-15 (10):
   family: SA
   name: Incident Response Plan
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to provide an incident response
-    plan."'
+    plan.
 SA-15 (11):
   family: SA
   name: Archive Information System / Component
-  description: '"The organization requires the developer of the information system
-    or system component to archive the system or component to be released or delivered
-    together with the corresponding evidence supporting the final security review."'
+  description: The organization requires the developer of the information system or
+    system component to archive the system or component to be released or delivered
+    together with the corresponding evidence supporting the final security review.
 SA-16:
   family: SA
   name: Developer-Provided Training
@@ -4365,15 +4356,15 @@ SA-17 (5):
 SA-17 (6):
   family: SA
   name: Structure For Testing
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to structure security-relevant
-    hardware, software, and firmware to facilitate testing."'
+    hardware, software, and firmware to facilitate testing.
 SA-17 (7):
   family: SA
   name: Structure For Least Privilege
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to structure security-relevant
-    hardware, software, and firmware to facilitate controlling access with least privilege."'
+    hardware, software, and firmware to facilitate controlling access with least privilege.
 SA-18:
   family: SA
   name: Tamper Resistance And Detection
@@ -4382,16 +4373,16 @@ SA-18:
 SA-18 (1):
   family: SA
   name: Multiple Phases Of Sdlc
-  description: '"The organization employs anti-tamper technologies and techniques
-    during multiple phases in the system development life cycle including design,
-    development, integration, operations, and maintenance."'
+  description: The organization employs anti-tamper technologies and techniques during
+    multiple phases in the system development life cycle including design, development,
+    integration, operations, and maintenance.
 SA-18 (2):
   family: SA
   name: Inspection Of Information Systems, Components, Or Devices
-  description: '"The organization inspects [Assignment: organization-defined information
+  description: 'The organization inspects [Assignment: organization-defined information
     systems, system components, or devices] [Selection (one or more): at random; at
     [Assignment: organization-defined frequency], upon [Assignment: organization-defined
-    indications of need for inspection]] to detect tampering."'
+    indications of need for inspection]] to detect tampering.'
 SA-19:
   family: SA
   name: Component Authenticity
@@ -4402,25 +4393,25 @@ SA-19:
 SA-19 (1):
   family: SA
   name: Anti-Counterfeit Training
-  description: '"The organization trains [Assignment: organization-defined personnel
+  description: 'The organization trains [Assignment: organization-defined personnel
     or roles] to detect counterfeit information system components (including hardware,
-    software, and firmware)."'
+    software, and firmware).'
 SA-19 (2):
   family: SA
   name: Configuration Control For Component Service / Repair
-  description: '"The organization maintains configuration control over [Assignment:
+  description: 'The organization maintains configuration control over [Assignment:
     organization-defined information system components] awaiting service/repair and
-    serviced/repaired components awaiting return to service."'
+    serviced/repaired components awaiting return to service.'
 SA-19 (3):
   family: SA
   name: Component Disposal
-  description: '"The organization disposes of information system components using
-    [Assignment: organization-defined techniques and methods]."'
+  description: 'The organization disposes of information system components using [Assignment:
+    organization-defined techniques and methods].'
 SA-19 (4):
   family: SA
   name: Anti-Counterfeit Scanning
-  description: '"The organization scans for counterfeit information system components
-    [Assignment: organization-defined frequency]."'
+  description: 'The organization scans for counterfeit information system components
+    [Assignment: organization-defined frequency].'
 SA-20:
   family: SA
   name: Customized Development Of Critical Components
@@ -4436,10 +4427,10 @@ SA-21:
 SA-21 (1):
   family: SA
   name: Validation Of Screening
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service take [Assignment: organization-defined
     actions] to ensure that the required access authorizations and screening criteria
-    are satisfied."'
+    are satisfied.'
 SA-22:
   family: SA
   name: Unsupported System Components
@@ -4450,9 +4441,9 @@ SA-22:
 SA-22 (1):
   family: SA
   name: Alternative Sources For Continued Support
-  description: '"The organization provides [Selection (one or more): in-house support;
+  description: 'The organization provides [Selection (one or more): in-house support;
     [Assignment: organization-defined support from external providers]] for unsupported
-    information system components."'
+    information system components.'
 SC-1:
   family: SC
   name: System And Communications Protection Policy And Procedures
@@ -4472,8 +4463,8 @@ SC-2:
 SC-2 (1):
   family: SC
   name: Interfaces For Non-Privileged Users
-  description: '"The information system prevents the presentation of information system
-    management-related functionality at an interface for non-privileged users."'
+  description: The information system prevents the presentation of information system
+    management-related functionality at an interface for non-privileged users.
 SC-3:
   family: SC
   name: Security Function Isolation
@@ -4482,31 +4473,31 @@ SC-3:
 SC-3 (1):
   family: SC
   name: Hardware Separation
-  description: '"The information system utilizes underlying hardware separation mechanisms
-    to implement security function isolation."'
+  description: The information system utilizes underlying hardware separation mechanisms
+    to implement security function isolation.
 SC-3 (2):
   family: SC
   name: Access / Flow Control Functions
-  description: '"The information system isolates security functions enforcing access
+  description: The information system isolates security functions enforcing access
     and information flow control from nonsecurity functions and from other security
-    functions."'
+    functions.
 SC-3 (3):
   family: SC
   name: Minimize Nonsecurity Functionality
-  description: '"The organization minimizes the number of nonsecurity functions included
-    within the isolation boundary containing security functions."'
+  description: The organization minimizes the number of nonsecurity functions included
+    within the isolation boundary containing security functions.
 SC-3 (4):
   family: SC
   name: Module Coupling And Cohesiveness
-  description: '"The organization implements security functions as largely independent
+  description: The organization implements security functions as largely independent
     modules that maximize internal cohesiveness within modules and minimize coupling
-    between modules."'
+    between modules.
 SC-3 (5):
   family: SC
   name: Layered Structures
-  description: '"The organization implements security functions as a layered structure
+  description: The organization implements security functions as a layered structure
     minimizing interactions between layers of the design and avoiding any dependence
-    by lower layers on the functionality or correctness of higher layers."'
+    by lower layers on the functionality or correctness of higher layers.
 SC-4:
   family: SC
   name: Information In Shared Resources
@@ -4515,14 +4506,14 @@ SC-4:
 SC-4 (1):
   family: SC
   name: Security Levels
-  description: '"[Withdrawn: Incorporated into SC-4]."'
+  description: '[Withdrawn: Incorporated into SC-4].'
 SC-4 (2):
   family: SC
   name: Periods Processing
-  description: '"The information system prevents unauthorized information transfer
+  description: 'The information system prevents unauthorized information transfer
     via shared resources in accordance with [Assignment: organization-defined procedures]
     when system processing explicitly switches between different information classification
-    levels or security categories."'
+    levels or security categories.'
 SC-5:
   family: SC
   name: Denial Of Service Protection
@@ -4533,14 +4524,14 @@ SC-5:
 SC-5 (1):
   family: SC
   name: Restrict Internal Users
-  description: '"The information system restricts the ability of individuals to launch
+  description: 'The information system restricts the ability of individuals to launch
     [Assignment: organization-defined denial of service attacks] against other information
-    systems."'
+    systems.'
 SC-5 (2):
   family: SC
   name: Excess Capacity / Bandwidth / Redundancy
-  description: '"The information system manages excess capacity, bandwidth, or other
-    redundancy to limit the effects of information flooding denial of service attacks."'
+  description: The information system manages excess capacity, bandwidth, or other
+    redundancy to limit the effects of information flooding denial of service attacks.
 SC-5 (3):
   family: SC
   name: Detection / Monitoring
@@ -4565,16 +4556,16 @@ SC-7:
 SC-7 (1):
   family: SC
   name: Physically Separated Subnetworks
-  description: '"[Withdrawn: Incorporated into SC-7]."'
+  description: '[Withdrawn: Incorporated into SC-7].'
 SC-7 (2):
   family: SC
   name: Public Access
-  description: '"[Withdrawn: Incorporated into SC-7]."'
+  description: '[Withdrawn: Incorporated into SC-7].'
 SC-7 (3):
   family: SC
   name: Access Points
-  description: '"The organization limits the number of external network connections
-    to the information system."'
+  description: The organization limits the number of external network connections
+    to the information system.
 SC-7 (4):
   family: SC
   name: External Telecommunications Services
@@ -4588,25 +4579,25 @@ SC-7 (4):
 SC-7 (5):
   family: SC
   name: Deny By Default / Allow By Exception
-  description: '"The information system at managed interfaces denies network communications
+  description: The information system at managed interfaces denies network communications
     traffic by default and allows network communications traffic by exception (i.e.,
-    deny all, permit by exception)."'
+    deny all, permit by exception).
 SC-7 (6):
   family: SC
   name: Response To Recognized Failures
-  description: '"[Withdrawn: Incorporated into SC-7 (18)]."'
+  description: '[Withdrawn: Incorporated into SC-7 (18)].'
 SC-7 (7):
   family: SC
   name: Prevent Split Tunneling For Remote Devices
-  description: '"The information system, in conjunction with a remote device, prevents
+  description: The information system, in conjunction with a remote device, prevents
     the device from simultaneously establishing non-remote connections with the system
-    and communicating via some other connection to resources in external networks."'
+    and communicating via some other connection to resources in external networks.
 SC-7 (8):
   family: SC
   name: Route Traffic To Authenticated Proxy Servers
-  description: '"The information system routes [Assignment: organization-defined internal
+  description: 'The information system routes [Assignment: organization-defined internal
     communications traffic] to [Assignment: organization-defined external networks]
-    through authenticated proxy servers at managed interfaces."'
+    through authenticated proxy servers at managed interfaces.'
 SC-7 (9):
   family: SC
   name: Restrict Threatening Outgoing Communications Traffic
@@ -4617,79 +4608,79 @@ SC-7 (9):
 SC-7 (10):
   family: SC
   name: Prevent Unauthorized Exfiltration
-  description: '"The organization prevents the unauthorized exfiltration of information
-    across managed interfaces."'
+  description: The organization prevents the unauthorized exfiltration of information
+    across managed interfaces.
 SC-7 (11):
   family: SC
   name: Restrict Incoming Communications Traffic
-  description: '"The information system only allows incoming communications from [Assignment:
+  description: 'The information system only allows incoming communications from [Assignment:
     organization-defined authorized sources] to be routed to [Assignment: organization-defined
-    authorized destinations]."'
+    authorized destinations].'
 SC-7 (12):
   family: SC
   name: Host-Based Protection
-  description: '"The organization implements [Assignment: organization-defined host-based
+  description: 'The organization implements [Assignment: organization-defined host-based
     boundary protection mechanisms] at [Assignment: organization-defined information
-    system components]."'
+    system components].'
 SC-7 (13):
   family: SC
   name: Isolation Of Security Tools / Mechanisms / Support Components
-  description: '"The organization isolates [Assignment: organization-defined information
+  description: 'The organization isolates [Assignment: organization-defined information
     security tools, mechanisms, and support components] from other internal information
     system components by implementing physically separate subnetworks with managed
-    interfaces to other components of the system."'
+    interfaces to other components of the system.'
 SC-7 (14):
   family: SC
   name: Protects Against Unauthorized Physical Connections
-  description: '"The organization protects against unauthorized physical connections
-    at [Assignment: organization-defined managed interfaces]."'
+  description: 'The organization protects against unauthorized physical connections
+    at [Assignment: organization-defined managed interfaces].'
 SC-7 (15):
   family: SC
   name: Route Privileged Network Accesses
-  description: '"The information system routes all networked, privileged accesses
-    through a dedicated, managed interface for purposes of access control and auditing."'
+  description: The information system routes all networked, privileged accesses through
+    a dedicated, managed interface for purposes of access control and auditing.
 SC-7 (16):
   family: SC
   name: Prevent Discovery Of Components / Devices
-  description: '"The information system prevents discovery of specific system components
-    composing a managed interface."'
+  description: The information system prevents discovery of specific system components
+    composing a managed interface.
 SC-7 (17):
   family: SC
   name: Automated Enforcement Of Protocol Formats
-  description: '"The information system enforces adherence to protocol formats."'
+  description: The information system enforces adherence to protocol formats.
 SC-7 (18):
   family: SC
   name: Fail Secure
-  description: '"The information system fails securely in the event of an operational
-    failure of a boundary protection device."'
+  description: The information system fails securely in the event of an operational
+    failure of a boundary protection device.
 SC-7 (19):
   family: SC
   name: Blocks Communication From Non-Organizationally Configured Hosts
-  description: '"The information system blocks both inbound and outbound communications
+  description: 'The information system blocks both inbound and outbound communications
     traffic between [Assignment: organization-defined communication clients] that
-    are independently configured by end users and external service providers."'
+    are independently configured by end users and external service providers.'
 SC-7 (20):
   family: SC
   name: Dynamic Isolation / Segregation
-  description: '"The information system provides the capability to dynamically isolate/segregate
+  description: 'The information system provides the capability to dynamically isolate/segregate
     [Assignment: organization-defined information system components] from other components
-    of the system."'
+    of the system.'
 SC-7 (21):
   family: SC
   name: Isolation Of Information System Components
-  description: '"The organization employs boundary protection mechanisms to separate
+  description: 'The organization employs boundary protection mechanisms to separate
     [Assignment: organization-defined information system components] supporting [Assignment:
-    organization-defined missions and/or business functions]."'
+    organization-defined missions and/or business functions].'
 SC-7 (22):
   family: SC
   name: Separate Subnets For Connecting To Different Security Domains
-  description: '"The information system implements separate network addresses (i.e.,
-    different subnets) to connect to systems in different security domains."'
+  description: The information system implements separate network addresses (i.e.,
+    different subnets) to connect to systems in different security domains.
 SC-7 (23):
   family: SC
   name: Disable Sender Feedback On Protocol Validation Failure
-  description: '"The information system disables feedback to senders on protocol format
-    validation failure."'
+  description: The information system disables feedback to senders on protocol format
+    validation failure.
 SC-8:
   family: SC
   name: Transmission Confidentiality And Integrity
@@ -4698,27 +4689,27 @@ SC-8:
 SC-8 (1):
   family: SC
   name: Cryptographic Or Alternate Physical Protection
-  description: '"The information system implements cryptographic mechanisms to [Selection
+  description: 'The information system implements cryptographic mechanisms to [Selection
     (one or more): prevent unauthorized disclosure of information; detect changes
     to information] during transmission unless otherwise protected by [Assignment:
-    organization-defined alternative physical safeguards]."'
+    organization-defined alternative physical safeguards].'
 SC-8 (2):
   family: SC
   name: Pre / Post Transmission Handling
-  description: '"The information system maintains the [Selection (one or more): confidentiality;
-    integrity] of information during preparation for transmission and during reception."'
+  description: 'The information system maintains the [Selection (one or more): confidentiality;
+    integrity] of information during preparation for transmission and during reception.'
 SC-8 (3):
   family: SC
   name: Cryptographic Protection For Message Externals
-  description: '"The information system implements cryptographic mechanisms to protect
+  description: 'The information system implements cryptographic mechanisms to protect
     message externals unless otherwise protected by [Assignment: organization-defined
-    alternative physical safeguards]."'
+    alternative physical safeguards].'
 SC-8 (4):
   family: SC
   name: Conceal / Randomize Communications
-  description: '"The information system implements cryptographic mechanisms to conceal
+  description: 'The information system implements cryptographic mechanisms to conceal
     or randomize communication patterns unless otherwise protected by [Assignment:
-    organization-defined alternative physical safeguards]."'
+    organization-defined alternative physical safeguards].'
 SC-9:
   family: SC
   name: Transmission Confidentiality
@@ -4739,8 +4730,8 @@ SC-11:
 SC-11 (1):
   family: SC
   name: Logical Isolation
-  description: '"The information system provides a trusted communications path that
-    is logically isolated and distinguishable from other paths."'
+  description: The information system provides a trusted communications path that
+    is logically isolated and distinguishable from other paths.
 SC-12:
   family: SC
   name: Cryptographic Key Establishment And Management
@@ -4751,30 +4742,30 @@ SC-12:
 SC-12 (1):
   family: SC
   name: Availability
-  description: '"The organization maintains availability of information in the event
-    of the loss of cryptographic keys by users."'
+  description: The organization maintains availability of information in the event
+    of the loss of cryptographic keys by users.
 SC-12 (2):
   family: SC
   name: Symmetric Keys
-  description: '"The organization produces, controls, and distributes symmetric cryptographic
+  description: 'The organization produces, controls, and distributes symmetric cryptographic
     keys using [Selection: NIST FIPS-compliant; NSA-approved] key management technology
-    and processes."'
+    and processes.'
 SC-12 (3):
   family: SC
   name: Asymmetric Keys
-  description: '"The organization produces, controls, and distributes asymmetric cryptographic
+  description: 'The organization produces, controls, and distributes asymmetric cryptographic
     keys using [Selection: NSA-approved key management technology and processes; approved
     PKI Class 3 certificates or prepositioned keying material; approved PKI Class
-    3 or Class 4 certificates and hardware security tokens that protect the user�s
-    private key]."'
+    3 or Class 4 certificates and hardware security tokens that protect the user''s
+    private key].'
 SC-12 (4):
   family: SC
   name: Pki Certificates
-  description: '"[Withdrawn: Incorporated into SC-12]."'
+  description: '[Withdrawn: Incorporated into SC-12].'
 SC-12 (5):
   family: SC
   name: Pki Certificates / Hardware Tokens
-  description: '"[Withdrawn: Incorporated into SC-12]."'
+  description: '[Withdrawn: Incorporated into SC-12].'
 SC-13:
   family: SC
   name: Cryptographic Protection
@@ -4785,19 +4776,19 @@ SC-13:
 SC-13 (1):
   family: SC
   name: Fips-Validated Cryptography
-  description: '"[Withdrawn: Incorporated into SC-13]."'
+  description: '[Withdrawn: Incorporated into SC-13].'
 SC-13 (2):
   family: SC
   name: Nsa-Approved Cryptography
-  description: '"[Withdrawn: Incorporated into SC-13]."'
+  description: '[Withdrawn: Incorporated into SC-13].'
 SC-13 (3):
   family: SC
   name: Individuals Without Formal Access  Approvals
-  description: '"[Withdrawn: Incorporated into SC-13]."'
+  description: '[Withdrawn: Incorporated into SC-13].'
 SC-13 (4):
   family: SC
   name: Digital Signatures
-  description: '"[Withdrawn: Incorporated into SC-13]."'
+  description: '[Withdrawn: Incorporated into SC-13].'
 SC-14:
   family: SC
   name: Public Access Protections
@@ -4813,23 +4804,23 @@ SC-15:
 SC-15 (1):
   family: SC
   name: Physical Disconnect
-  description: '"The information system provides physical disconnect of collaborative
-    computing devices in a manner that supports ease of use."'
+  description: The information system provides physical disconnect of collaborative
+    computing devices in a manner that supports ease of use.
 SC-15 (2):
   family: SC
   name: Blocking Inbound / Outbound Communications Traffic
-  description: '"[Withdrawn: Incorporated into SC-7]."'
+  description: '[Withdrawn: Incorporated into SC-7].'
 SC-15 (3):
   family: SC
   name: Disabling / Removal In Secure Work Areas
-  description: '"The organization disables or removes collaborative computing devices
+  description: 'The organization disables or removes collaborative computing devices
     from [Assignment: organization-defined information systems or information system
-    components] in [Assignment: organization-defined secure work areas]."'
+    components] in [Assignment: organization-defined secure work areas].'
 SC-15 (4):
   family: SC
   name: Explicitly Indicate Current Participants
-  description: '"The information system provides an explicit indication of current
-    participants in [Assignment: organization-defined online meetings and teleconferences]."'
+  description: 'The information system provides an explicit indication of current
+    participants in [Assignment: organization-defined online meetings and teleconferences].'
 SC-16:
   family: SC
   name: Transmission Of Security Attributes
@@ -4839,8 +4830,8 @@ SC-16:
 SC-16 (1):
   family: SC
   name: Integrity Validation
-  description: '"The information system validates the integrity of transmitted security
-    attributes."'
+  description: The information system validates the integrity of transmitted security
+    attributes.
 SC-17:
   family: SC
   name: Public Key Infrastructure Certificates
@@ -4858,31 +4849,31 @@ SC-18:
 SC-18 (1):
   family: SC
   name: Identify Unacceptable Code / Take Corrective Actions
-  description: '"The information system identifies [Assignment: organization-defined
+  description: 'The information system identifies [Assignment: organization-defined
     unacceptable mobile code] and takes [Assignment: organization-defined corrective
-    actions]."'
+    actions].'
 SC-18 (2):
   family: SC
   name: Acquisition / Development / Use
-  description: '"The organization ensures that the acquisition, development, and use
+  description: 'The organization ensures that the acquisition, development, and use
     of mobile code to be deployed in the information system meets [Assignment: organization-defined
-    mobile code requirements]."'
+    mobile code requirements].'
 SC-18 (3):
   family: SC
   name: Prevent Downloading / Execution
-  description: '"The information system prevents the download and execution of [Assignment:
-    organization-defined unacceptable mobile code]."'
+  description: 'The information system prevents the download and execution of [Assignment:
+    organization-defined unacceptable mobile code].'
 SC-18 (4):
   family: SC
   name: Prevent Automatic Execution
-  description: '"The information system prevents the automatic execution of mobile
+  description: 'The information system prevents the automatic execution of mobile
     code in [Assignment: organization-defined software applications] and enforces
-    [Assignment: organization-defined actions] prior to executing the code."'
+    [Assignment: organization-defined actions] prior to executing the code.'
 SC-18 (5):
   family: SC
   name: Allow Execution Only In Confined Environments
-  description: '"The organization allows execution of permitted mobile code only in
-    confined virtual machine environments."'
+  description: The organization allows execution of permitted mobile code only in
+    confined virtual machine environments.
 SC-19:
   family: SC
   name: Voice Over Internet Protocol
@@ -4900,12 +4891,12 @@ SC-20:
 SC-20 (1):
   family: SC
   name: Child Subspaces
-  description: '"[Withdrawn: Incorporated into SC-20]."'
+  description: '[Withdrawn: Incorporated into SC-20].'
 SC-20 (2):
   family: SC
   name: Data Origin / Integrity
-  description: '"The information system provides data origin and integrity protection
-    artifacts for internal name/address resolution queries."'
+  description: The information system provides data origin and integrity protection
+    artifacts for internal name/address resolution queries.
 SC-21:
   family: SC
   name: Secure Name / Address Resolution Service (Recursive Or Caching Resolver)
@@ -4915,7 +4906,7 @@ SC-21:
 SC-21 (1):
   family: SC
   name: Data Origin / Integrity
-  description: '"[Withdrawn: Incorporated into SC-21]."'
+  description: '[Withdrawn: Incorporated into SC-21].'
 SC-22:
   family: SC
   name: Architecture And Provisioning For Name / Address Resolution Service
@@ -4930,27 +4921,27 @@ SC-23:
 SC-23 (1):
   family: SC
   name: Invalidate Session Identifiers At Logout
-  description: '"The information system invalidates session identifiers upon user
-    logout or other session termination."'
+  description: The information system invalidates session identifiers upon user logout
+    or other session termination.
 SC-23 (2):
   family: SC
   name: User-Initiated Logouts / Message Displays
-  description: '"[Withdrawn: Incorporated into AC-12 (1)]."'
+  description: '[Withdrawn: Incorporated into AC-12 (1)].'
 SC-23 (3):
   family: SC
   name: Unique Session Identifiers With Randomization
-  description: '"The information system generates a unique session identifier for
-    each session with [Assignment: organization-defined randomness requirements] and
-    recognizes only session identifiers that are system-generated."'
+  description: 'The information system generates a unique session identifier for each
+    session with [Assignment: organization-defined randomness requirements] and recognizes
+    only session identifiers that are system-generated.'
 SC-23 (4):
   family: SC
   name: Unique Session Identifiers With Randomization
-  description: '"[Withdrawn: Incorporated into SC-23 (3)]."'
+  description: '[Withdrawn: Incorporated into SC-23 (3)].'
 SC-23 (5):
   family: SC
   name: Allowed Certificate Authorities
-  description: '"The information system only allows the use of [Assignment: organization-defined
-    certificate authorities] for verification of the establishment of protected sessions."'
+  description: 'The information system only allows the use of [Assignment: organization-defined
+    certificate authorities] for verification of the establishment of protected sessions.'
 SC-24:
   family: SC
   name: Fail In Known State
@@ -4971,7 +4962,7 @@ SC-26:
 SC-26 (1):
   family: SC
   name: Detection Of Malicious Code
-  description: '"[Withdrawn: Incorporated into SC-35]."'
+  description: '[Withdrawn: Incorporated into SC-35].'
 SC-27:
   family: SC
   name: Platform-Independent Applications
@@ -4985,14 +4976,14 @@ SC-28:
 SC-28 (1):
   family: SC
   name: Cryptographic Protection
-  description: '"The information system implements cryptographic mechanisms to prevent
+  description: 'The information system implements cryptographic mechanisms to prevent
     unauthorized disclosure and modification of [Assignment: organization-defined
-    information] on [Assignment: organization-defined information system components]."'
+    information] on [Assignment: organization-defined information system components].'
 SC-28 (2):
   family: SC
   name: Off-Line Storage
-  description: '"The organization removes from online storage and stores off-line
-    in a secure location [Assignment: organization-defined information]."'
+  description: 'The organization removes from online storage and stores off-line in
+    a secure location [Assignment: organization-defined information].'
 SC-29:
   family: SC
   name: Heterogeneity
@@ -5002,9 +4993,9 @@ SC-29:
 SC-29 (1):
   family: SC
   name: Virtualization Techniques
-  description: '"The organization employs virtualization techniques to support the
+  description: 'The organization employs virtualization techniques to support the
     deployment of a diversity of operating systems and applications that are changed
-    [Assignment: organization-defined frequency]."'
+    [Assignment: organization-defined frequency].'
 SC-30:
   family: SC
   name: Concealment And Misdirection
@@ -5015,29 +5006,29 @@ SC-30:
 SC-30 (1):
   family: SC
   name: Virtualization Techniques
-  description: '"[Withdrawn: Incorporated into SC-29 (1)]."'
+  description: '[Withdrawn: Incorporated into SC-29 (1)].'
 SC-30 (2):
   family: SC
   name: Randomness
-  description: '"The organization employs [Assignment: organization-defined techniques]
-    to introduce randomness into organizational operations and assets."'
+  description: 'The organization employs [Assignment: organization-defined techniques]
+    to introduce randomness into organizational operations and assets.'
 SC-30 (3):
   family: SC
   name: Change Processing / Storage Locations
-  description: '"The organization changes the location of [Assignment: organization-defined
+  description: 'The organization changes the location of [Assignment: organization-defined
     processing and/or storage] [Selection: [Assignment: organization-defined time
-    frequency]; at random time intervals]]."'
+    frequency]; at random time intervals]].'
 SC-30 (4):
   family: SC
   name: Misleading Information
-  description: '"The organization employs realistic, but misleading information in
+  description: 'The organization employs realistic, but misleading information in
     [Assignment: organization-defined information system components] with regard to
-    its security state or posture."'
+    its security state or posture.'
 SC-30 (5):
   family: SC
   name: Concealment Of System Components
-  description: '"The organization employs [Assignment: organization-defined techniques]
-    to hide or conceal [Assignment: organization-defined information system components]."'
+  description: 'The organization employs [Assignment: organization-defined techniques]
+    to hide or conceal [Assignment: organization-defined information system components].'
 SC-31:
   family: SC
   name: Covert Channel Analysis
@@ -5048,20 +5039,20 @@ SC-31:
 SC-31 (1):
   family: SC
   name: Test Covert Channels For Exploitability
-  description: '"The organization tests a subset of the identified covert channels
-    to determine which channels are exploitable."'
+  description: The organization tests a subset of the identified covert channels to
+    determine which channels are exploitable.
 SC-31 (2):
   family: SC
   name: Maximum Bandwidth
-  description: '"The organization reduces the maximum bandwidth for identified covert
+  description: 'The organization reduces the maximum bandwidth for identified covert
     [Selection (one or more); storage; timing] channels to [Assignment: organization-defined
-    values]."'
+    values].'
 SC-31 (3):
   family: SC
   name: Measure Bandwidth In Operational Environments
-  description: '"The organization measures the bandwidth of [Assignment: organization-defined
+  description: 'The organization measures the bandwidth of [Assignment: organization-defined
     subset of identified covert channels] in the operational environment of the information
-    system."'
+    system.'
 SC-32:
   family: SC
   name: Information System Partitioning
@@ -5083,15 +5074,15 @@ SC-34:
 SC-34 (1):
   family: SC
   name: No Writable Storage
-  description: '"The organization employs [Assignment: organization-defined information
+  description: 'The organization employs [Assignment: organization-defined information
     system components] with no writeable storage that is persistent across component
-    restart or power on/off."'
+    restart or power on/off.'
 SC-34 (2):
   family: SC
   name: Integrity Protection / Read-Only Media
-  description: '"The organization protects the integrity of information prior to storage
+  description: The organization protects the integrity of information prior to storage
     on read-only media and controls the media after such information has been recorded
-    onto the media."'
+    onto the media.
 SC-34 (3):
   family: SC
   name: Hardware-Based Protection
@@ -5112,9 +5103,9 @@ SC-36:
 SC-36 (1):
   family: SC
   name: Polling Techniques
-  description: '"The organization employs polling techniques to identify potential
+  description: 'The organization employs polling techniques to identify potential
     faults, errors, or compromises to [Assignment: organization-defined distributed
-    processing and storage components]."'
+    processing and storage components].'
 SC-37:
   family: SC
   name: Out-Of-Band Channels
@@ -5125,10 +5116,10 @@ SC-37:
 SC-37 (1):
   family: SC
   name: Ensure Delivery / Transmission
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to ensure that only [Assignment: organization-defined individuals
     or information systems] receive the [Assignment: organization-defined information,
-    information system components, or devices]."'
+    information system components, or devices].'
 SC-38:
   family: SC
   name: Operations Security
@@ -5143,13 +5134,13 @@ SC-39:
 SC-39 (1):
   family: SC
   name: Hardware Separation
-  description: '"The information system implements underlying hardware separation
-    mechanisms to facilitate process separation."'
+  description: The information system implements underlying hardware separation mechanisms
+    to facilitate process separation.
 SC-39 (2):
   family: SC
   name: Thread Isolation
-  description: '"The information system maintains a separate execution domain for
-    each thread in [Assignment: organization-defined multi-threaded processing]."'
+  description: 'The information system maintains a separate execution domain for each
+    thread in [Assignment: organization-defined multi-threaded processing].'
 SC-40:
   family: SC
   name: Wireless Link Protection
@@ -5159,27 +5150,27 @@ SC-40:
 SC-40 (1):
   family: SC
   name: Electromagnetic Interference
-  description: '"The information system implements cryptographic mechanisms that achieve
+  description: 'The information system implements cryptographic mechanisms that achieve
     [Assignment: organization-defined level of protection] against the effects of
-    intentional electromagnetic interference."'
+    intentional electromagnetic interference.'
 SC-40 (2):
   family: SC
   name: Reduce Detection Potential
-  description: '"The information system implements cryptographic mechanisms to reduce
+  description: 'The information system implements cryptographic mechanisms to reduce
     the detection potential of wireless links to [Assignment: organization-defined
-    level of reduction]."'
+    level of reduction].'
 SC-40 (3):
   family: SC
   name: Imitative Or Manipulative Communications Deception
-  description: '"The information system implements cryptographic mechanisms to identify
+  description: The information system implements cryptographic mechanisms to identify
     and reject wireless transmissions that are deliberate attempts to achieve imitative
-    or manipulative communications deception based on signal parameters."'
+    or manipulative communications deception based on signal parameters.
 SC-40 (4):
   family: SC
   name: Signal Parameter Identification
-  description: '"The information system implements cryptographic mechanisms to prevent
+  description: 'The information system implements cryptographic mechanisms to prevent
     the identification of [Assignment: organization-defined wireless transmitters]
-    by using the transmitter signal parameters."'
+    by using the transmitter signal parameters.'
 SC-41:
   family: SC
   name: Port And I/O Device Access
@@ -5196,21 +5187,21 @@ SC-42:
 SC-42 (1):
   family: SC
   name: Reporting To Authorized Individuals Or Roles
-  description: '"The organization ensures that the information system is configured
+  description: 'The organization ensures that the information system is configured
     so that data or information collected by the [Assignment: organization-defined
-    sensors] is only reported to authorized individuals or roles."'
+    sensors] is only reported to authorized individuals or roles.'
 SC-42 (2):
   family: SC
   name: Authorized Use
-  description: '"The organization employs the following measures: [Assignment: organization-defined
+  description: 'The organization employs the following measures: [Assignment: organization-defined
     measures], so that data or information collected by [Assignment: organization-defined
-    sensors] is only used for authorized purposes."'
+    sensors] is only used for authorized purposes.'
 SC-42 (3):
   family: SC
   name: Prohibit Use Of Devices
-  description: '"The organization prohibits the use of devices possessing [Assignment:
+  description: 'The organization prohibits the use of devices possessing [Assignment:
     organization-defined environmental sensing capabilities] in [Assignment: organization-defined
-    facilities, areas, or systems]."'
+    facilities, areas, or systems].'
 SC-43:
   family: SC
   name: Usage Restrictions
@@ -5246,13 +5237,13 @@ SI-2:
 SI-2 (1):
   family: SI
   name: Central Management
-  description: '"The organization centrally manages the flaw remediation process."'
+  description: The organization centrally manages the flaw remediation process.
 SI-2 (2):
   family: SI
   name: Automated Flaw Remediation Status
-  description: '"The organization employs automated mechanisms [Assignment: organization-defined
+  description: 'The organization employs automated mechanisms [Assignment: organization-defined
     frequency] to determine the state of information system components with regard
-    to flaw remediation."'
+    to flaw remediation.'
 SI-2 (3):
   family: SI
   name: Time To Remediate Flaws / Benchmarks For Corrective Actions
@@ -5263,18 +5254,18 @@ SI-2 (3):
 SI-2 (4):
   family: SI
   name: Automated Patch Management Tools
-  description: '"[Withdrawn: Incorporated into SI-2]."'
+  description: '[Withdrawn: Incorporated into SI-2].'
 SI-2 (5):
   family: SI
   name: Automatic Software / Firmware Updates
-  description: '"The organization installs [Assignment: organization-defined security-relevant
+  description: 'The organization installs [Assignment: organization-defined security-relevant
     software and firmware updates] automatically to [Assignment: organization-defined
-    information system components]."'
+    information system components].'
 SI-2 (6):
   family: SI
   name: Removal Of Previous Versions Of Software / Firmware
-  description: '"The organization removes [Assignment: organization-defined software
-    and firmware components] after updated versions have been installed."'
+  description: 'The organization removes [Assignment: organization-defined software
+    and firmware components] after updated versions have been installed.'
 SI-3:
   family: SI
   name: Malicious Code Protection
@@ -5289,25 +5280,25 @@ SI-3:
 SI-3 (1):
   family: SI
   name: Central Management
-  description: '"The organization centrally manages malicious code protection mechanisms."'
+  description: The organization centrally manages malicious code protection mechanisms.
 SI-3 (2):
   family: SI
   name: Automatic Updates
-  description: '"The information system automatically updates malicious code protection
-    mechanisms."'
+  description: The information system automatically updates malicious code protection
+    mechanisms.
 SI-3 (3):
   family: SI
   name: Non-Privileged Users
-  description: '"[Withdrawn: Incorporated into AC-6 (10)]."'
+  description: '[Withdrawn: Incorporated into AC-6 (10)].'
 SI-3 (4):
   family: SI
   name: Updates Only By Privileged Users
-  description: '"The information system updates malicious code protection mechanisms
-    only when directed by a privileged user."'
+  description: The information system updates malicious code protection mechanisms
+    only when directed by a privileged user.
 SI-3 (5):
   family: SI
   name: Portable Storage Devices
-  description: '"[Withdrawn: Incorporated into MP-7]."'
+  description: '[Withdrawn: Incorporated into MP-7].'
 SI-3 (6):
   family: SI
   name: Testing / Verification
@@ -5318,22 +5309,22 @@ SI-3 (6):
 SI-3 (7):
   family: SI
   name: Nonsignature-Based Detection
-  description: '"The information system implements nonsignature-based malicious code
-    detection mechanisms."'
+  description: The information system implements nonsignature-based malicious code
+    detection mechanisms.
 SI-3 (8):
   family: SI
   name: Detect Unauthorized Commands
-  description: '"The information system detects [Assignment: organization-defined
-    unauthorized operating system commands] through the kernel application programming
-    interface at [Assignment: organization-defined information system hardware components]
-    and [Selection (one or more): issues a warning; audits the command execution;
-    prevents the execution of the command]."'
+  description: 'The information system detects [Assignment: organization-defined unauthorized
+    operating system commands] through the kernel application programming interface
+    at [Assignment: organization-defined information system hardware components] and
+    [Selection (one or more): issues a warning; audits the command execution; prevents
+    the execution of the command].'
 SI-3 (9):
   family: SI
   name: Authenticate Remote Commands
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     security safeguards] to authenticate [Assignment: organization-defined remote
-    commands]."'
+    commands].'
 SI-3 (10):
   family: SI
   name: Malicious Code Analysis
@@ -5360,71 +5351,71 @@ SI-4:
 SI-4 (1):
   family: SI
   name: System-Wide Intrusion Detection System
-  description: '"The organization connects and configures individual intrusion detection
-    tools into an information system-wide intrusion detection system."'
+  description: The organization connects and configures individual intrusion detection
+    tools into an information system-wide intrusion detection system.
 SI-4 (2):
   family: SI
   name: Automated Tools For Real-Time Analysis
-  description: '"The organization employs automated tools to support near real-time
-    analysis of events."'
+  description: The organization employs automated tools to support near real-time
+    analysis of events.
 SI-4 (3):
   family: SI
   name: Automated Tool Integration
-  description: '"The organization employs automated tools to integrate intrusion detection
+  description: The organization employs automated tools to integrate intrusion detection
     tools into access control and flow control mechanisms for rapid response to attacks
     by enabling reconfiguration of these mechanisms in support of attack isolation
-    and elimination."'
+    and elimination.
 SI-4 (4):
   family: SI
   name: Inbound And Outbound Communications Traffic
-  description: '"The information system monitors inbound and outbound communications
+  description: 'The information system monitors inbound and outbound communications
     traffic [Assignment: organization-defined frequency] for unusual or unauthorized
-    activities or conditions."'
+    activities or conditions.'
 SI-4 (5):
   family: SI
   name: System-Generated Alerts
-  description: '"The information system alerts [Assignment: organization-defined personnel
+  description: 'The information system alerts [Assignment: organization-defined personnel
     or roles] when the following indications of compromise or potential compromise
-    occur: [Assignment: organization-defined compromise indicators]."'
+    occur: [Assignment: organization-defined compromise indicators].'
 SI-4 (6):
   family: SI
   name: Restrict Non-Privileged Users
-  description: '"[Withdrawn: Incorporated into AC-6 (10)]."'
+  description: '[Withdrawn: Incorporated into AC-6 (10)].'
 SI-4 (7):
   family: SI
   name: Automated Response To Suspicious Events
-  description: '"The information system notifies [Assignment: organization-defined
+  description: 'The information system notifies [Assignment: organization-defined
     incident response personnel (identified by name and/or by role)] of detected suspicious
     events and takes [Assignment: organization-defined least-disruptive actions to
-    terminate suspicious events]."'
+    terminate suspicious events].'
 SI-4 (8):
   family: SI
   name: Protection Of Monitoring Information
-  description: '"[Withdrawn: Incorporated into SI-4]."'
+  description: '[Withdrawn: Incorporated into SI-4].'
 SI-4 (9):
   family: SI
   name: Testing Of Monitoring Tools
-  description: '"The organization tests intrusion-monitoring tools [Assignment: organization-defined
-    frequency]."'
+  description: 'The organization tests intrusion-monitoring tools [Assignment: organization-defined
+    frequency].'
 SI-4 (10):
   family: SI
   name: Visibility Of Encrypted Communications
-  description: '"The organization makes provisions so that [Assignment: organization-defined
+  description: 'The organization makes provisions so that [Assignment: organization-defined
     encrypted communications traffic] is visible to [Assignment: organization-defined
-    information system monitoring tools]."'
+    information system monitoring tools].'
 SI-4 (11):
   family: SI
   name: Analyze Communications Traffic Anomalies
-  description: '"The organization analyzes outbound communications traffic at the
-    external boundary of the information system and selected [Assignment: organization-defined
+  description: 'The organization analyzes outbound communications traffic at the external
+    boundary of the information system and selected [Assignment: organization-defined
     interior points within the system (e.g., subnetworks, subsystems)] to discover
-    anomalies."'
+    anomalies.'
 SI-4 (12):
   family: SI
   name: Automated Alerts
-  description: '"The organization employs automated mechanisms to alert security personnel
+  description: 'The organization employs automated mechanisms to alert security personnel
     of the following inappropriate or unusual activities with security implications:
-    [Assignment: organization-defined activities that trigger alerts]."'
+    [Assignment: organization-defined activities that trigger alerts].'
 SI-4 (13):
   family: SI
   name: Analyze Traffic / Event Patterns
@@ -5436,68 +5427,67 @@ SI-4 (13):
 SI-4 (14):
   family: SI
   name: Wireless Intrusion Detection
-  description: '"The organization employs a wireless intrusion detection system to
-    identify rogue wireless devices and to detect attack attempts and potential compromises/breaches
-    to the information system."'
+  description: The organization employs a wireless intrusion detection system to identify
+    rogue wireless devices and to detect attack attempts and potential compromises/breaches
+    to the information system.
 SI-4 (15):
   family: SI
   name: Wireless To Wireline Communications
-  description: '"The organization employs an intrusion detection system to monitor
-    wireless communications traffic as the traffic passes from wireless to wireline
-    networks."'
+  description: The organization employs an intrusion detection system to monitor wireless
+    communications traffic as the traffic passes from wireless to wireline networks.
 SI-4 (16):
   family: SI
   name: Correlate Monitoring Information
-  description: '"The organization correlates information from monitoring tools employed
-    throughout the information system."'
+  description: The organization correlates information from monitoring tools employed
+    throughout the information system.
 SI-4 (17):
   family: SI
   name: Integrated Situational Awareness
-  description: '"The organization correlates information from monitoring physical,
-    cyber, and supply chain activities to achieve integrated, organization-wide situational
-    awareness."'
+  description: The organization correlates information from monitoring physical, cyber,
+    and supply chain activities to achieve integrated, organization-wide situational
+    awareness.
 SI-4 (18):
   family: SI
   name: Analyze Traffic / Covert Exfiltration
-  description: '"The organization analyzes outbound communications traffic at the
-    external boundary of the information system (i.e., system perimeter) and at [Assignment:
+  description: 'The organization analyzes outbound communications traffic at the external
+    boundary of the information system (i.e., system perimeter) and at [Assignment:
     organization-defined interior points within the system (e.g., subsystems, subnetworks)]
-    to detect covert exfiltration of information."'
+    to detect covert exfiltration of information.'
 SI-4 (19):
   family: SI
   name: Individuals Posing Greater Risk
-  description: '"The organization implements [Assignment: organization-defined additional
+  description: 'The organization implements [Assignment: organization-defined additional
     monitoring] of individuals who have been identified by [Assignment: organization-defined
-    sources] as posing an increased level of risk."'
+    sources] as posing an increased level of risk.'
 SI-4 (20):
   family: SI
   name: Privileged Users
-  description: '"The organization implements [Assignment: organization-defined additional
-    monitoring] of privileged users."'
+  description: 'The organization implements [Assignment: organization-defined additional
+    monitoring] of privileged users.'
 SI-4 (21):
   family: SI
   name: Probationary Periods
-  description: '"The organization implements [Assignment: organization-defined additional
+  description: 'The organization implements [Assignment: organization-defined additional
     monitoring] of individuals during [Assignment: organization-defined probationary
-    period]."'
+    period].'
 SI-4 (22):
   family: SI
   name: Unauthorized Network Services
-  description: '"The information system detects network services that have not been
+  description: 'The information system detects network services that have not been
     authorized or approved by [Assignment: organization-defined authorization or approval
     processes] and [Selection (one or more): audits; alerts [Assignment: organization-defined
-    personnel or roles]]."'
+    personnel or roles]].'
 SI-4 (23):
   family: SI
   name: Host-Based Devices
-  description: '"The organization implements [Assignment: organization-defined host-based
+  description: 'The organization implements [Assignment: organization-defined host-based
     monitoring mechanisms] at [Assignment: organization-defined information system
-    components]."'
+    components].'
 SI-4 (24):
   family: SI
   name: Indicators Of Compromise
-  description: '"The information system discovers, collects, distributes, and uses
-    indicators of compromise."'
+  description: The information system discovers, collects, distributes, and uses indicators
+    of compromise.
 SI-5:
   family: SI
   name: Security Alerts, Advisories, And Directives
@@ -5510,8 +5500,8 @@ SI-5:
 SI-5 (1):
   family: SI
   name: Automated Alerts And Advisories
-  description: '"The organization employs automated mechanisms to make security alert
-    and advisory information available throughout the organization."'
+  description: The organization employs automated mechanisms to make security alert
+    and advisory information available throughout the organization.
 SI-6:
   family: SI
   name: Security Function Verification
@@ -5524,17 +5514,17 @@ SI-6:
 SI-6 (1):
   family: SI
   name: Notification Of Failed Security Tests
-  description: '"[Withdrawn: Incorporated into SI-6]."'
+  description: '[Withdrawn: Incorporated into SI-6].'
 SI-6 (2):
   family: SI
   name: Automation Support For Distributed Testing
-  description: '"The information system implements automated mechanisms to support
-    the management of distributed security testing."'
+  description: The information system implements automated mechanisms to support the
+    management of distributed security testing.
 SI-6 (3):
   family: SI
   name: Report Verification Results
-  description: '"The organization reports the results of security function verification
-    to [Assignment: organization-defined personnel or roles]."'
+  description: 'The organization reports the results of security function verification
+    to [Assignment: organization-defined personnel or roles].'
 SI-7:
   family: SI
   name: Software, Firmware, And Information Integrity
@@ -5543,79 +5533,78 @@ SI-7:
 SI-7 (1):
   family: SI
   name: Integrity Checks
-  description: '"The information system performs an integrity check of [Assignment:
+  description: 'The information system performs an integrity check of [Assignment:
     organization-defined software, firmware, and information] [Selection (one or more):
     at startup; at [Assignment: organization-defined transitional states or security-relevant
-    events]; [Assignment: organization-defined frequency]]."'
+    events]; [Assignment: organization-defined frequency]].'
 SI-7 (2):
   family: SI
   name: Automated Notifications Of Integrity Violations
-  description: '"The organization employs automated tools that provide notification
+  description: 'The organization employs automated tools that provide notification
     to [Assignment: organization-defined personnel or roles] upon discovering discrepancies
-    during integrity verification."'
+    during integrity verification.'
 SI-7 (3):
   family: SI
   name: Centrally-Managed Integrity Tools
-  description: '"The organization employs centrally managed integrity verification
-    tools."'
+  description: The organization employs centrally managed integrity verification tools.
 SI-7 (4):
   family: SI
   name: Tamper-Evident Packaging
-  description: '"[Withdrawn: Incorporated into SA-12]."'
+  description: '[Withdrawn: Incorporated into SA-12].'
 SI-7 (5):
   family: SI
   name: Automated Response To Integrity Violations
-  description: '"The information system automatically [Selection (one or more): shuts
+  description: 'The information system automatically [Selection (one or more): shuts
     the information system down; restarts the information system; implements [Assignment:
-    organization-defined security safeguards]] when integrity violations are discovered."'
+    organization-defined security safeguards]] when integrity violations are discovered.'
 SI-7 (6):
   family: SI
   name: Cryptographic Protection
-  description: '"The information system implements cryptographic mechanisms to detect
-    unauthorized changes to software, firmware, and information."'
+  description: The information system implements cryptographic mechanisms to detect
+    unauthorized changes to software, firmware, and information.
 SI-7 (7):
   family: SI
   name: Integration Of Detection And Response
-  description: '"The organization incorporates the detection of unauthorized [Assignment:
+  description: 'The organization incorporates the detection of unauthorized [Assignment:
     organization-defined security-relevant changes to the information system] into
-    the organizational incident response capability."'
+    the organizational incident response capability.'
 SI-7 (8):
   family: SI
   name: Auditing Capability For Significant Events
-  description: '"The information system, upon detection of a potential integrity violation,
+  description: 'The information system, upon detection of a potential integrity violation,
     provides the capability to audit the event and initiates the following actions:
     [Selection (one or more): generates an audit record; alerts current user; alerts
     [Assignment: organization-defined personnel or roles]; [Assignment: organization-defined
-    other actions]]."'
+    other actions]].'
 SI-7 (9):
   family: SI
   name: Verify Boot Process
-  description: '"The information system verifies the integrity of the boot process
-    of [Assignment: organization-defined devices]."'
+  description: 'The information system verifies the integrity of the boot process
+    of [Assignment: organization-defined devices].'
 SI-7 (10):
   family: SI
   name: Protection Of Boot Firmware
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     security safeguards] to protect the integrity of boot firmware in [Assignment:
-    organization-defined devices]."'
+    organization-defined devices].'
 SI-7 (11):
   family: SI
   name: Confined Environments With Limited Privileges
-  description: '"The organization requires that [Assignment: organization-defined
-    user-installed software] execute in a confined physical or virtual machine environment
-    with limited privileges."'
+  description: 'The organization requires that [Assignment: organization-defined user-installed
+    software] execute in a confined physical or virtual machine environment with limited
+    privileges.'
 SI-7 (12):
   family: SI
   name: Integrity Verification
-  description: '"The organization requires that the integrity of [Assignment: organization-defined
-    user-installed software] be verified prior to execution."'
+  description: 'The organization requires that the integrity of [Assignment: organization-defined
+    user-installed software] be verified prior to execution.'
 SI-7 (13):
   family: SI
   name: Code Execution In Protected Environments
-  description: '"The organization allows execution of binary or machine-executable
+  description: 'The organization allows execution of binary or machine-executable
     code obtained from sources with limited or no warranty and without the provision
     of source code only in confined physical or virtual machine environments and with
-    the explicit approval of [Assignment: organization-defined personnel or roles]."'
+    the explicit approval of [Assignment: organization-defined personnel or roles].'
 SI-7 (14):
   family: SI
   name: Binary Or Machine Executable Code
@@ -5626,13 +5615,13 @@ SI-7 (14):
 SI-7 (15):
   family: SI
   name: Code Authentication
-  description: '"The information system implements cryptographic mechanisms to authenticate
-    [Assignment: organization-defined software or firmware components] prior to installation."'
+  description: 'The information system implements cryptographic mechanisms to authenticate
+    [Assignment: organization-defined software or firmware components] prior to installation.'
 SI-7 (16):
   family: SI
   name: Time Limit On Process Execution W/O Supervision
-  description: '"The organization does not allow processes to execute without supervision
-    for more than [Assignment: organization-defined time period]."'
+  description: 'The organization does not allow processes to execute without supervision
+    for more than [Assignment: organization-defined time period].'
 SI-8:
   family: SI
   name: Spam Protection
@@ -5643,16 +5632,16 @@ SI-8:
 SI-8 (1):
   family: SI
   name: Central Management
-  description: '"The organization centrally manages spam protection mechanisms."'
+  description: The organization centrally manages spam protection mechanisms.
 SI-8 (2):
   family: SI
   name: Automatic Updates
-  description: '"The information system automatically updates spam protection mechanisms."'
+  description: The information system automatically updates spam protection mechanisms.
 SI-8 (3):
   family: SI
   name: Continuous Learning Capability
-  description: '"The information system implements spam protection mechanisms with
-    a learning capability to more effectively identify legitimate communications traffic."'
+  description: The information system implements spam protection mechanisms with a
+    learning capability to more effectively identify legitimate communications traffic.
 SI-9:
   family: SI
   name: Information Input Restrictions
@@ -5673,24 +5662,24 @@ SI-10 (1):
 SI-10 (2):
   family: SI
   name: Review / Resolution Of Errors
-  description: '"The organization ensures that input validation errors are reviewed
-    and resolved within [Assignment: organization-defined time period]."'
+  description: 'The organization ensures that input validation errors are reviewed
+    and resolved within [Assignment: organization-defined time period].'
 SI-10 (3):
   family: SI
   name: Predictable Behavior
-  description: '"The information system behaves in a predictable and documented manner
-    that reflects organizational and system objectives when invalid inputs are received."'
+  description: The information system behaves in a predictable and documented manner
+    that reflects organizational and system objectives when invalid inputs are received.
 SI-10 (4):
   family: SI
   name: Review / Timing Interactions
-  description: '"The organization accounts for timing interactions among information
-    system components in determining appropriate responses for invalid inputs."'
+  description: The organization accounts for timing interactions among information
+    system components in determining appropriate responses for invalid inputs.
 SI-10 (5):
   family: SI
   name: Restrict Inputs To Trusted Sources And Approved Formats
-  description: '"The organization restricts the use of information inputs to [Assignment:
+  description: 'The organization restricts the use of information inputs to [Assignment:
     organization-defined trusted sources] and/or [Assignment: organization-defined
-    formats]."'
+    formats].'
 SI-11:
   family: SI
   name: Error Handling
@@ -5715,19 +5704,19 @@ SI-13:
 SI-13 (1):
   family: SI
   name: Transferring Component Responsibilities
-  description: '"The organization takes information system components out of service
+  description: 'The organization takes information system components out of service
     by transferring component responsibilities to substitute components no later than
-    [Assignment: organization-defined fraction or percentage] of mean time to failure."'
+    [Assignment: organization-defined fraction or percentage] of mean time to failure.'
 SI-13 (2):
   family: SI
   name: Time Limit On Process Execution Without Supervision
-  description: '"[Withdrawn: Incorporated into SI-7 (16)]."'
+  description: '[Withdrawn: Incorporated into SI-7 (16)].'
 SI-13 (3):
   family: SI
   name: Manual Transfer Between Components
-  description: '"The organization manually initiates transfers between active and
-    standby information system components [Assignment: organization-defined frequency]
-    if the mean time to failure exceeds [Assignment: organization-defined time period]."'
+  description: 'The organization manually initiates transfers between active and standby
+    information system components [Assignment: organization-defined frequency] if
+    the mean time to failure exceeds [Assignment: organization-defined time period].'
 SI-13 (4):
   family: SI
   name: Standby Component Installation / Notification
@@ -5738,8 +5727,8 @@ SI-13 (4):
 SI-13 (5):
   family: SI
   name: Failover Capability
-  description: '"The organization provides [Selection: real-time; near real-time]
-    [Assignment: organization-defined failover capability] for the information system."'
+  description: 'The organization provides [Selection: real-time; near real-time] [Assignment:
+    organization-defined failover capability] for the information system.'
 SI-14:
   family: SI
   name: Non-Persistence
@@ -5750,9 +5739,9 @@ SI-14:
 SI-14 (1):
   family: SI
   name: Refresh From Trusted Sources
-  description: '"The organization ensures that software and data employed during information
+  description: 'The organization ensures that software and data employed during information
     system component and service refreshes are obtained from [Assignment: organization-defined
-    trusted sources]."'
+    trusted sources].'
 SI-15:
   family: SI
   name: Information Output Filtering

--- a/nist-800-53-latest.yaml
+++ b/nist-800-53-latest.yaml
@@ -110,9 +110,9 @@ AC-2 (13):
 AC-3:
   family: AC
   name: Access Enforcement
-  description: '"The information system enforces approved authorizations for logical
+  description: The information system enforces approved authorizations for logical
     access to information           and system resources in accordance with applicable
-    access control policies."'
+    access control policies.
 AC-3 (1):
   family: AC
   name: Restricted Access To Privileged Functions
@@ -182,9 +182,9 @@ AC-3 (10):
 AC-4:
   family: AC
   name: Information Flow Enforcement
-  description: '"The information system enforces approved authorizations for controlling
+  description: 'The information system enforces approved authorizations for controlling
     the flow of information within the system and between interconnected systems based
-    on [Assignment: organization-defined information flow control policies]."'
+    on [Assignment: organization-defined information flow control policies].'
 AC-4 (1):
   family: AC
   name: Object Security Attributes
@@ -319,17 +319,17 @@ AC-5:
   family: AC
   name: Separation Of Duties
   description: |-
-    "The organization:
+    The organization:
       a.  Separates [Assignment: organization-defined duties of individuals];
       b.  Documents separation of duties of individuals; and
-      c.  Defines information system access authorizations to support separation of duties."
+      c.  Defines information system access authorizations to support separation of duties.
 AC-6:
   family: AC
   name: Least Privilege
-  description: '"The organization employs the principle of least privilege, allowing
+  description: The organization employs the principle of least privilege, allowing
     only authorized accesses for users (or processes acting on behalf of users) which
     are necessary to accomplish assigned tasks in accordance with organizational missions
-    and business functions."'
+    and business functions.
 AC-6 (1):
   family: AC
   name: Authorize Access To Security Functions
@@ -423,8 +423,8 @@ AC-8:
 AC-9:
   family: AC
   name: Previous Logon (Access) Notification
-  description: '"The information system notifies the user, upon successful logon (access)
-    to the system, of the date and time of the last logon (access)."'
+  description: The information system notifies the user, upon successful logon (access)
+    to the system, of the date and time of the last logon (access).
 AC-9 (1):
   family: AC
   name: Unsuccessful Logons
@@ -452,9 +452,9 @@ AC-9 (4):
 AC-10:
   family: AC
   name: Concurrent Session Control
-  description: '"The information system limits the number of concurrent sessions for
+  description: 'The information system limits the number of concurrent sessions for
     each [Assignment: organization-defined account and/or account type] to [Assignment:
-    organization-defined number]."'
+    organization-defined number].'
 AC-11:
   family: AC
   name: Session Lock
@@ -470,9 +470,9 @@ AC-11 (1):
 AC-12:
   family: AC
   name: Session Termination
-  description: '"The information system automatically terminates a user session after
+  description: 'The information system automatically terminates a user session after
     [Assignment: organization-defined conditions or trigger events requiring session
-    disconnect]."'
+    disconnect].'
 AC-12 (1):
   family: AC
   name: User-Initiated Logouts / Message Displays
@@ -483,7 +483,7 @@ AC-12 (1):
 AC-13:
   family: AC
   name: Supervision And Review - Access Control
-  description: '"[Withdrawn: Incorporated into AC-2 and AU-6]."'
+  description: '[Withdrawn: Incorporated into AC-2 and AU-6].'
 AC-14:
   family: AC
   name: Permitted Actions Without Identification Or Authentication
@@ -498,7 +498,7 @@ AC-14 (1):
 AC-15:
   family: AC
   name: Automated Marking
-  description: '"[Withdrawn: Incorporated into MP-3]."'
+  description: '[Withdrawn: Incorporated into MP-3].'
 AC-16:
   family: AC
   name: Security Attributes
@@ -751,14 +751,14 @@ AC-22:
 AC-23:
   family: AC
   name: Data Mining Protection
-  description: '"The organization employs [Assignment: organization-defined data mining
+  description: 'The organization employs [Assignment: organization-defined data mining
     prevention and detection techniques] for [Assignment: organization-defined data
-    storage objects] to adequately detect and protect against data mining."'
+    storage objects] to adequately detect and protect against data mining.'
 AC-24:
   family: AC
   name: Access Control Decisions
-  description: '"The organization establishes procedures to ensure [Assignment: organization-defined
-    access control decisions] are applied to each access request prior to access enforcement."'
+  description: 'The organization establishes procedures to ensure [Assignment: organization-defined
+    access control decisions] are applied to each access request prior to access enforcement.'
 AC-24 (1):
   family: AC
   name: Transmit Access Authorization Information
@@ -775,10 +775,10 @@ AC-24 (2):
 AC-25:
   family: AC
   name: Reference Monitor
-  description: '"The information system implements a reference monitor for [Assignment:
+  description: 'The information system implements a reference monitor for [Assignment:
     organization-defined access control policies] that is tamperproof, always invoked,
     and small enough to be subject to analysis and testing, the completeness of which
-    can be assured."'
+    can be assured.'
 AT-1:
   family: AT
   name: Security Awareness And Training Policy And Procedures
@@ -849,7 +849,7 @@ AT-4:
 AT-5:
   family: AT
   name: Contacts With Security Groups And Associations
-  description: '"[Withdrawn: Incorporated into PM-15]."'
+  description: '[Withdrawn: Incorporated into PM-15].'
 AU-1:
   family: AU
   name: Audit And Accountability Policy And Procedures
@@ -890,10 +890,10 @@ AU-2 (4):
 AU-3:
   family: AU
   name: Content Of Audit Records
-  description: '"The information system generates audit records containing information
+  description: The information system generates audit records containing information
     that establishes what type of event occurred, when the event occurred, where the
     event occurred, the source of the event, the outcome of the event, and the identity
-    of any individuals or subjects associated with the event."'
+    of any individuals or subjects associated with the event.
 AU-3 (1):
   family: AU
   name: Additional Audit Information
@@ -909,8 +909,8 @@ AU-3 (2):
 AU-4:
   family: AU
   name: Audit Storage Capacity
-  description: '"The organization allocates audit record storage capacity in accordance
-    with [Assignment: organization-defined audit record storage requirements]."'
+  description: 'The organization allocates audit record storage capacity in accordance
+    with [Assignment: organization-defined audit record storage requirements].'
 AU-4 (1):
   family: AU
   name: Transfer To Alternate Storage
@@ -1056,8 +1056,8 @@ AU-8 (2):
 AU-9:
   family: AU
   name: Protection Of Audit Information
-  description: '"The information system protects audit information and audit tools
-    from unauthorized access, modification, and deletion."'
+  description: The information system protects audit information and audit tools from
+    unauthorized access, modification, and deletion.
 AU-9 (1):
   family: AU
   name: Hardware Write-Once Media
@@ -1092,9 +1092,9 @@ AU-9 (6):
 AU-10:
   family: AU
   name: Non-Repudiation
-  description: '"The information system protects against an individual (or process
+  description: 'The information system protects against an individual (or process
     acting on behalf of an individual) falsely denying having performed [Assignment:
-    organization-defined actions to be covered by non-repudiation]."'
+    organization-defined actions to be covered by non-repudiation].'
 AU-10 (1):
   family: AU
   name: Association Of Identities
@@ -1128,10 +1128,10 @@ AU-10 (5):
 AU-11:
   family: AU
   name: Audit Record Retention
-  description: '"The organization retains audit records for [Assignment: organization-defined
+  description: 'The organization retains audit records for [Assignment: organization-defined
     time period consistent with records retention policy] to provide support for after-the-fact
     investigations of security incidents and to meet regulatory and organizational
-    information retention requirements."'
+    information retention requirements.'
 AU-11 (1):
   family: AU
   name: Long-Term Retrieval Capability
@@ -1169,9 +1169,9 @@ AU-12 (3):
 AU-13:
   family: AU
   name: Monitoring For Information Disclosure
-  description: '"The organization monitors [Assignment: organization-defined open
-    source information and/or information sites] [Assignment: organization-defined
-    frequency] for evidence of unauthorized disclosure of organizational information."'
+  description: 'The organization monitors [Assignment: organization-defined open source
+    information and/or information sites] [Assignment: organization-defined frequency]
+    for evidence of unauthorized disclosure of organizational information.'
 AU-13 (1):
   family: AU
   name: Use Of Automated Tools
@@ -1185,8 +1185,8 @@ AU-13 (2):
 AU-14:
   family: AU
   name: Session Audit
-  description: '"The information system provides the capability for authorized users
-    to select a user session to capture/record or view/hear."'
+  description: The information system provides the capability for authorized users
+    to select a user session to capture/record or view/hear.
 AU-14 (1):
   family: AU
   name: System Start-Up
@@ -1205,15 +1205,15 @@ AU-14 (3):
 AU-15:
   family: AU
   name: Alternate Audit Capability
-  description: '"The organization provides an alternate audit capability in the event
+  description: 'The organization provides an alternate audit capability in the event
     of a failure in primary audit capability that provides [Assignment: organization-defined
-    alternate audit functionality]."'
+    alternate audit functionality].'
 AU-16:
   family: AU
   name: Cross-Organizational Auditing
-  description: '"The organization employs [Assignment: organization-defined methods]
+  description: 'The organization employs [Assignment: organization-defined methods]
     for coordinating [Assignment: organization-defined audit information] among external
-    organizations when audit information is transmitted across organizational boundaries."'
+    organizations when audit information is transmitted across organizational boundaries.'
 AU-16 (1):
   family: AU
   name: Identity Preservation
@@ -1309,7 +1309,7 @@ CA-3 (5):
 CA-4:
   family: CA
   name: Security Certification
-  description: '"[Withdrawn: Incorporated into CA-2]."'
+  description: '[Withdrawn: Incorporated into CA-2].'
 CA-5:
   family: CA
   name: Plan Of Action And Milestones
@@ -1363,9 +1363,9 @@ CA-7 (3):
 CA-8:
   family: CA
   name: Penetration Testing
-  description: '"The organization conducts penetration testing [Assignment: organization-defined
+  description: 'The organization conducts penetration testing [Assignment: organization-defined
     frequency] on [Assignment: organization-defined information systems or system
-    components]."'
+    components].'
 CA-8 (1):
   family: CA
   name: Independent Penetration Agent Or Team
@@ -1403,8 +1403,8 @@ CM-1:
 CM-2:
   family: CM
   name: Baseline Configuration
-  description: '"The organization develops, documents, and maintains under configuration
-    control, a current baseline configuration of the information system."'
+  description: The organization develops, documents, and maintains under configuration
+    control, a current baseline configuration of the information system.
 CM-2 (1):
   family: CM
   name: Reviews And Updates
@@ -1500,8 +1500,8 @@ CM-3 (6):
 CM-4:
   family: CM
   name: Security Impact Analysis
-  description: '"The organization analyzes changes to the information system to determine
-    potential security impacts prior to change implementation."'
+  description: The organization analyzes changes to the information system to determine
+    potential security impacts prior to change implementation.
 CM-4 (1):
   family: CM
   name: Separate Test Environments
@@ -1519,8 +1519,8 @@ CM-4 (2):
 CM-5:
   family: CM
   name: Access Restrictions For Change
-  description: '"The organization defines, documents, approves, and enforces physical
-    and logical access restrictions associated with changes to the information system."'
+  description: The organization defines, documents, approves, and enforces physical
+    and logical access restrictions associated with changes to the information system.
 CM-5 (1):
   family: CM
   name: Automated Access Enforcement / Auditing
@@ -1870,7 +1870,7 @@ CP-4 (4):
 CP-5:
   family: CP
   name: Contingency Plan Update
-  description: '"[Withdrawn: Incorporated into CP-2]."'
+  description: '[Withdrawn: Incorporated into CP-2].'
 CP-6:
   family: CP
   name: Alternate Storage Site
@@ -1937,12 +1937,12 @@ CP-7 (6):
 CP-8:
   family: CP
   name: Telecommunications Services
-  description: '"The organization establishes alternate telecommunications services
+  description: 'The organization establishes alternate telecommunications services
     including necessary agreements to permit the resumption of [Assignment: organization-defined
     information system operations] for essential missions and business functions within
     [Assignment: organization-defined time period] when the primary telecommunications
     capabilities are unavailable at either the primary or alternate processing or
-    storage sites."'
+    storage sites.'
 CP-8 (1):
   family: CP
   name: Priority Of Service Provisions
@@ -2025,8 +2025,8 @@ CP-9 (7):
 CP-10:
   family: CP
   name: Information System Recovery And Reconstitution
-  description: '"The organization provides for the recovery and reconstitution of
-    the information system to a known state after a disruption, compromise, or failure."'
+  description: The organization provides for the recovery and reconstitution of the
+    information system to a known state after a disruption, compromise, or failure.
 CP-10 (1):
   family: CP
   name: Contingency Plan Testing
@@ -2059,22 +2059,22 @@ CP-10 (6):
 CP-11:
   family: CP
   name: Alternate Communications Protocols
-  description: '"The information system provides the capability to employ [Assignment:
+  description: 'The information system provides the capability to employ [Assignment:
     organization-defined alternative communications protocols] in support of maintaining
-    continuity of operations."'
+    continuity of operations.'
 CP-12:
   family: CP
   name: Safe Mode
-  description: '"The information system, when [Assignment: organization-defined conditions]
+  description: 'The information system, when [Assignment: organization-defined conditions]
     are detected, enters a safe mode of operation with [Assignment: organization-defined
-    restrictions of safe mode of operation]."'
+    restrictions of safe mode of operation].'
 CP-13:
   family: CP
   name: Alternative Security Mechanisms
-  description: '"The organization employs [Assignment: organization-defined alternative
+  description: 'The organization employs [Assignment: organization-defined alternative
     or supplemental security mechanisms] for satisfying [Assignment: organization-defined
     security functions] when the primary means of implementing the security function
-    is unavailable or compromised."'
+    is unavailable or compromised.'
 IA-1:
   family: IA
   name: Identification And Authentication Policy And Procedures
@@ -2089,8 +2089,8 @@ IA-1:
 IA-2:
   family: IA
   name: Identification And Authentication (Organizational Users)
-  description: '"The information system uniquely identifies and authenticates organizational
-    users (or processes acting on behalf of organizational users)."'
+  description: The information system uniquely identifies and authenticates organizational
+    users (or processes acting on behalf of organizational users).
 IA-2 (1):
   family: IA
   name: Network Access To Privileged Accounts
@@ -2165,9 +2165,9 @@ IA-2 (13):
 IA-3:
   family: IA
   name: Device Identification And Authentication
-  description: '"The information system uniquely identifies and authenticates [Assignment:
+  description: 'The information system uniquely identifies and authenticates [Assignment:
     organization-defined specific and/or types of devices] before establishing a [Selection
-    (one or more): local; remote; network] connection."'
+    (one or more): local; remote; network] connection.'
 IA-3 (1):
   family: IA
   name: Cryptographic Bidirectional Authentication
@@ -2347,21 +2347,21 @@ IA-5 (15):
 IA-6:
   family: IA
   name: Authenticator Feedback
-  description: '"The information system obscures feedback of authentication information
+  description: The information system obscures feedback of authentication information
     during the authentication process to protect the information from possible exploitation/use
-    by unauthorized individuals."'
+    by unauthorized individuals.
 IA-7:
   family: IA
   name: Cryptographic Module Authentication
-  description: '"The information system implements mechanisms for authentication to
+  description: The information system implements mechanisms for authentication to
     a cryptographic module that meet the requirements of applicable federal laws,
     Executive Orders, directives, policies, regulations, standards, and guidance for
-    such authentication."'
+    such authentication.
 IA-8:
   family: IA
   name: Identification And Authentication (Non-Organizational Users)
-  description: '"The information system uniquely identifies and authenticates non-organizational
-    users (or processes acting on behalf of non-organizational users)."'
+  description: The information system uniquely identifies and authenticates non-organizational
+    users (or processes acting on behalf of non-organizational users).
 IA-8 (1):
   family: IA
   name: Acceptance Of Piv Credentials From Other Agencies
@@ -2389,9 +2389,9 @@ IA-8 (5):
 IA-9:
   family: IA
   name: Service Identification And Authentication
-  description: '"The organization identifies and authenticates [Assignment: organization-defined
+  description: 'The organization identifies and authenticates [Assignment: organization-defined
     information system services] using [Assignment: organization-defined security
-    safeguards]."'
+    safeguards].'
 IA-9 (1):
   family: IA
   name: Information Exchange
@@ -2406,15 +2406,15 @@ IA-9 (2):
 IA-10:
   family: IA
   name: Adaptive Identification And Authentication
-  description: '"The organization requires that individuals accessing the information
+  description: 'The organization requires that individuals accessing the information
     system employ [Assignment: organization-defined supplemental authentication techniques
     or mechanisms] under specific [Assignment: organization-defined circumstances
-    or situations]."'
+    or situations].'
 IA-11:
   family: IA
   name: Re-Authentication
-  description: '"The organization requires users and devices to re-authenticate when
-    [Assignment: organization-defined circumstances or situations requiring re-authentication]."'
+  description: 'The organization requires users and devices to re-authenticate when
+    [Assignment: organization-defined circumstances or situations requiring re-authentication].'
 IR-1:
   family: IR
   name: Incident Response Policy And Procedures
@@ -2447,9 +2447,9 @@ IR-2 (2):
 IR-3:
   family: IR
   name: Incident Response Testing
-  description: '"The organization tests the incident response capability for the information
+  description: 'The organization tests the incident response capability for the information
     system [Assignment: organization-defined frequency] using [Assignment: organization-defined
-    tests] to determine the incident response effectiveness and documents the results."'
+    tests] to determine the incident response effectiveness and documents the results.'
 IR-3 (1):
   family: IR
   name: Automated Testing
@@ -2529,8 +2529,7 @@ IR-4 (10):
 IR-5:
   family: IR
   name: Incident Monitoring
-  description: '"The organization tracks and documents information system security
-    incidents."'
+  description: The organization tracks and documents information system security incidents.
 IR-5 (1):
   family: IR
   name: Automated Tracking / Data Collection / Analysis
@@ -2563,10 +2562,10 @@ IR-6 (3):
 IR-7:
   family: IR
   name: Incident Response Assistance
-  description: '"The organization provides an incident response support resource,
-    integral to the organizational incident response capability that offers advice
-    and assistance to users of the information system for the handling and reporting
-    of security incidents."'
+  description: The organization provides an incident response support resource, integral
+    to the organizational incident response capability that offers advice and assistance
+    to users of the information system for the handling and reporting of security
+    incidents.
 IR-7 (1):
   family: IR
   name: Automation Support For Availability Of Information / Support
@@ -2634,8 +2633,8 @@ IR-9 (4):
 IR-10:
   family: IR
   name: Integrated Information Security Analysis Team
-  description: '"The organization establishes an integrated team of forensic/malicious
-    code analysts, tool developers, and real-time operations personnel."'
+  description: The organization establishes an integrated team of forensic/malicious
+    code analysts, tool developers, and real-time operations personnel.
 MA-1:
   family: MA
   name: System Maintenance Policy And Procedures
@@ -2672,8 +2671,8 @@ MA-2 (2):
 MA-3:
   family: MA
   name: Maintenance Tools
-  description: '"The organization approves, controls, and monitors information system
-    maintenance tools."'
+  description: The organization approves, controls, and monitors information system
+    maintenance tools.
 MA-3 (1):
   family: MA
   name: Inspect Tools
@@ -2801,9 +2800,9 @@ MA-5 (5):
 MA-6:
   family: MA
   name: Timely Maintenance
-  description: '"The organization obtains maintenance support and/or spare parts for
+  description: 'The organization obtains maintenance support and/or spare parts for
     [Assignment: organization-defined information system components] within [Assignment:
-    organization-defined time period] of failure."'
+    organization-defined time period] of failure.'
 MA-6 (1):
   family: MA
   name: Preventive Maintenance
@@ -2833,9 +2832,9 @@ MP-1:
 MP-2:
   family: MP
   name: Media Access
-  description: '"The organization restricts access to [Assignment: organization-defined
+  description: 'The organization restricts access to [Assignment: organization-defined
     types of digital and/or non-digital media] to [Assignment: organization-defined
-    personnel or roles]."'
+    personnel or roles].'
 MP-2 (1):
   family: MP
   name: Automated Restricted Access
@@ -2947,10 +2946,10 @@ MP-6 (8):
 MP-7:
   family: MP
   name: Media Use
-  description: '"The organization [Selection: restricts; prohibits] the use of [Assignment:
+  description: 'The organization [Selection: restricts; prohibits] the use of [Assignment:
     organization-defined types of information system media] on [Assignment: organization-defined
     information systems or system components] using [Assignment: organization-defined
-    security safeguards]."'
+    security safeguards].'
 MP-7 (1):
   family: MP
   name: Prohibit Use Without Owner
@@ -3087,14 +3086,14 @@ PE-3 (6):
 PE-4:
   family: PE
   name: Access Control For Transmission Medium
-  description: '"The organization controls physical access to [Assignment: organization-defined
+  description: 'The organization controls physical access to [Assignment: organization-defined
     information system distribution and transmission lines] within organizational
-    facilities using [Assignment: organization-defined security safeguards]."'
+    facilities using [Assignment: organization-defined security safeguards].'
 PE-5:
   family: PE
   name: Access Control For Output Devices
-  description: '"The organization controls physical access to information system output
-    devices to prevent unauthorized individuals from obtaining the output."'
+  description: The organization controls physical access to information system output
+    devices to prevent unauthorized individuals from obtaining the output.
 PE-5 (1):
   family: PE
   name: Access To Output By Authorized Individuals
@@ -3150,7 +3149,7 @@ PE-6 (4):
 PE-7:
   family: PE
   name: Visitor Control
-  description: '"[Withdrawn: Incorporated into PE-2 and PE-3]."'
+  description: '[Withdrawn: Incorporated into PE-2 and PE-3].'
 PE-8:
   family: PE
   name: Visitor Access Records
@@ -3170,8 +3169,8 @@ PE-8 (2):
 PE-9:
   family: PE
   name: Power Equipment And Cabling
-  description: '"The organization protects power equipment and power cabling for the
-    information system from damage and destruction."'
+  description: The organization protects power equipment and power cabling for the
+    information system from damage and destruction.
 PE-9 (1):
   family: PE
   name: Redundant Cabling
@@ -3197,10 +3196,10 @@ PE-10 (1):
 PE-11:
   family: PE
   name: Emergency Power
-  description: '"The organization provides a short-term uninterruptible power supply
+  description: 'The organization provides a short-term uninterruptible power supply
     to facilitate [Selection (one or more): an orderly shutdown of the information
     system; transition of the information system to long-term alternate power] in
-    the event of a primary power source loss."'
+    the event of a primary power source loss.'
 PE-11 (1):
   family: PE
   name: Long-Term Alternate Power Supply - Minimal Operational Capability
@@ -3218,9 +3217,9 @@ PE-11 (2):
 PE-12:
   family: PE
   name: Emergency Lighting
-  description: '"The organization employs and maintains automatic emergency lighting
+  description: The organization employs and maintains automatic emergency lighting
     for the information system that activates in the event of a power outage or disruption
-    and that covers emergency exits and evacuation routes within the facility."'
+    and that covers emergency exits and evacuation routes within the facility.
 PE-12 (1):
   family: PE
   name: Essential Missions / Business Functions
@@ -3229,9 +3228,9 @@ PE-12 (1):
 PE-13:
   family: PE
   name: Fire Protection
-  description: '"The organization employs and maintains fire suppression and detection
+  description: The organization employs and maintains fire suppression and detection
     devices/systems for the information system that are supported by an independent
-    energy source."'
+    energy source.
 PE-13 (1):
   family: PE
   name: Detection Devices / Systems
@@ -3279,9 +3278,9 @@ PE-14 (2):
 PE-15:
   family: PE
   name: Water Damage Protection
-  description: '"The organization protects the information system from damage resulting
+  description: The organization protects the information system from damage resulting
     from water leakage by providing master shutoff or isolation valves that are accessible,
-    working properly, and known to key personnel."'
+    working properly, and known to key personnel.
 PE-15 (1):
   family: PE
   name: Automation Support
@@ -3291,9 +3290,9 @@ PE-15 (1):
 PE-16:
   family: PE
   name: Delivery And Removal
-  description: '"The organization authorizes, monitors, and controls [Assignment:
-    organization-defined types of information system components] entering and exiting
-    the facility and maintains records of those items."'
+  description: 'The organization authorizes, monitors, and controls [Assignment: organization-defined
+    types of information system components] entering and exiting the facility and
+    maintains records of those items.'
 PE-17:
   family: PE
   name: Alternate Work Site
@@ -3305,9 +3304,9 @@ PE-17:
 PE-18:
   family: PE
   name: Location Of Information System Components
-  description: '"The organization positions information system components within the
+  description: 'The organization positions information system components within the
     facility to minimize potential damage from [Assignment: organization-defined physical
-    and environmental hazards] and to minimize the opportunity for unauthorized access."'
+    and environmental hazards] and to minimize the opportunity for unauthorized access.'
 PE-18 (1):
   family: PE
   name: Facility Site
@@ -3318,8 +3317,8 @@ PE-18 (1):
 PE-19:
   family: PE
   name: Information Leakage
-  description: '"The organization protects the information system from information
-    leakage due to electromagnetic signals emanations."'
+  description: The organization protects the information system from information leakage
+    due to electromagnetic signals emanations.
 PE-19 (1):
   family: PE
   name: National Emissions / Tempest Policies And Procedures
@@ -3382,7 +3381,7 @@ PL-2 (3):
 PL-3:
   family: PL
   name: System Security Plan Update
-  description: '"[Withdrawn: Incorporated into PL-2]."'
+  description: '[Withdrawn: Incorporated into PL-2].'
 PL-4:
   family: PL
   name: Rules Of Behavior
@@ -3401,11 +3400,11 @@ PL-4 (1):
 PL-5:
   family: PL
   name: Privacy Impact Assessment
-  description: '"[Withdrawn: Incorporated into Appendix J, AR-2]."'
+  description: '[Withdrawn: Incorporated into Appendix J, AR-2].'
 PL-6:
   family: PL
   name: Security-Related Activity Planning
-  description: '"[Withdrawn: Incorporated into PL-2]."'
+  description: '[Withdrawn: Incorporated into PL-2].'
 PL-7:
   family: PL
   name: Security Concept Of Operations
@@ -3440,8 +3439,8 @@ PL-8 (2):
 PL-9:
   family: PL
   name: Central Management
-  description: '"The organization centrally manages [Assignment: organization-defined
-    security controls and related processes]."'
+  description: 'The organization centrally manages [Assignment: organization-defined
+    security controls and related processes].'
 PM-1:
   family: PM
   name: Information Security Program Plan
@@ -3458,9 +3457,9 @@ PM-1:
 PM-2:
   family: PM
   name: Senior Information Security Officer
-  description: '"The organization appoints a senior information security officer with
+  description: The organization appoints a senior information security officer with
     the mission and resources to coordinate, develop, implement, and maintain an organization-wide
-    information security program."'
+    information security program.
 PM-3:
   family: PM
   name: Information Security Resources
@@ -3482,25 +3481,25 @@ PM-4:
 PM-5:
   family: PM
   name: Information System Inventory
-  description: '"The organization develops and maintains an inventory of its information
-    systems."'
+  description: The organization develops and maintains an inventory of its information
+    systems.
 PM-6:
   family: PM
   name: Information Security Measures Of Performance
-  description: '"The organization develops, monitors, and reports on the results of
-    information security measures of performance."'
+  description: The organization develops, monitors, and reports on the results of
+    information security measures of performance.
 PM-7:
   family: PM
   name: Enterprise Architecture
-  description: '"The organization develops an enterprise architecture with consideration
+  description: The organization develops an enterprise architecture with consideration
     for information security and the resulting risk to organizational operations,
-    organizational assets, individuals, other organizations, and the Nation."'
+    organizational assets, individuals, other organizations, and the Nation.
 PM-8:
   family: PM
   name: Critical Infrastructure Plan
-  description: '"The organization addresses information security issues in the development,
+  description: The organization addresses information security issues in the development,
     documentation, and updating of a critical infrastructure and key resources protection
-    plan."'
+    plan.
 PM-9:
   family: PM
   name: Risk Management Strategy
@@ -3527,13 +3526,13 @@ PM-11:
 PM-12:
   family: PM
   name: Insider Threat Program
-  description: '"The organization implements an insider threat program that includes
-    a cross-discipline insider threat incident handling team."'
+  description: The organization implements an insider threat program that includes
+    a cross-discipline insider threat incident handling team.
 PM-13:
   family: PM
   name: Information Security Workforce
-  description: '"The organization establishes an information security workforce development
-    and improvement program."'
+  description: The organization establishes an information security workforce development
+    and improvement program.
 PM-14:
   family: PM
   name: Testing, Training, And Monitoring
@@ -3554,8 +3553,8 @@ PM-15:
 PM-16:
   family: PM
   name: Threat Awareness Program
-  description: '"The organization implements a threat awareness program that includes
-    a cross-organization information-sharing capability."'
+  description: The organization implements a threat awareness program that includes
+    a cross-organization information-sharing capability.
 PS-1:
   family: PS
   name: Personnel Security Policy And Procedures
@@ -3713,7 +3712,7 @@ RA-3:
 RA-4:
   family: RA
   name: Risk Assessment Update
-  description: '"[Withdrawn: Incorporated into RA-3]."'
+  description: '[Withdrawn: Incorporated into RA-3].'
 RA-5:
   family: RA
   name: Vulnerability Scanning
@@ -3783,10 +3782,10 @@ RA-5 (10):
 RA-6:
   family: RA
   name: Technical Surveillance Countermeasures Survey
-  description: '"The organization employs a technical surveillance countermeasures
+  description: 'The organization employs a technical surveillance countermeasures
     survey at [Assignment: organization-defined locations] [Selection (one or more):
     [Assignment: organization-defined frequency]; [Assignment: organization-defined
-    events or indicators occur]]."'
+    events or indicators occur]].'
 SA-1:
   family: SA
   name: System And Services Acquisition Policy And Procedures
@@ -3935,17 +3934,17 @@ SA-5 (5):
 SA-6:
   family: SA
   name: Software Usage Restrictions
-  description: '"[Withdrawn: Incorporated into CM-10 and SI-7]."'
+  description: '[Withdrawn: Incorporated into CM-10 and SI-7].'
 SA-7:
   family: SA
   name: User-Installed Software
-  description: '"[Withdrawn: Incorporated into CM-11 and SI-7]."'
+  description: '[Withdrawn: Incorporated into CM-11 and SI-7].'
 SA-8:
   family: SA
   name: Security Engineering Principles
-  description: '"The organization applies information system security engineering
-    principles in the specification, design, development, implementation, and modification
-    of the information system."'
+  description: The organization applies information system security engineering principles
+    in the specification, design, development, implementation, and modification of
+    the information system.
 SA-9:
   family: SA
   name: External Information System Services
@@ -3999,43 +3998,43 @@ SA-10:
 SA-10 (1):
   family: SA
   name: Software / Firmware Integrity Verification
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to enable integrity verification
-    of software and firmware components."'
+    of software and firmware components.
 SA-10 (2):
   family: SA
   name: Alternative Configuration Management Processes
-  description: '"The organization provides an alternate configuration management process
+  description: The organization provides an alternate configuration management process
     using organizational personnel in the absence of a dedicated developer configuration
-    management team."'
+    management team.
 SA-10 (3):
   family: SA
   name: Hardware Integrity Verification
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to enable integrity verification
-    of hardware components."'
+    of hardware components.
 SA-10 (4):
   family: SA
   name: Trusted Generation
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to employ tools for comparing
     newly generated versions of security-relevant hardware descriptions and software/firmware
-    source and object code with previous versions."'
+    source and object code with previous versions.
 SA-10 (5):
   family: SA
   name: Mapping Integrity For Version Control
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to maintain the integrity of the
     mapping between the  master build data (hardware drawings and software/firmware
     code) describing the current version of security-relevant hardware, software,
-    and firmware and the on-site master copy of the data for the current version."'
+    and firmware and the on-site master copy of the data for the current version.
 SA-10 (6):
   family: SA
   name: Trusted Distribution
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to execute procedures for ensuring
     that security-relevant hardware, software, and firmware updates distributed to
-    the organization are exactly as specified by the master copies."'
+    the organization are exactly as specified by the master copies.
 SA-11:
   family: SA
   name: Developer Security Testing And Evaluation
@@ -4101,10 +4100,10 @@ SA-11 (8):
 SA-12:
   family: SA
   name: Supply Chain Protection
-  description: '"The organization protects against supply chain threats to the information
+  description: 'The organization protects against supply chain threats to the information
     system, system component, or information system service by employing [Assignment:
     organization-defined security safeguards] as part of a comprehensive, defense-in-breadth
-    information security strategy."'
+    information security strategy.'
 SA-12 (1):
   family: SA
   name: Acquisition Strategies / Tools / Methods
@@ -4203,11 +4202,11 @@ SA-13:
 SA-14:
   family: SA
   name: Criticality Analysis
-  description: '"The organization identifies critical information system components
+  description: 'The organization identifies critical information system components
     and functions by performing a criticality analysis for [Assignment: organization-defined
     information systems, information system components, or information system services]
     at [Assignment: organization-defined decision points in the system development
-    life cycle]."'
+    life cycle].'
 SA-14 (1):
   family: SA
   name: Critical Components With  No Viable Alternative Sourcing
@@ -4300,10 +4299,10 @@ SA-15 (11):
 SA-16:
   family: SA
   name: Developer-Provided Training
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to provide [Assignment: organization-defined
     training] on the correct use and operation of the implemented security functions,
-    controls, and/or mechanisms."'
+    controls, and/or mechanisms.'
 SA-17:
   family: SA
   name: Developer Security Architecture And Design
@@ -4368,8 +4367,8 @@ SA-17 (7):
 SA-18:
   family: SA
   name: Tamper Resistance And Detection
-  description: '"The organization implements a tamper protection program for the information
-    system, system component, or information system service."'
+  description: The organization implements a tamper protection program for the information
+    system, system component, or information system service.
 SA-18 (1):
   family: SA
   name: Multiple Phases Of Sdlc
@@ -4415,8 +4414,8 @@ SA-19 (4):
 SA-20:
   family: SA
   name: Customized Development Of Critical Components
-  description: '"The organization re-implements or custom develops [Assignment: organization-defined
-    critical information system components]."'
+  description: 'The organization re-implements or custom develops [Assignment: organization-defined
+    critical information system components].'
 SA-21:
   family: SA
   name: Developer Screening
@@ -4458,8 +4457,8 @@ SC-1:
 SC-2:
   family: SC
   name: Application Partitioning
-  description: '"The information system separates user functionality (including user
-    interface services) from information system management functionality."'
+  description: The information system separates user functionality (including user
+    interface services) from information system management functionality.
 SC-2 (1):
   family: SC
   name: Interfaces For Non-Privileged Users
@@ -4468,8 +4467,8 @@ SC-2 (1):
 SC-3:
   family: SC
   name: Security Function Isolation
-  description: '"The information system isolates security functions from nonsecurity
-    functions."'
+  description: The information system isolates security functions from nonsecurity
+    functions.
 SC-3 (1):
   family: SC
   name: Hardware Separation
@@ -4501,8 +4500,8 @@ SC-3 (5):
 SC-4:
   family: SC
   name: Information In Shared Resources
-  description: '"The information system prevents unauthorized and unintended information
-    transfer via shared system resources."'
+  description: The information system prevents unauthorized and unintended information
+    transfer via shared system resources.
 SC-4 (1):
   family: SC
   name: Security Levels
@@ -4517,10 +4516,10 @@ SC-4 (2):
 SC-5:
   family: SC
   name: Denial Of Service Protection
-  description: '"The information system protects against or limits the effects of
-    the following types of denial of service attacks: [Assignment: organization-defined
+  description: 'The information system protects against or limits the effects of the
+    following types of denial of service attacks: [Assignment: organization-defined
     types of denial of service attacks or references to sources for such information]
-    by employing [Assignment: organization-defined security safeguards]."'
+    by employing [Assignment: organization-defined security safeguards].'
 SC-5 (1):
   family: SC
   name: Restrict Internal Users
@@ -4542,9 +4541,9 @@ SC-5 (3):
 SC-6:
   family: SC
   name: Resource Availability
-  description: '"The information system protects the availability of resources by
-    allocating [Assignment: organization-defined resources] by [Selection (one or
-    more); priority; quota; [Assignment: organization-defined security safeguards]]."'
+  description: 'The information system protects the availability of resources by allocating
+    [Assignment: organization-defined resources] by [Selection (one or more); priority;
+    quota; [Assignment: organization-defined security safeguards]].'
 SC-7:
   family: SC
   name: Boundary Protection
@@ -4684,8 +4683,8 @@ SC-7 (23):
 SC-8:
   family: SC
   name: Transmission Confidentiality And Integrity
-  description: '"The information system protects the [Selection (one or more): confidentiality;
-    integrity] of transmitted information."'
+  description: 'The information system protects the [Selection (one or more): confidentiality;
+    integrity] of transmitted information.'
 SC-8 (1):
   family: SC
   name: Cryptographic Or Alternate Physical Protection
@@ -4713,20 +4712,20 @@ SC-8 (4):
 SC-9:
   family: SC
   name: Transmission Confidentiality
-  description: '"[Withdrawn: Incorporated into SC-8]."'
+  description: '[Withdrawn: Incorporated into SC-8].'
 SC-10:
   family: SC
   name: Network Disconnect
-  description: '"The information system terminates the network connection associated
+  description: 'The information system terminates the network connection associated
     with a communications session at the end of the session or after [Assignment:
-    organization-defined time period] of inactivity."'
+    organization-defined time period] of inactivity.'
 SC-11:
   family: SC
   name: Trusted Path
-  description: '"The information system establishes a trusted communications path
-    between the user and the following security functions of the system: [Assignment:
-    organization-defined security functions to include at a minimum, information system
-    authentication and re-authentication]."'
+  description: 'The information system establishes a trusted communications path between
+    the user and the following security functions of the system: [Assignment: organization-defined
+    security functions to include at a minimum, information system authentication
+    and re-authentication].'
 SC-11 (1):
   family: SC
   name: Logical Isolation
@@ -4735,10 +4734,10 @@ SC-11 (1):
 SC-12:
   family: SC
   name: Cryptographic Key Establishment And Management
-  description: '"The organization establishes and manages cryptographic keys for required
+  description: 'The organization establishes and manages cryptographic keys for required
     cryptography employed within the information system in accordance with [Assignment:
     organization-defined requirements for key generation, distribution, storage, access,
-    and destruction]."'
+    and destruction].'
 SC-12 (1):
   family: SC
   name: Availability
@@ -4769,10 +4768,10 @@ SC-12 (5):
 SC-13:
   family: SC
   name: Cryptographic Protection
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     cryptographic uses and type of cryptography required for each use] in accordance
     with applicable federal laws, Executive Orders, directives, policies, regulations,
-    and standards."'
+    and standards.'
 SC-13 (1):
   family: SC
   name: Fips-Validated Cryptography
@@ -4792,8 +4791,8 @@ SC-13 (4):
 SC-14:
   family: SC
   name: Public Access Protections
-  description: '"[Withdrawn: Capability provided by AC-2, AC-3, AC-5, AC-6, SI-3,
-    SI-4, SI-5, SI-7, SI-10]."'
+  description: '[Withdrawn: Capability provided by AC-2, AC-3, AC-5, AC-6, SI-3, SI-4,
+    SI-5, SI-7, SI-10].'
 SC-15:
   family: SC
   name: Collaborative Computing Devices
@@ -4824,9 +4823,9 @@ SC-15 (4):
 SC-16:
   family: SC
   name: Transmission Of Security Attributes
-  description: '"The information system associates [Assignment: organization-defined
+  description: 'The information system associates [Assignment: organization-defined
     security attributes] with information exchanged between information systems and
-    between system components."'
+    between system components.'
 SC-16 (1):
   family: SC
   name: Integrity Validation
@@ -4835,9 +4834,9 @@ SC-16 (1):
 SC-17:
   family: SC
   name: Public Key Infrastructure Certificates
-  description: '"The organization issues public key certificates under an [Assignment:
+  description: 'The organization issues public key certificates under an [Assignment:
     organization-defined certificate policy] or obtains public key certificates from
-    an approved service provider."'
+    an approved service provider.'
 SC-18:
   family: SC
   name: Mobile Code
@@ -4900,9 +4899,9 @@ SC-20 (2):
 SC-21:
   family: SC
   name: Secure Name / Address Resolution Service (Recursive Or Caching Resolver)
-  description: '"The information system requests and performs data origin authentication
+  description: The information system requests and performs data origin authentication
     and data integrity verification on the name/address resolution responses the system
-    receives from authoritative sources."'
+    receives from authoritative sources.
 SC-21 (1):
   family: SC
   name: Data Origin / Integrity
@@ -4910,14 +4909,14 @@ SC-21 (1):
 SC-22:
   family: SC
   name: Architecture And Provisioning For Name / Address Resolution Service
-  description: '"The information systems that collectively provide name/address resolution
+  description: The information systems that collectively provide name/address resolution
     service for an organization are fault-tolerant and implement internal/external
-    role separation."'
+    role separation.
 SC-23:
   family: SC
   name: Session Authenticity
-  description: '"The information system protects the authenticity of communications
-    sessions."'
+  description: The information system protects the authenticity of communications
+    sessions.
 SC-23 (1):
   family: SC
   name: Invalidate Session Identifiers At Logout
@@ -4945,20 +4944,20 @@ SC-23 (5):
 SC-24:
   family: SC
   name: Fail In Known State
-  description: '"The information system fails to a [Assignment: organization-defined
+  description: 'The information system fails to a [Assignment: organization-defined
     known-state] for [Assignment: organization-defined types of failures] preserving
-    [Assignment: organization-defined system state information] in failure."'
+    [Assignment: organization-defined system state information] in failure.'
 SC-25:
   family: SC
   name: Thin Nodes
-  description: '"The organization employs [Assignment: organization-defined information
-    system components] with minimal functionality and information storage."'
+  description: 'The organization employs [Assignment: organization-defined information
+    system components] with minimal functionality and information storage.'
 SC-26:
   family: SC
   name: Honeypots
-  description: '"The information system includes components specifically designed
-    to be the target of malicious attacks for the purpose of detecting, deflecting,
-    and analyzing such attacks."'
+  description: The information system includes components specifically designed to
+    be the target of malicious attacks for the purpose of detecting, deflecting, and
+    analyzing such attacks.
 SC-26 (1):
   family: SC
   name: Detection Of Malicious Code
@@ -4966,13 +4965,13 @@ SC-26 (1):
 SC-27:
   family: SC
   name: Platform-Independent Applications
-  description: '"The information system includes: [Assignment: organization-defined
-    platform-independent applications]."'
+  description: 'The information system includes: [Assignment: organization-defined
+    platform-independent applications].'
 SC-28:
   family: SC
   name: Protection Of Information At Rest
-  description: '"The information system protects the [Selection (one or more): confidentiality;
-    integrity] of [Assignment: organization-defined information at rest]."'
+  description: 'The information system protects the [Selection (one or more): confidentiality;
+    integrity] of [Assignment: organization-defined information at rest].'
 SC-28 (1):
   family: SC
   name: Cryptographic Protection
@@ -4987,9 +4986,9 @@ SC-28 (2):
 SC-29:
   family: SC
   name: Heterogeneity
-  description: '"The organization employs a diverse set of information technologies
+  description: 'The organization employs a diverse set of information technologies
     for [Assignment: organization-defined information system components] in the implementation
-    of the information system."'
+    of the information system.'
 SC-29 (1):
   family: SC
   name: Virtualization Techniques
@@ -4999,10 +4998,10 @@ SC-29 (1):
 SC-30:
   family: SC
   name: Concealment And Misdirection
-  description: '"The organization employs [Assignment: organization-defined concealment
+  description: 'The organization employs [Assignment: organization-defined concealment
     and misdirection techniques] for [Assignment: organization-defined information
     systems] at [Assignment: organization-defined time periods] to confuse and mislead
-    adversaries."'
+    adversaries.'
 SC-30 (1):
   family: SC
   name: Virtualization Techniques
@@ -5056,14 +5055,14 @@ SC-31 (3):
 SC-32:
   family: SC
   name: Information System Partitioning
-  description: '"The organization partitions the information system into [Assignment:
+  description: 'The organization partitions the information system into [Assignment:
     organization-defined information system components] residing in separate physical
     domains or environments based on [Assignment: organization-defined circumstances
-    for physical separation of components]."'
+    for physical separation of components].'
 SC-33:
   family: SC
   name: Transmission Preparation Integrity
-  description: '"[Withdrawn: Incorporated into SC-8]."'
+  description: '[Withdrawn: Incorporated into SC-8].'
 SC-34:
   family: SC
   name: Non-Modifiable Executable Programs
@@ -5093,13 +5092,13 @@ SC-34 (3):
 SC-35:
   family: SC
   name: Honeyclients
-  description: '"The information system includes components that proactively seek
-    to identify malicious websites and/or web-based malicious code."'
+  description: The information system includes components that proactively seek to
+    identify malicious websites and/or web-based malicious code.
 SC-36:
   family: SC
   name: Distributed Processing And Storage
-  description: '"The organization distributes [Assignment: organization-defined processing
-    and storage] across multiple physical locations."'
+  description: 'The organization distributes [Assignment: organization-defined processing
+    and storage] across multiple physical locations.'
 SC-36 (1):
   family: SC
   name: Polling Techniques
@@ -5109,10 +5108,10 @@ SC-36 (1):
 SC-37:
   family: SC
   name: Out-Of-Band Channels
-  description: '"The organization employs [Assignment: organization-defined out-of-band
+  description: 'The organization employs [Assignment: organization-defined out-of-band
     channels] for the physical delivery or electronic transmission of [Assignment:
     organization-defined information, information system components, or devices] to
-    [Assignment: organization-defined individuals or information systems]."'
+    [Assignment: organization-defined individuals or information systems].'
 SC-37 (1):
   family: SC
   name: Ensure Delivery / Transmission
@@ -5123,14 +5122,14 @@ SC-37 (1):
 SC-38:
   family: SC
   name: Operations Security
-  description: '"The organization employs [Assignment: organization-defined operations
+  description: 'The organization employs [Assignment: organization-defined operations
     security safeguards] to protect key organizational information throughout the
-    system development life cycle."'
+    system development life cycle.'
 SC-39:
   family: SC
   name: Process Isolation
-  description: '"The information system maintains a separate execution domain for
-    each executing process."'
+  description: The information system maintains a separate execution domain for each
+    executing process.
 SC-39 (1):
   family: SC
   name: Hardware Separation
@@ -5144,9 +5143,9 @@ SC-39 (2):
 SC-40:
   family: SC
   name: Wireless Link Protection
-  description: '"The information system protects external and internal [Assignment:
+  description: 'The information system protects external and internal [Assignment:
     organization-defined wireless links] from [Assignment: organization-defined types
-    of signal parameter attacks or references to sources for such attacks]."'
+    of signal parameter attacks or references to sources for such attacks].'
 SC-40 (1):
   family: SC
   name: Electromagnetic Interference
@@ -5174,9 +5173,9 @@ SC-40 (4):
 SC-41:
   family: SC
   name: Port And I/O Device Access
-  description: '"The organization physically disables or removes [Assignment: organization-defined
+  description: 'The organization physically disables or removes [Assignment: organization-defined
     connection ports or input/output devices] on [Assignment: organization-defined
-    information systems or information system components]."'
+    information systems or information system components].'
 SC-42:
   family: SC
   name: Sensor Capability And Data
@@ -5212,8 +5211,8 @@ SC-43:
 SC-44:
   family: SC
   name: Detonation Chambers
-  description: '"The organization employs a detonation chamber capability within [Assignment:
-    organization-defined information system, system component, or location]."'
+  description: 'The organization employs a detonation chamber capability within [Assignment:
+    organization-defined information system, system component, or location].'
 SI-1:
   family: SI
   name: System And Information Integrity Policy And Procedures
@@ -5528,8 +5527,8 @@ SI-6 (3):
 SI-7:
   family: SI
   name: Software, Firmware, And Information Integrity
-  description: '"The organization employs integrity verification tools to detect unauthorized
-    changes to [Assignment: organization-defined software, firmware, and information]."'
+  description: 'The organization employs integrity verification tools to detect unauthorized
+    changes to [Assignment: organization-defined software, firmware, and information].'
 SI-7 (1):
   family: SI
   name: Integrity Checks
@@ -5645,12 +5644,12 @@ SI-8 (3):
 SI-9:
   family: SI
   name: Information Input Restrictions
-  description: '"[Withdrawn: Incorporated into AC-2, AC-3, AC-5, AC-6]."'
+  description: '[Withdrawn: Incorporated into AC-2, AC-3, AC-5, AC-6].'
 SI-10:
   family: SI
   name: Information Input Validation
-  description: '"The information system checks the validity of [Assignment: organization-defined
-    information inputs]."'
+  description: 'The information system checks the validity of [Assignment: organization-defined
+    information inputs].'
 SI-10 (1):
   family: SI
   name: Manual Override Capability
@@ -5690,10 +5689,10 @@ SI-11:
 SI-12:
   family: SI
   name: Information Handling And Retention
-  description: '"The organization handles and retains information within the information
+  description: The organization handles and retains information within the information
     system and information output from the system in accordance with applicable federal
     laws, Executive Orders, directives, policies, regulations, standards, and operational
-    requirements."'
+    requirements.
 SI-13:
   family: SI
   name: Predictable Failure Prevention
@@ -5732,10 +5731,10 @@ SI-13 (5):
 SI-14:
   family: SI
   name: Non-Persistence
-  description: '"The organization implements non-persistent [Assignment: organization-defined
+  description: 'The organization implements non-persistent [Assignment: organization-defined
     information system components and services] that are initiated in a known state
     and terminated [Selection (one or more): upon end of session of use; periodically
-    at [Assignment: organization-defined frequency]]."'
+    at [Assignment: organization-defined frequency]].'
 SI-14 (1):
   family: SI
   name: Refresh From Trusted Sources
@@ -5745,17 +5744,17 @@ SI-14 (1):
 SI-15:
   family: SI
   name: Information Output Filtering
-  description: '"The information system validates information output from [Assignment:
+  description: 'The information system validates information output from [Assignment:
     organization-defined software programs and/or applications] to ensure that the
-    information is consistent with the expected content."'
+    information is consistent with the expected content.'
 SI-16:
   family: SI
   name: Memory Protection
-  description: '"The information system implements [Assignment: organization-defined
-    security safeguards] to protect its memory from unauthorized code execution."'
+  description: 'The information system implements [Assignment: organization-defined
+    security safeguards] to protect its memory from unauthorized code execution.'
 SI-17:
   family: SI
   name: Fail-Safe Procedures
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     fail-safe procedures] when [Assignment: organization-defined failure conditions
-    occur]."'
+    occur].'

--- a/nist-800-53-rev4.yaml
+++ b/nist-800-53-rev4.yaml
@@ -35,36 +35,36 @@ AC-2:
 AC-2 (1):
   family: AC
   name: Automated System Account Management
-  description: '"The organization employs automated mechanisms to support the management
-    of information system accounts."'
+  description: The organization employs automated mechanisms to support the management
+    of information system accounts.
 AC-2 (2):
   family: AC
   name: Removal Of Temporary / Emergency Accounts
-  description: '"The information system automatically [Selection: removes; disables]
+  description: 'The information system automatically [Selection: removes; disables]
     temporary and emergency accounts after [Assignment: organization-defined time
-    period for each type of account]."'
+    period for each type of account].'
 AC-2 (3):
   family: AC
   name: Disable Inactive Accounts
-  description: '"The information system automatically disables inactive accounts after
-    [Assignment: organization-defined time period]."'
+  description: 'The information system automatically disables inactive accounts after
+    [Assignment: organization-defined time period].'
 AC-2 (4):
   family: AC
   name: Automated Audit Actions
-  description: '"The information system automatically audits account creation, modification,
+  description: 'The information system automatically audits account creation, modification,
     enabling, disabling, and removal actions, and notifies [Assignment: organization-defined
-    personnel or roles]."'
+    personnel or roles].'
 AC-2 (5):
   family: AC
   name: Inactivity Logout
-  description: '"The organization requires that users log out when [Assignment: organization-defined
-    time-period of expected inactivity or description of when to log out]."'
+  description: 'The organization requires that users log out when [Assignment: organization-defined
+    time-period of expected inactivity or description of when to log out].'
 AC-2 (6):
   family: AC
   name: Dynamic Privilege Management
-  description: '"The information system implements the following dynamic privilege
+  description: 'The information system implements the following dynamic privilege
     management capabilities: [Assignment: organization-defined list of dynamic privilege
-    management capabilities]."'
+    management capabilities].'
 AC-2 (7):
   family: AC
   name: Role-Based Schemes
@@ -76,25 +76,25 @@ AC-2 (7):
 AC-2 (8):
   family: AC
   name: Dynamic Account Creation
-  description: '"The information system creates [Assignment: organization-defined
-    information system accounts] dynamically."'
+  description: 'The information system creates [Assignment: organization-defined information
+    system accounts] dynamically.'
 AC-2 (9):
   family: AC
   name: Restrictions On Use Of Shared / Group Accounts
-  description: '"The organization only permits the use of shared/group accounts that
+  description: 'The organization only permits the use of shared/group accounts that
     meet [Assignment: organization-defined conditions for establishing shared/group
-    accounts]."'
+    accounts].'
 AC-2 (10):
   family: AC
   name: Shared / Group Account Credential Termination
-  description: '"The information system terminates shared/group account credentials
-    when members leave the group."'
+  description: The information system terminates shared/group account credentials
+    when members leave the group.
 AC-2 (11):
   family: AC
   name: Usage Conditions
-  description: '"The information system enforces [Assignment: organization-defined
+  description: 'The information system enforces [Assignment: organization-defined
     circumstances and/or usage conditions] for [Assignment: organization-defined information
-    system accounts]."'
+    system accounts].'
 AC-2 (12):
   family: AC
   name: Account Monitoring / Atypical Usage
@@ -105,9 +105,8 @@ AC-2 (12):
 AC-2 (13):
   family: AC
   name: Disable Accounts For High-Risk Individuals
-  description: '"The organization disables accounts of users posing a significant
-    risk within [Assignment: organization-defined time period] of discovery of the
-    risk."'
+  description: 'The organization disables accounts of users posing a significant risk
+    within [Assignment: organization-defined time period] of discovery of the risk.'
 AC-3:
   family: AC
   name: Access Enforcement
@@ -117,12 +116,12 @@ AC-3:
 AC-3 (1):
   family: AC
   name: Restricted Access To Privileged Functions
-  description: '"[Withdrawn: Incorporated into AC-6]."'
+  description: '[Withdrawn: Incorporated into AC-6].'
 AC-3 (2):
   family: AC
   name: Dual Authorization
-  description: '"The information system enforces dual authorization for [Assignment:
-    organization-defined privileged commands and/or other organization-defined actions]."'
+  description: 'The information system enforces dual authorization for [Assignment:
+    organization-defined privileged commands and/or other organization-defined actions].'
 AC-3 (3):
   family: AC
   name: Mandatory Access Control
@@ -149,25 +148,25 @@ AC-3 (4):
 AC-3 (5):
   family: AC
   name: Security-Relevant Information
-  description: '"The information system prevents access to [Assignment: organization-defined
-    security-relevant information] except during secure, non-operable system states."'
+  description: 'The information system prevents access to [Assignment: organization-defined
+    security-relevant information] except during secure, non-operable system states.'
 AC-3 (6):
   family: AC
   name: Protection Of User And System Information
-  description: '"[Withdrawn: Incorporated into MP-4 and SC-28]."'
+  description: '[Withdrawn: Incorporated into MP-4 and SC-28].'
 AC-3 (7):
   family: AC
   name: Role-Based Access Control
-  description: '"The information system enforces a role-based access control policy
+  description: 'The information system enforces a role-based access control policy
     over defined subjects and objects and controls access based upon [Assignment:
-    organization-defined roles and users authorized to assume such roles]."'
+    organization-defined roles and users authorized to assume such roles].'
 AC-3 (8):
   family: AC
   name: Revocation Of Access Authorizations
-  description: '"The information system enforces the revocation of access authorizations
+  description: 'The information system enforces the revocation of access authorizations
     resulting from changes to the security attributes of subjects and objects based
     on [Assignment: organization-defined rules governing the timing of revocations
-    of access authorizations]."'
+    of access authorizations].'
 AC-3 (9):
   family: AC
   name: Controlled Release
@@ -178,8 +177,8 @@ AC-3 (9):
 AC-3 (10):
   family: AC
   name: Audited Override Of Access Control Mechanisms
-  description: '"The organization employs an audited override of automated access
-    control mechanisms under [Assignment: organization-defined conditions]."'
+  description: 'The organization employs an audited override of automated access control
+    mechanisms under [Assignment: organization-defined conditions].'
 AC-4:
   family: AC
   name: Information Flow Enforcement
@@ -189,141 +188,141 @@ AC-4:
 AC-4 (1):
   family: AC
   name: Object Security Attributes
-  description: '"The information system uses [Assignment: organization-defined security
+  description: 'The information system uses [Assignment: organization-defined security
     attributes] associated with [Assignment: organization-defined information, source,
     and destination objects] to enforce [Assignment: organization-defined information
-    flow control policies] as a basis for flow control decisions."'
+    flow control policies] as a basis for flow control decisions.'
 AC-4 (2):
   family: AC
   name: Processing Domains
-  description: '"The information system uses protected processing domains to enforce
+  description: 'The information system uses protected processing domains to enforce
     [Assignment: organization-defined information flow control policies] as a basis
-    for flow control decisions."'
+    for flow control decisions.'
 AC-4 (3):
   family: AC
   name: Dynamic Information Flow Control
-  description: '"The information system enforces dynamic information flow control
-    based on [Assignment: organization-defined policies]."'
+  description: 'The information system enforces dynamic information flow control based
+    on [Assignment: organization-defined policies].'
 AC-4 (4):
   family: AC
   name: Content Check Encrypted Information
-  description: '"The information system prevents encrypted information from bypassing
+  description: 'The information system prevents encrypted information from bypassing
     content-checking mechanisms by [Selection (one or more): decrypting the information;
     blocking the flow of the encrypted information; terminating communications sessions
     attempting to pass encrypted information; [Assignment: organization-defined procedure
-    or method]]."'
+    or method]].'
 AC-4 (5):
   family: AC
   name: Embedded Data Types
-  description: '"The information system enforces [Assignment: organization-defined
-    limitations] on embedding data types within other data types."'
+  description: 'The information system enforces [Assignment: organization-defined
+    limitations] on embedding data types within other data types.'
 AC-4 (6):
   family: AC
   name: Metadata
-  description: '"The information system enforces information flow control based on
-    [Assignment: organization-defined metadata]."'
+  description: 'The information system enforces information flow control based on
+    [Assignment: organization-defined metadata].'
 AC-4 (7):
   family: AC
   name: One-Way Flow Mechanisms
-  description: '"The information system enforces [Assignment: organization-defined
-    one-way information flows] using hardware mechanisms."'
+  description: 'The information system enforces [Assignment: organization-defined
+    one-way information flows] using hardware mechanisms.'
 AC-4 (8):
   family: AC
   name: Security Policy Filters
-  description: '"The information system enforces information flow control using [Assignment:
+  description: 'The information system enforces information flow control using [Assignment:
     organization-defined security policy filters] as a basis for flow control decisions
-    for [Assignment: organization-defined information flows]."'
+    for [Assignment: organization-defined information flows].'
 AC-4 (9):
   family: AC
   name: Human Reviews
-  description: '"The information system enforces the use of human reviews for [Assignment:
+  description: 'The information system enforces the use of human reviews for [Assignment:
     organization-defined information flows] under the following conditions: [Assignment:
-    organization-defined conditions]."'
+    organization-defined conditions].'
 AC-4 (10):
   family: AC
   name: Enable / Disable Security Policy Filters
-  description: '"The information system provides the capability for privileged administrators
+  description: 'The information system provides the capability for privileged administrators
     to enable/disable [Assignment: organization-defined security policy filters] under
-    the following conditions: [Assignment: organization-defined conditions]."'
+    the following conditions: [Assignment: organization-defined conditions].'
 AC-4 (11):
   family: AC
   name: Configuration Of Security Policy Filters
-  description: '"The information system provides the capability for privileged administrators
+  description: 'The information system provides the capability for privileged administrators
     to configure [Assignment: organization-defined security policy filters] to support
-    different security policies."'
+    different security policies.'
 AC-4 (12):
   family: AC
   name: Data Type Identifiers
-  description: '"The information system, when transferring information between different
+  description: 'The information system, when transferring information between different
     security domains, uses [Assignment: organization-defined data type identifiers]
-    to validate data essential for information flow decisions."'
+    to validate data essential for information flow decisions.'
 AC-4 (13):
   family: AC
   name: Decomposition Into Policy-Relevant Subcomponents
-  description: '"The information system, when transferring information between different
+  description: 'The information system, when transferring information between different
     security domains, decomposes information into [Assignment: organization-defined
-    policy-relevant subcomponents] for submission to policy enforcement mechanisms."'
+    policy-relevant subcomponents] for submission to policy enforcement mechanisms.'
 AC-4 (14):
   family: AC
   name: Security Policy Filter Constraints
-  description: '"The information system, when transferring information between different
+  description: 'The information system, when transferring information between different
     security domains, implements [Assignment: organization-defined security policy
-    filters] requiring fully enumerated formats that restrict data structure and content."'
+    filters] requiring fully enumerated formats that restrict data structure and content.'
 AC-4 (15):
   family: AC
   name: Detection Of Unsanctioned Information
-  description: '"The information system, when transferring information between different
+  description: 'The information system, when transferring information between different
     security domains, examines the information for the presence of [Assignment: organized-defined
     unsanctioned information] and prohibits the transfer of such information in accordance
-    with the [Assignment: organization-defined security policy]."'
+    with the [Assignment: organization-defined security policy].'
 AC-4 (16):
   family: AC
   name: Information Transfers On Interconnected Systems
-  description: '"[Withdrawn: Incorporated into AC-4]."'
+  description: '[Withdrawn: Incorporated into AC-4].'
 AC-4 (17):
   family: AC
   name: Domain Authentication
-  description: '"The information system uniquely identifies and authenticates source
+  description: 'The information system uniquely identifies and authenticates source
     and destination points by [Selection (one or more): organization, system, application,
-    individual] for information transfer."'
+    individual] for information transfer.'
 AC-4 (18):
   family: AC
   name: Security Attribute Binding
-  description: '"The information system binds security attributes to information using
+  description: 'The information system binds security attributes to information using
     [Assignment: organization-defined binding techniques] to facilitate information
-    flow policy enforcement."'
+    flow policy enforcement.'
 AC-4 (19):
   family: AC
   name: Validation Of Metadata
-  description: '"The information system, when transferring information between different
+  description: The information system, when transferring information between different
     security domains, applies the same security policy filtering to metadata as it
-    applies to data payloads."'
+    applies to data payloads.
 AC-4 (20):
   family: AC
   name: Approved Solutions
-  description: '"The organization employs [Assignment: organization-defined solutions
+  description: 'The organization employs [Assignment: organization-defined solutions
     in approved configurations] to control the flow of [Assignment: organization-defined
-    information] across security domains."'
+    information] across security domains.'
 AC-4 (21):
   family: AC
   name: Physical / Logical Separation Of Information Flows
-  description: '"The information system separates information flows logically or physically
+  description: 'The information system separates information flows logically or physically
     using [Assignment: organization-defined mechanisms and/or techniques] to accomplish
-    [Assignment: organization-defined required separations by types of information]."'
+    [Assignment: organization-defined required separations by types of information].'
 AC-4 (22):
   family: AC
   name: Access Only
-  description: '"The information system provides access from a single device to computing
+  description: The information system provides access from a single device to computing
     platforms, applications, or data residing on multiple different security domains,
-    while preventing any information flow between the different security domains."'
+    while preventing any information flow between the different security domains.
 AC-5:
   family: AC
   name: Separation Of Duties
   description: |-
-    The organization:
+    "The organization:
       a.  Separates [Assignment: organization-defined duties of individuals];
       b.  Documents separation of duties of individuals; and
-      c.  Defines information system access authorizations to support separation of duties.
+      c.  Defines information system access authorizations to support separation of duties."
 AC-6:
   family: AC
   name: Least Privilege
@@ -334,38 +333,38 @@ AC-6:
 AC-6 (1):
   family: AC
   name: Authorize Access To Security Functions
-  description: '"The organization explicitly authorizes access to [Assignment: organization-defined
+  description: 'The organization explicitly authorizes access to [Assignment: organization-defined
     security functions (deployed in hardware, software, and firmware) and security-relevant
-    information]."'
+    information].'
 AC-6 (2):
   family: AC
   name: Non-Privileged Access For Nonsecurity Functions
-  description: '"The organization requires that users of information system accounts,
+  description: 'The organization requires that users of information system accounts,
     or roles, with access to [Assignment: organization-defined security functions
     or security-relevant information], use non-privileged accounts or roles, when
-    accessing nonsecurity functions."'
+    accessing nonsecurity functions.'
 AC-6 (3):
   family: AC
   name: Network Access To Privileged Commands
-  description: '"The organization authorizes network access to [Assignment: organization-defined
+  description: 'The organization authorizes network access to [Assignment: organization-defined
     privileged commands] only for [Assignment: organization-defined compelling operational
     needs] and documents the rationale for such access in the security plan for the
-    information system."'
+    information system.'
 AC-6 (4):
   family: AC
   name: Separate Processing Domains
-  description: '"The information system provides separate processing domains to enable
-    finer-grained allocation of user privileges."'
+  description: The information system provides separate processing domains to enable
+    finer-grained allocation of user privileges.
 AC-6 (5):
   family: AC
   name: Privileged Accounts
-  description: '"The organization restricts privileged accounts on the information
-    system to [Assignment: organization-defined personnel or roles]."'
+  description: 'The organization restricts privileged accounts on the information
+    system to [Assignment: organization-defined personnel or roles].'
 AC-6 (6):
   family: AC
   name: Privileged Access By Non-Organizational Users
-  description: '"The organization prohibits privileged access to the information system
-    by non-organizational users."'
+  description: The organization prohibits privileged access to the information system
+    by non-organizational users.
 AC-6 (7):
   family: AC
   name: Review Of User Privileges
@@ -376,18 +375,18 @@ AC-6 (7):
 AC-6 (8):
   family: AC
   name: Privilege Levels For Code Execution
-  description: '"The information system prevents [Assignment: organization-defined
-    software] from executing at higher privilege levels than users executing the software."'
+  description: 'The information system prevents [Assignment: organization-defined
+    software] from executing at higher privilege levels than users executing the software.'
 AC-6 (9):
   family: AC
   name: Auditing Use Of Privileged Functions
-  description: '"The information system audits the execution of privileged functions."'
+  description: The information system audits the execution of privileged functions.
 AC-6 (10):
   family: AC
   name: Prohibit Non-Privileged Users From Executing Privileged Functions
-  description: '"The information system prevents non-privileged users from executing
+  description: The information system prevents non-privileged users from executing
     privileged functions to include disabling, circumventing, or altering implemented
-    security safeguards/countermeasures."'
+    security safeguards/countermeasures.
 AC-7:
   family: AC
   name: Unsuccessful Logon Attempts
@@ -398,14 +397,14 @@ AC-7:
 AC-7 (1):
   family: AC
   name: Automatic Account Lock
-  description: '"[Withdrawn: Incorporated into AC-7]."'
+  description: '[Withdrawn: Incorporated into AC-7].'
 AC-7 (2):
   family: AC
   name: Purge / Wipe Mobile Device
-  description: '"The information system purges/wipes information from [Assignment:
+  description: 'The information system purges/wipes information from [Assignment:
     organization-defined mobile devices] based on [Assignment: organization-defined
     purging/wiping requirements/techniques] after [Assignment: organization-defined
-    number] consecutive, unsuccessful device logon attempts."'
+    number] consecutive, unsuccessful device logon attempts.'
 AC-8:
   family: AC
   name: System Use Notification
@@ -429,27 +428,27 @@ AC-9:
 AC-9 (1):
   family: AC
   name: Unsuccessful Logons
-  description: '"The information system notifies the user, upon successful logon/access,
+  description: The information system notifies the user, upon successful logon/access,
     of the number of unsuccessful logon/access attempts since the last successful
-    logon/access."'
+    logon/access.
 AC-9 (2):
   family: AC
   name: Successful / Unsuccessful Logons
-  description: '"The information system notifies the user of the number of [Selection:
+  description: 'The information system notifies the user of the number of [Selection:
     successful logons/accesses; unsuccessful logon/access attempts; both] during [Assignment:
-    organization-defined time period]."'
+    organization-defined time period].'
 AC-9 (3):
   family: AC
   name: Notification Of Account Changes
-  description: '"The information system notifies the user of changes to [Assignment:
-    organization-defined security-related characteristics/parameters of the user�s
-    account] during [Assignment: organization-defined time period]."'
+  description: 'The information system notifies the user of changes to [Assignment:
+    organization-defined security-related characteristics/parameters of the user''s
+    account] during [Assignment: organization-defined time period].'
 AC-9 (4):
   family: AC
   name: Additional Logon Information
-  description: '"The information system notifies the user, upon successful logon (access),
+  description: 'The information system notifies the user, upon successful logon (access),
     of the following additional information: [Assignment: organization-defined information
-    to be included in addition to the date and time of the last logon (access)]."'
+    to be included in addition to the date and time of the last logon (access)].'
 AC-10:
   family: AC
   name: Concurrent Session Control
@@ -466,8 +465,8 @@ AC-11:
 AC-11 (1):
   family: AC
   name: Pattern-Hiding Displays
-  description: '"The information system conceals, via the session lock, information
-    previously visible on the display with a publicly viewable image."'
+  description: The information system conceals, via the session lock, information
+    previously visible on the display with a publicly viewable image.
 AC-12:
   family: AC
   name: Session Termination
@@ -495,7 +494,7 @@ AC-14:
 AC-14 (1):
   family: AC
   name: Necessary Uses
-  description: '"[Withdrawn: Incorporated into AC-14]."'
+  description: '[Withdrawn: Incorporated into AC-14].'
 AC-15:
   family: AC
   name: Automated Marking
@@ -512,65 +511,65 @@ AC-16:
 AC-16 (1):
   family: AC
   name: Dynamic Attribute Association
-  description: '"The information system dynamically associates security attributes
+  description: 'The information system dynamically associates security attributes
     with [Assignment: organization-defined subjects and objects] in accordance with
     [Assignment: organization-defined security policies] as information is created
-    and combined."'
+    and combined.'
 AC-16 (2):
   family: AC
   name: Attribute Value Changes By Authorized Individuals
-  description: '"The information system provides authorized individuals (or processes
+  description: The information system provides authorized individuals (or processes
     acting on behalf of individuals) the capability to define or change the value
-    of associated security attributes."'
+    of associated security attributes.
 AC-16 (3):
   family: AC
   name: Maintenance Of Attribute Associations By Information System
-  description: '"The information system maintains the association and integrity of
+  description: 'The information system maintains the association and integrity of
     [Assignment: organization-defined security attributes] to [Assignment: organization-defined
-    subjects and objects]."'
+    subjects and objects].'
 AC-16 (4):
   family: AC
   name: Association Of Attributes By Authorized Individuals
-  description: '"The information system supports the association of [Assignment: organization-defined
+  description: 'The information system supports the association of [Assignment: organization-defined
     security attributes] with [Assignment: organization-defined subjects and objects]
-    by authorized individuals (or processes acting on behalf of individuals)."'
+    by authorized individuals (or processes acting on behalf of individuals).'
 AC-16 (5):
   family: AC
   name: Attribute Displays For Output Devices
-  description: '"The information system displays security attributes in human-readable
+  description: 'The information system displays security attributes in human-readable
     form on each object that the system transmits to output devices to identify [Assignment:
     organization-identified special dissemination, handling, or distribution instructions]
-    using [Assignment: organization-identified human-readable, standard naming conventions]."'
+    using [Assignment: organization-identified human-readable, standard naming conventions].'
 AC-16 (6):
   family: AC
   name: Maintenance Of Attribute Association By Organization
-  description: '"The organization allows personnel to associate, and maintain the
-    association of [Assignment: organization-defined security attributes] with [Assignment:
-    organization-defined subjects and objects] in accordance with [Assignment: organization-defined
-    security policies]."'
+  description: 'The organization allows personnel to associate, and maintain the association
+    of [Assignment: organization-defined security attributes] with [Assignment: organization-defined
+    subjects and objects] in accordance with [Assignment: organization-defined security
+    policies].'
 AC-16 (7):
   family: AC
   name: Consistent Attribute Interpretation
-  description: '"The organization provides a consistent interpretation of security
-    attributes transmitted between distributed information system components."'
+  description: The organization provides a consistent interpretation of security attributes
+    transmitted between distributed information system components.
 AC-16 (8):
   family: AC
   name: Association Techniques / Technologies
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     techniques or technologies] with [Assignment: organization-defined level of assurance]
-    in associating security attributes to information."'
+    in associating security attributes to information.'
 AC-16 (9):
   family: AC
   name: Attribute Reassignment
-  description: '"The organization ensures that security attributes associated with
+  description: 'The organization ensures that security attributes associated with
     information are reassigned only via re-grading mechanisms validated using [Assignment:
-    organization-defined techniques or procedures]."'
+    organization-defined techniques or procedures].'
 AC-16 (10):
   family: AC
   name: Attribute Configuration By Authorized Individuals
-  description: '"The information system provides authorized individuals the capability
+  description: The information system provides authorized individuals the capability
     to define or change the type and value of security attributes available for association
-    with subjects and objects."'
+    with subjects and objects.
 AC-17:
   family: AC
   name: Remote Access
@@ -581,17 +580,17 @@ AC-17:
 AC-17 (1):
   family: AC
   name: Automated Monitoring / Control
-  description: '"The information system monitors and controls remote access methods."'
+  description: The information system monitors and controls remote access methods.
 AC-17 (2):
   family: AC
   name: Protection Of Confidentiality / Integrity Using Encryption
-  description: '"The information system implements cryptographic mechanisms to protect
-    the confidentiality and integrity of remote access sessions."'
+  description: The information system implements cryptographic mechanisms to protect
+    the confidentiality and integrity of remote access sessions.
 AC-17 (3):
   family: AC
   name: Managed Access Control Points
-  description: '"The information system routes all remote accesses through [Assignment:
-    organization-defined number] managed network access control points."'
+  description: 'The information system routes all remote accesses through [Assignment:
+    organization-defined number] managed network access control points.'
 AC-17 (4):
   family: AC
   name: Privileged Commands / Access
@@ -602,26 +601,26 @@ AC-17 (4):
 AC-17 (5):
   family: AC
   name: Monitoring For Unauthorized Connections
-  description: '"[Withdrawn: Incorporated into SI-4]."'
+  description: '[Withdrawn: Incorporated into SI-4].'
 AC-17 (6):
   family: AC
   name: Protection Of Information
-  description: '"The organization ensures that users protect information about remote
-    access mechanisms from unauthorized use and disclosure."'
+  description: The organization ensures that users protect information about remote
+    access mechanisms from unauthorized use and disclosure.
 AC-17 (7):
   family: AC
   name: Additional Protection For Security Function Access
-  description: '"[Withdrawn: Incorporated into AC-3 (10)]."'
+  description: '[Withdrawn: Incorporated into AC-3 (10)].'
 AC-17 (8):
   family: AC
   name: Disable Nonsecure Network Protocols
-  description: '"[Withdrawn: Incorporated into CM-7]."'
+  description: '[Withdrawn: Incorporated into CM-7].'
 AC-17 (9):
   family: AC
   name: Disconnect / Disable Access
-  description: '"The organization provides the capability to expeditiously disconnect
+  description: 'The organization provides the capability to expeditiously disconnect
     or disable remote access to the information system within [Assignment: organization-defined
-    time period]."'
+    time period].'
 AC-18:
   family: AC
   name: Wireless Access
@@ -632,29 +631,29 @@ AC-18:
 AC-18 (1):
   family: AC
   name: Authentication And Encryption
-  description: '"The information system protects wireless access to the system using
-    authentication of [Selection (one or more): users; devices] and encryption."'
+  description: 'The information system protects wireless access to the system using
+    authentication of [Selection (one or more): users; devices] and encryption.'
 AC-18 (2):
   family: AC
   name: Monitoring Unauthorized Connections
-  description: '"[Withdrawn: Incorporated into SI-4]."'
+  description: '[Withdrawn: Incorporated into SI-4].'
 AC-18 (3):
   family: AC
   name: Disable Wireless Networking
-  description: '"The organization disables, when not intended for use, wireless networking
+  description: The organization disables, when not intended for use, wireless networking
     capabilities internally embedded within information system components prior to
-    issuance and deployment."'
+    issuance and deployment.
 AC-18 (4):
   family: AC
   name: Restrict Configurations By Users
-  description: '"The organization identifies and explicitly authorizes users allowed
-    to independently configure wireless networking capabilities."'
+  description: The organization identifies and explicitly authorizes users allowed
+    to independently configure wireless networking capabilities.
 AC-18 (5):
   family: AC
   name: Antennas / Transmission Power Levels
-  description: '"The organization selects radio antennas and calibrates transmission
+  description: The organization selects radio antennas and calibrates transmission
     power levels to reduce the probability that usable signals can be received outside
-    of organization-controlled boundaries."'
+    of organization-controlled boundaries.
 AC-19:
   family: AC
   name: Access Control For Mobile Devices
@@ -665,15 +664,15 @@ AC-19:
 AC-19 (1):
   family: AC
   name: Use Of  Writable / Portable Storage Devices
-  description: '"[Withdrawn: Incorporated into MP-7]."'
+  description: '[Withdrawn: Incorporated into MP-7].'
 AC-19 (2):
   family: AC
   name: Use Of Personally Owned Portable Storage Devices
-  description: '"[Withdrawn: Incorporated into MP-7]."'
+  description: '[Withdrawn: Incorporated into MP-7].'
 AC-19 (3):
   family: AC
   name: Use Of Portable Storage Devices With No Identifiable Owner
-  description: '"[Withdrawn: Incorporated into MP-7]."'
+  description: '[Withdrawn: Incorporated into MP-7].'
 AC-19 (4):
   family: AC
   name: Restrictions For Classified Information
@@ -689,9 +688,9 @@ AC-19 (4):
 AC-19 (5):
   family: AC
   name: Full Device / Container-Based  Encryption
-  description: '"The organization employs [Selection: full-device encryption; container
+  description: 'The organization employs [Selection: full-device encryption; container
     encryption] to protect the confidentiality and integrity of information on [Assignment:
-    organization-defined mobile devices]."'
+    organization-defined mobile devices].'
 AC-20:
   family: AC
   name: Use Of External Information Systems
@@ -709,19 +708,19 @@ AC-20 (1):
 AC-20 (2):
   family: AC
   name: Portable Storage Devices
-  description: '"The organization [Selection: restricts; prohibits] the use of organization-controlled
-    portable storage devices by authorized individuals on external information systems."'
+  description: 'The organization [Selection: restricts; prohibits] the use of organization-controlled
+    portable storage devices by authorized individuals on external information systems.'
 AC-20 (3):
   family: AC
   name: Non-Organizationally Owned Systems / Components / Devices
-  description: '"The organization [Selection: restricts; prohibits] the use of non-organizationally
+  description: 'The organization [Selection: restricts; prohibits] the use of non-organizationally
     owned information systems, system components, or devices to process, store, or
-    transmit organizational information."'
+    transmit organizational information.'
 AC-20 (4):
   family: AC
   name: Network Accessible Storage Devices
-  description: '"The organization prohibits the use of [Assignment: organization-defined
-    network accessible storage devices] in external information systems."'
+  description: 'The organization prohibits the use of [Assignment: organization-defined
+    network accessible storage devices] in external information systems.'
 AC-21:
   family: AC
   name: Information Sharing
@@ -732,14 +731,14 @@ AC-21:
 AC-21 (1):
   family: AC
   name: Automated Decision Support
-  description: '"The information system enforces information-sharing decisions by
-    authorized users based on access authorizations of sharing partners and access
-    restrictions on information to be shared."'
+  description: The information system enforces information-sharing decisions by authorized
+    users based on access authorizations of sharing partners and access restrictions
+    on information to be shared.
 AC-21 (2):
   family: AC
   name: Information Search And Retrieval
-  description: '"The information system implements information search and retrieval
-    services that enforce [Assignment: organization-defined information sharing restrictions]."'
+  description: 'The information system implements information search and retrieval
+    services that enforce [Assignment: organization-defined information sharing restrictions].'
 AC-22:
   family: AC
   name: Publicly Accessible Content
@@ -763,16 +762,16 @@ AC-24:
 AC-24 (1):
   family: AC
   name: Transmit Access Authorization Information
-  description: '"The information system transmits [Assignment: organization-defined
+  description: 'The information system transmits [Assignment: organization-defined
     access authorization information] using [Assignment: organization-defined security
     safeguards] to [Assignment: organization-defined information systems] that enforce
-    access control decisions."'
+    access control decisions.'
 AC-24 (2):
   family: AC
   name: No User Or Process Identity
-  description: '"The information system enforces access control decisions based on
+  description: 'The information system enforces access control decisions based on
     [Assignment: organization-defined security attributes] that do not include the
-    identity of the user or process acting on behalf of the user."'
+    identity of the user or process acting on behalf of the user.'
 AC-25:
   family: AC
   name: Reference Monitor
@@ -802,13 +801,13 @@ AT-2:
 AT-2 (1):
   family: AT
   name: Practical Exercises
-  description: '"The organization includes practical exercises in security awareness
-    training that simulate actual cyber attacks."'
+  description: The organization includes practical exercises in security awareness
+    training that simulate actual cyber attacks.
 AT-2 (2):
   family: AT
   name: Insider Threat
-  description: '"The organization includes security awareness training on recognizing
-    and reporting potential indicators of insider threat."'
+  description: The organization includes security awareness training on recognizing
+    and reporting potential indicators of insider threat.
 AT-3:
   family: AT
   name: Role-Based Security Training
@@ -820,26 +819,26 @@ AT-3:
 AT-3 (1):
   family: AT
   name: Environmental Controls
-  description: '"The organization provides [Assignment: organization-defined personnel
+  description: 'The organization provides [Assignment: organization-defined personnel
     or roles] with initial and [Assignment: organization-defined frequency] training
-    in the employment and operation of environmental controls."'
+    in the employment and operation of environmental controls.'
 AT-3 (2):
   family: AT
   name: Physical Security Controls
-  description: '"The organization provides [Assignment: organization-defined personnel
+  description: 'The organization provides [Assignment: organization-defined personnel
     or roles] with initial and [Assignment: organization-defined frequency] training
-    in the employment and operation of physical security controls."'
+    in the employment and operation of physical security controls.'
 AT-3 (3):
   family: AT
   name: Practical Exercises
-  description: '"The organization includes practical exercises in security training
-    that reinforce training objectives."'
+  description: The organization includes practical exercises in security training
+    that reinforce training objectives.
 AT-3 (4):
   family: AT
   name: Suspicious Communications And Anomalous System Behavior
-  description: '"The organization provides training to its personnel on [Assignment:
+  description: 'The organization provides training to its personnel on [Assignment:
     organization-defined indicators of malicious code] to recognize suspicious communications
-    and anomalous behavior in organizational information systems."'
+    and anomalous behavior in organizational information systems.'
 AT-4:
   family: AT
   name: Security Training Records
@@ -874,20 +873,20 @@ AU-2:
 AU-2 (1):
   family: AU
   name: Compilation Of Audit Records From Multiple Sources
-  description: '"[Withdrawn: Incorporated into AU-12]."'
+  description: '[Withdrawn: Incorporated into AU-12].'
 AU-2 (2):
   family: AU
   name: Selection Of Audit Events By Component
-  description: '"[Withdrawn: Incorporated into AU-12]."'
+  description: '[Withdrawn: Incorporated into AU-12].'
 AU-2 (3):
   family: AU
   name: Reviews And Updates
-  description: '"The organization reviews and updates the audited events [Assignment:
-    organization-defined frequency]."'
+  description: 'The organization reviews and updates the audited events [Assignment:
+    organization-defined frequency].'
 AU-2 (4):
   family: AU
   name: Privileged Functions
-  description: '"[Withdrawn: Incorporated into AC-6 (9)]."'
+  description: '[Withdrawn: Incorporated into AC-6 (9)].'
 AU-3:
   family: AU
   name: Content Of Audit Records
@@ -898,15 +897,15 @@ AU-3:
 AU-3 (1):
   family: AU
   name: Additional Audit Information
-  description: '"The information system generates audit records containing the following
+  description: 'The information system generates audit records containing the following
     additional information: [Assignment: organization-defined additional, more detailed
-    information]."'
+    information].'
 AU-3 (2):
   family: AU
   name: Centralized Management Of Planned Audit Record Content
-  description: '"The information system provides centralized management and configuration
+  description: 'The information system provides centralized management and configuration
     of the content to be captured in audit records generated by [Assignment: organization-defined
-    information system components]."'
+    information system components].'
 AU-4:
   family: AU
   name: Audit Storage Capacity
@@ -915,8 +914,8 @@ AU-4:
 AU-4 (1):
   family: AU
   name: Transfer To Alternate Storage
-  description: '"The information system off-loads audit records [Assignment: organization-defined
-    frequency] onto a different system or media than the system being audited."'
+  description: 'The information system off-loads audit records [Assignment: organization-defined
+    frequency] onto a different system or media than the system being audited.'
 AU-5:
   family: AU
   name: Response To Audit Processing Failures
@@ -927,30 +926,30 @@ AU-5:
 AU-5 (1):
   family: AU
   name: Audit Storage Capacity
-  description: '"The information system provides a warning to [Assignment: organization-defined
+  description: 'The information system provides a warning to [Assignment: organization-defined
     personnel, roles, and/or locations] within [Assignment: organization-defined time
     period] when allocated audit record storage volume reaches [Assignment: organization-defined
-    percentage] of repository maximum audit record storage capacity."'
+    percentage] of repository maximum audit record storage capacity.'
 AU-5 (2):
   family: AU
   name: Real-Time Alerts
-  description: '"The information system provides an alert in [Assignment: organization-defined
+  description: 'The information system provides an alert in [Assignment: organization-defined
     real-time period] to [Assignment: organization-defined personnel, roles, and/or
     locations] when the following audit failure events occur: [Assignment: organization-defined
-    audit failure events requiring real-time alerts]."'
+    audit failure events requiring real-time alerts].'
 AU-5 (3):
   family: AU
   name: Configurable Traffic Volume Thresholds
-  description: '"The information system enforces configurable network communications
+  description: 'The information system enforces configurable network communications
     traffic volume thresholds reflecting limits on auditing capacity and [Selection:
-    rejects; delays] network traffic above those thresholds."'
+    rejects; delays] network traffic above those thresholds.'
 AU-5 (4):
   family: AU
   name: Shutdown On Failure
-  description: '"The information system invokes a [Selection: full system shutdown;
+  description: 'The information system invokes a [Selection: full system shutdown;
     partial system shutdown; degraded operational mode with limited mission/business
     functionality available] in the event of [Assignment: organization-defined audit
-    failures], unless an alternate audit capability exists."'
+    failures], unless an alternate audit capability exists.'
 AU-6:
   family: AU
   name: Audit Review, Analysis, And Reporting
@@ -961,61 +960,60 @@ AU-6:
 AU-6 (1):
   family: AU
   name: Process Integration
-  description: '"The organization employs automated mechanisms to integrate audit
-    review, analysis, and reporting processes to support organizational processes
-    for investigation and response to suspicious activities."'
+  description: The organization employs automated mechanisms to integrate audit review,
+    analysis, and reporting processes to support organizational processes for investigation
+    and response to suspicious activities.
 AU-6 (2):
   family: AU
   name: Automated Security Alerts
-  description: '"[Withdrawn: Incorporated into SI-4]."'
+  description: '[Withdrawn: Incorporated into SI-4].'
 AU-6 (3):
   family: AU
   name: Correlate Audit Repositories
-  description: '"The organization analyzes and correlates audit records across different
-    repositories to gain organization-wide situational awareness."'
+  description: The organization analyzes and correlates audit records across different
+    repositories to gain organization-wide situational awareness.
 AU-6 (4):
   family: AU
   name: Central Review And Analysis
-  description: '"The information system provides the capability to centrally review
-    and analyze audit records from multiple components within the system."'
+  description: The information system provides the capability to centrally review
+    and analyze audit records from multiple components within the system.
 AU-6 (5):
   family: AU
   name: Integration / Scanning And Monitoring Capabilities
-  description: '"The organization integrates analysis of audit records with analysis
+  description: 'The organization integrates analysis of audit records with analysis
     of [Selection (one or more): vulnerability scanning information; performance data;
     information system monitoring information; [Assignment: organization-defined data/information
     collected from other sources]] to further enhance the ability to identify inappropriate
-    or unusual activity."'
+    or unusual activity.'
 AU-6 (6):
   family: AU
   name: Correlation With Physical Monitoring
-  description: '"The organization correlates information from audit records with information
+  description: The organization correlates information from audit records with information
     obtained from monitoring physical access to further enhance the ability to identify
-    suspicious, inappropriate, unusual, or malevolent activity."'
+    suspicious, inappropriate, unusual, or malevolent activity.
 AU-6 (7):
   family: AU
   name: Permitted Actions
-  description: '"The organization specifies the permitted actions for each [Selection
+  description: 'The organization specifies the permitted actions for each [Selection
     (one or more): information system process; role; user] associated with the review,
-    analysis, and reporting of audit information."'
+    analysis, and reporting of audit information.'
 AU-6 (8):
   family: AU
   name: Full Text Analysis Of Privileged Commands
-  description: '"The organization performs a full text analysis of audited privileged
+  description: The organization performs a full text analysis of audited privileged
     commands in a physically distinct component or subsystem of the information system,
-    or other information system that is dedicated to that analysis."'
+    or other information system that is dedicated to that analysis.
 AU-6 (9):
   family: AU
   name: Correlation With Information From Nontechnical Sources
-  description: '"The organization correlates information from nontechnical sources
-    with audit information to enhance organization-wide situational awareness."'
+  description: The organization correlates information from nontechnical sources with
+    audit information to enhance organization-wide situational awareness.
 AU-6 (10):
   family: AU
   name: Audit Level Adjustment
-  description: '"The organization adjusts the level of audit review, analysis, and
-    reporting within the information system when there is a change in risk based on
-    law enforcement information, intelligence information, or other credible sources
-    of information."'
+  description: The organization adjusts the level of audit review, analysis, and reporting
+    within the information system when there is a change in risk based on law enforcement
+    information, intelligence information, or other credible sources of information.
 AU-7:
   family: AU
   name: Audit Reduction And Report Generation
@@ -1026,15 +1024,15 @@ AU-7:
 AU-7 (1):
   family: AU
   name: Automatic Processing
-  description: '"The information system provides the capability to process audit records
+  description: 'The information system provides the capability to process audit records
     for events of interest based on [Assignment: organization-defined audit fields
-    within audit records]."'
+    within audit records].'
 AU-7 (2):
   family: AU
   name: Automatic Sort And Search
-  description: '"The information system provides the capability to sort and search
+  description: 'The information system provides the capability to sort and search
     audit records for events of interest based on the content of [Assignment: organization-defined
-    audit fields within audit records]."'
+    audit fields within audit records].'
 AU-8:
   family: AU
   name: Time Stamps
@@ -1052,9 +1050,9 @@ AU-8 (1):
 AU-8 (2):
   family: AU
   name: Secondary Authoritative Time Source
-  description: '"The information system identifies a secondary authoritative time
-    source that is located in a different geographic region than the primary authoritative
-    time source."'
+  description: The information system identifies a secondary authoritative time source
+    that is located in a different geographic region than the primary authoritative
+    time source.
 AU-9:
   family: AU
   name: Protection Of Audit Information
@@ -1063,34 +1061,34 @@ AU-9:
 AU-9 (1):
   family: AU
   name: Hardware Write-Once Media
-  description: '"The information system writes audit trails to hardware-enforced,
-    write-once media."'
+  description: The information system writes audit trails to hardware-enforced, write-once
+    media.
 AU-9 (2):
   family: AU
   name: Audit Backup On Separate Physical Systems / Components
-  description: '"The information system backs up audit records [Assignment: organization-defined
+  description: 'The information system backs up audit records [Assignment: organization-defined
     frequency] onto a physically different system or system component than the system
-    or component being audited."'
+    or component being audited.'
 AU-9 (3):
   family: AU
   name: Cryptographic Protection
-  description: '"The information system implements cryptographic mechanisms to protect
-    the integrity of audit information and audit tools."'
+  description: The information system implements cryptographic mechanisms to protect
+    the integrity of audit information and audit tools.
 AU-9 (4):
   family: AU
   name: Access By Subset Of Privileged Users
-  description: '"The organization authorizes access to management of audit functionality
-    to only [Assignment: organization-defined subset of privileged users]."'
+  description: 'The organization authorizes access to management of audit functionality
+    to only [Assignment: organization-defined subset of privileged users].'
 AU-9 (5):
   family: AU
   name: Dual Authorization
-  description: '"The organization enforces dual authorization for [Selection (one
-    or more): movement; deletion] of [Assignment: organization-defined audit information]."'
+  description: 'The organization enforces dual authorization for [Selection (one or
+    more): movement; deletion] of [Assignment: organization-defined audit information].'
 AU-9 (6):
   family: AU
   name: Read Only Access
-  description: '"The organization authorizes read-only access to audit information
-    to [Assignment: organization-defined subset of privileged users]."'
+  description: 'The organization authorizes read-only access to audit information
+    to [Assignment: organization-defined subset of privileged users].'
 AU-10:
   family: AU
   name: Non-Repudiation
@@ -1114,8 +1112,8 @@ AU-10 (2):
 AU-10 (3):
   family: AU
   name: Chain Of Custody
-  description: '"The information system maintains reviewer/releaser identity and credentials
-    within the established chain of custody for all information reviewed or released."'
+  description: The information system maintains reviewer/releaser identity and credentials
+    within the established chain of custody for all information reviewed or released.
 AU-10 (4):
   family: AU
   name: Validate Binding Of Information Reviewer Identity
@@ -1126,7 +1124,7 @@ AU-10 (4):
 AU-10 (5):
   family: AU
   name: Digital Signatures
-  description: '"[Withdrawn: Incorporated into SI-7]."'
+  description: '[Withdrawn: Incorporated into SI-7].'
 AU-11:
   family: AU
   name: Audit Record Retention
@@ -1137,9 +1135,9 @@ AU-11:
 AU-11 (1):
   family: AU
   name: Long-Term Retrieval Capability
-  description: '"The organization employs [Assignment: organization-defined measures]
+  description: 'The organization employs [Assignment: organization-defined measures]
     to ensure that long-term audit records generated by the information system can
-    be retrieved."'
+    be retrieved.'
 AU-12:
   family: AU
   name: Audit Generation
@@ -1151,23 +1149,23 @@ AU-12:
 AU-12 (1):
   family: AU
   name: System-Wide / Time-Correlated Audit Trail
-  description: '"The information system compiles audit records from [Assignment: organization-defined
+  description: 'The information system compiles audit records from [Assignment: organization-defined
     information system components] into a system-wide (logical or physical) audit
     trail that is time-correlated to within [Assignment: organization-defined level
     of tolerance for the relationship between time stamps of individual records in
-    the audit trail]."'
+    the audit trail].'
 AU-12 (2):
   family: AU
   name: Standardized Formats
-  description: '"The information system produces a system-wide (logical or physical)
-    audit trail composed of audit records in a standardized format."'
+  description: The information system produces a system-wide (logical or physical)
+    audit trail composed of audit records in a standardized format.
 AU-12 (3):
   family: AU
   name: Changes By Authorized Individuals
-  description: '"The information system provides the capability for [Assignment: organization-defined
+  description: 'The information system provides the capability for [Assignment: organization-defined
     individuals or roles] to change the auditing to be performed on [Assignment: organization-defined
     information system components] based on [Assignment: organization-defined selectable
-    event criteria] within [Assignment: organization-defined time thresholds]."'
+    event criteria] within [Assignment: organization-defined time thresholds].'
 AU-13:
   family: AU
   name: Monitoring For Information Disclosure
@@ -1177,13 +1175,13 @@ AU-13:
 AU-13 (1):
   family: AU
   name: Use Of Automated Tools
-  description: '"The organization employs automated mechanisms to determine if organizational
-    information has been disclosed in an unauthorized manner."'
+  description: The organization employs automated mechanisms to determine if organizational
+    information has been disclosed in an unauthorized manner.
 AU-13 (2):
   family: AU
   name: Review Of Monitored Sites
-  description: '"The organization reviews the open source information sites being
-    monitored [Assignment: organization-defined frequency]."'
+  description: 'The organization reviews the open source information sites being monitored
+    [Assignment: organization-defined frequency].'
 AU-14:
   family: AU
   name: Session Audit
@@ -1192,18 +1190,18 @@ AU-14:
 AU-14 (1):
   family: AU
   name: System Start-Up
-  description: '"The information system initiates session audits at system start-up."'
+  description: The information system initiates session audits at system start-up.
 AU-14 (2):
   family: AU
   name: Capture/Record And Log Content
-  description: '"The information system provides the capability for authorized users
-    to capture/record and log content related to a user session."'
+  description: The information system provides the capability for authorized users
+    to capture/record and log content related to a user session.
 AU-14 (3):
   family: AU
   name: Remote Viewing / Listening
-  description: '"The information system provides the capability for authorized users
+  description: The information system provides the capability for authorized users
     to remotely view/hear all content related to an established user session in real
-    time."'
+    time.
 AU-15:
   family: AU
   name: Alternate Audit Capability
@@ -1219,14 +1217,14 @@ AU-16:
 AU-16 (1):
   family: AU
   name: Identity Preservation
-  description: '"The organization requires that the identity of individuals be preserved
-    in cross-organizational audit trails."'
+  description: The organization requires that the identity of individuals be preserved
+    in cross-organizational audit trails.
 AU-16 (2):
   family: AU
   name: Sharing Of Audit Information
-  description: '"The organization provides cross-organizational audit information
-    to [Assignment: organization-defined organizations] based on [Assignment: organization-defined
-    cross-organizational sharing agreements]."'
+  description: 'The organization provides cross-organizational audit information to
+    [Assignment: organization-defined organizations] based on [Assignment: organization-defined
+    cross-organizational sharing agreements].'
 CA-1:
   family: CA
   name: Security Assessment And Authorization Policy And Procedures
@@ -1253,23 +1251,23 @@ CA-2:
 CA-2 (1):
   family: CA
   name: Independent Assessors
-  description: '"The organization employs assessors or assessment teams with [Assignment:
-    organization-defined level of independence] to conduct security control assessments."'
+  description: 'The organization employs assessors or assessment teams with [Assignment:
+    organization-defined level of independence] to conduct security control assessments.'
 CA-2 (2):
   family: CA
   name: Specialized Assessments
-  description: '"The organization includes as part of security control assessments,
+  description: 'The organization includes as part of security control assessments,
     [Assignment: organization-defined frequency], [Selection: announced; unannounced],
     [Selection (one or more): in-depth monitoring; vulnerability scanning; malicious
     user testing; insider threat assessment; performance/load testing; [Assignment:
-    organization-defined other forms of security assessment]]."'
+    organization-defined other forms of security assessment]].'
 CA-2 (3):
   family: CA
   name: External Organizations
-  description: '"The organization accepts the results of an assessment of [Assignment:
+  description: 'The organization accepts the results of an assessment of [Assignment:
     organization-defined information system] performed by [Assignment: organization-defined
     external organization] when the assessment meets [Assignment: organization-defined
-    requirements]."'
+    requirements].'
 CA-3:
   family: CA
   name: System Interconnections
@@ -1281,33 +1279,33 @@ CA-3:
 CA-3 (1):
   family: CA
   name: Unclassified National Security System Connections
-  description: '"The organization prohibits the direct connection of an [Assignment:
+  description: 'The organization prohibits the direct connection of an [Assignment:
     organization-defined unclassified, national security system] to an external network
-    without the use of [Assignment: organization-defined boundary protection device]."'
+    without the use of [Assignment: organization-defined boundary protection device].'
 CA-3 (2):
   family: CA
   name: Classified National Security System Connections
-  description: '"The organization prohibits the direct connection of a classified,
+  description: 'The organization prohibits the direct connection of a classified,
     national security system to an external network without the use of [Assignment:
-    organization-defined boundary protection device]."'
+    organization-defined boundary protection device].'
 CA-3 (3):
   family: CA
   name: Unclassified Non-National Security System Connections
-  description: '"The organization prohibits the direct connection of an [Assignment:
+  description: 'The organization prohibits the direct connection of an [Assignment:
     organization-defined unclassified, non-national security system] to an external
     network without the use of [Assignment; organization-defined boundary protection
-    device]."'
+    device].'
 CA-3 (4):
   family: CA
   name: Connections To Public Networks
-  description: '"The organization prohibits the direct connection of an [Assignment:
-    organization-defined information system] to a public network."'
+  description: 'The organization prohibits the direct connection of an [Assignment:
+    organization-defined information system] to a public network.'
 CA-3 (5):
   family: CA
   name: Restrictions On External System Connections
-  description: '"The organization employs [Selection: allow-all, deny-by-exception;
+  description: 'The organization employs [Selection: allow-all, deny-by-exception;
     deny-all, permit-by-exception] policy for allowing [Assignment: organization-defined
-    information systems] to connect to external information systems."'
+    information systems] to connect to external information systems.'
 CA-4:
   family: CA
   name: Security Certification
@@ -1322,9 +1320,9 @@ CA-5:
 CA-5 (1):
   family: CA
   name: Automation Support For Accuracy / Currency
-  description: '"The organization employs automated mechanisms to help ensure that
-    the plan of action and milestones for the information system is accurate, up to
-    date, and readily available."'
+  description: The organization employs automated mechanisms to help ensure that the
+    plan of action and milestones for the information system is accurate, up to date,
+    and readily available.
 CA-6:
   family: CA
   name: Security Authorization
@@ -1348,20 +1346,20 @@ CA-7:
 CA-7 (1):
   family: CA
   name: Independent Assessment
-  description: '"The organization employs assessors or assessment teams with [Assignment:
+  description: 'The organization employs assessors or assessment teams with [Assignment:
     organization-defined level of independence] to monitor the security controls in
-    the information system on an ongoing basis."'
+    the information system on an ongoing basis.'
 CA-7 (2):
   family: CA
   name: Types Of Assessments
-  description: '"[Withdrawn: Incorporated into CA-2]."'
+  description: '[Withdrawn: Incorporated into CA-2].'
 CA-7 (3):
   family: CA
   name: Trend Analyses
-  description: '"The organization employs trend analyses to determine if security
-    control implementations, the frequency of continuous monitoring activities, and/or
-    the types of activities used in the continuous monitoring process need to be modified
-    based on empirical data."'
+  description: The organization employs trend analyses to determine if security control
+    implementations, the frequency of continuous monitoring activities, and/or the
+    types of activities used in the continuous monitoring process need to be modified
+    based on empirical data.
 CA-8:
   family: CA
   name: Penetration Testing
@@ -1371,14 +1369,14 @@ CA-8:
 CA-8 (1):
   family: CA
   name: Independent Penetration Agent Or Team
-  description: '"The organization employs an independent penetration agent or penetration
-    team to perform penetration testing on the information system or system components."'
+  description: The organization employs an independent penetration agent or penetration
+    team to perform penetration testing on the information system or system components.
 CA-8 (2):
   family: CA
   name: Red Team Exercises
-  description: '"The organization employs [Assignment: organization-defined red team
+  description: 'The organization employs [Assignment: organization-defined red team
     exercises] to simulate attempts by adversaries to compromise organizational information
-    systems in accordance with [Assignment: organization-defined rules of engagement]."'
+    systems in accordance with [Assignment: organization-defined rules of engagement].'
 CA-9:
   family: CA
   name: Internal System Connections
@@ -1389,8 +1387,8 @@ CA-9:
 CA-9 (1):
   family: CA
   name: Security Compliance Checks
-  description: '"The information system performs security compliance checks on constituent
-    system components prior to the establishment of the internal connection."'
+  description: The information system performs security compliance checks on constituent
+    system components prior to the establishment of the internal connection.
 CM-1:
   family: CM
   name: Configuration Management Policy And Procedures
@@ -1418,28 +1416,28 @@ CM-2 (1):
 CM-2 (2):
   family: CM
   name: Automation Support For Accuracy / Currency
-  description: '"The organization employs automated mechanisms to maintain an up-to-date,
+  description: The organization employs automated mechanisms to maintain an up-to-date,
     complete, accurate, and readily available baseline configuration of the information
-    system."'
+    system.
 CM-2 (3):
   family: CM
   name: Retention Of Previous Configurations
-  description: '"The organization retains [Assignment: organization-defined previous
-    versions of baseline configurations of the information system] to support rollback."'
+  description: 'The organization retains [Assignment: organization-defined previous
+    versions of baseline configurations of the information system] to support rollback.'
 CM-2 (4):
   family: CM
   name: Unauthorized Software
-  description: '"[Withdrawn: Incorporated into CM-7]."'
+  description: '[Withdrawn: Incorporated into CM-7].'
 CM-2 (5):
   family: CM
   name: Authorized Software
-  description: '"[Withdrawn: Incorporated into CM-7]."'
+  description: '[Withdrawn: Incorporated into CM-7].'
 CM-2 (6):
   family: CM
   name: Development And Test Environments
-  description: '"The organization maintains a baseline configuration for information
+  description: The organization maintains a baseline configuration for information
     system development and test environments that is managed separately from the operational
-    baseline configuration."'
+    baseline configuration.
 CM-2 (7):
   family: CM
   name: Configure Systems, Components, Or Devices For High-Risk Areas
@@ -1473,32 +1471,32 @@ CM-3 (1):
 CM-3 (2):
   family: CM
   name: Test / Validate / Document Changes
-  description: '"The organization tests, validates, and documents changes to the information
-    system before implementing the changes on the operational system."'
+  description: The organization tests, validates, and documents changes to the information
+    system before implementing the changes on the operational system.
 CM-3 (3):
   family: CM
   name: Automated Change Implementation
-  description: '"The organization employs automated mechanisms to implement changes
+  description: The organization employs automated mechanisms to implement changes
     to the current information system baseline and deploys the updated baseline across
-    the installed base."'
+    the installed base.
 CM-3 (4):
   family: CM
   name: Security Representative
-  description: '"The organization requires an information security representative
-    to be a member of the [Assignment: organization-defined configuration change control
-    element]."'
+  description: 'The organization requires an information security representative to
+    be a member of the [Assignment: organization-defined configuration change control
+    element].'
 CM-3 (5):
   family: CM
   name: Automated Security Response
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     security responses] automatically if baseline configurations are changed in an
-    unauthorized manner."'
+    unauthorized manner.'
 CM-3 (6):
   family: CM
   name: Cryptography Management
-  description: '"The organization ensures that cryptographic mechanisms used to provide
+  description: 'The organization ensures that cryptographic mechanisms used to provide
     [Assignment: organization-defined security safeguards] are under configuration
-    management."'
+    management.'
 CM-4:
   family: CM
   name: Security Impact Analysis
@@ -1507,17 +1505,17 @@ CM-4:
 CM-4 (1):
   family: CM
   name: Separate Test Environments
-  description: '"The organization analyzes changes to the information system in a
-    separate test environment before implementation in an operational environment,
-    looking for security impacts due to flaws, weaknesses, incompatibility, or intentional
-    malice."'
+  description: The organization analyzes changes to the information system in a separate
+    test environment before implementation in an operational environment, looking
+    for security impacts due to flaws, weaknesses, incompatibility, or intentional
+    malice.
 CM-4 (2):
   family: CM
   name: Verification Of Security Functions
-  description: '"The organization, after the information system is changed, checks
-    the security functions to verify that the functions are implemented correctly,
-    operating as intended, and producing the desired outcome with regard to meeting
-    the security requirements for the system."'
+  description: The organization, after the information system is changed, checks the
+    security functions to verify that the functions are implemented correctly, operating
+    as intended, and producing the desired outcome with regard to meeting the security
+    requirements for the system.
 CM-5:
   family: CM
   name: Access Restrictions For Change
@@ -1526,27 +1524,27 @@ CM-5:
 CM-5 (1):
   family: CM
   name: Automated Access Enforcement / Auditing
-  description: '"The information system enforces access restrictions and supports
-    auditing of the enforcement actions."'
+  description: The information system enforces access restrictions and supports auditing
+    of the enforcement actions.
 CM-5 (2):
   family: CM
   name: Review System Changes
-  description: '"The organization reviews information system changes [Assignment:
-    organization-defined frequency] and [Assignment: organization-defined circumstances]
-    to determine whether unauthorized changes have occurred."'
+  description: 'The organization reviews information system changes [Assignment: organization-defined
+    frequency] and [Assignment: organization-defined circumstances] to determine whether
+    unauthorized changes have occurred.'
 CM-5 (3):
   family: CM
   name: Signed Components
-  description: '"The information system prevents the installation of [Assignment:
-    organization-defined software and firmware components] without verification that
-    the component has been digitally signed using a certificate that is recognized
-    and approved by the organization."'
+  description: 'The information system prevents the installation of [Assignment: organization-defined
+    software and firmware components] without verification that the component has
+    been digitally signed using a certificate that is recognized and approved by the
+    organization.'
 CM-5 (4):
   family: CM
   name: Dual Authorization
-  description: '"The organization enforces dual authorization for implementing changes
+  description: 'The organization enforces dual authorization for implementing changes
     to [Assignment: organization-defined information system components and system-level
-    information]."'
+    information].'
 CM-5 (5):
   family: CM
   name: Limit Production / Operational Privileges
@@ -1557,12 +1555,12 @@ CM-5 (5):
 CM-5 (6):
   family: CM
   name: Limit Library Privileges
-  description: '"The organization limits privileges to change software resident within
-    software libraries."'
+  description: The organization limits privileges to change software resident within
+    software libraries.
 CM-5 (7):
   family: CM
   name: Automatic Implementation Of Security Safeguards
-  description: '"[Withdrawn: Incorporated into SI-7]."'
+  description: '[Withdrawn: Incorporated into SI-7].'
 CM-6:
   family: CM
   name: Configuration Settings
@@ -1575,23 +1573,23 @@ CM-6:
 CM-6 (1):
   family: CM
   name: Automated Central Management / Application / Verification
-  description: '"The organization employs automated mechanisms to centrally manage,
+  description: 'The organization employs automated mechanisms to centrally manage,
     apply, and verify configuration settings for [Assignment: organization-defined
-    information system components]."'
+    information system components].'
 CM-6 (2):
   family: CM
   name: Respond To Unauthorized Changes
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to respond to unauthorized changes to [Assignment: organization-defined
-    configuration settings]."'
+    configuration settings].'
 CM-6 (3):
   family: CM
   name: Unauthorized Change Detection
-  description: '"[Withdrawn: Incorporated into SI-7]."'
+  description: '[Withdrawn: Incorporated into SI-7].'
 CM-6 (4):
   family: CM
   name: Conformance Demonstration
-  description: '"[Withdrawn: Incorporated into CM-4]."'
+  description: '[Withdrawn: Incorporated into CM-4].'
 CM-7:
   family: CM
   name: Least Functionality
@@ -1609,15 +1607,15 @@ CM-7 (1):
 CM-7 (2):
   family: CM
   name: Prevent Program Execution
-  description: '"The information system prevents program execution in accordance with
+  description: 'The information system prevents program execution in accordance with
     [Selection (one or more): [Assignment: organization-defined policies regarding
     software program usage and restrictions]; rules authorizing the terms and conditions
-    of software program usage]."'
+    of software program usage].'
 CM-7 (3):
   family: CM
   name: Registration Compliance
-  description: '"The organization ensures compliance with [Assignment: organization-defined
-    registration requirements for functions, ports, protocols, and services]."'
+  description: 'The organization ensures compliance with [Assignment: organization-defined
+    registration requirements for functions, ports, protocols, and services].'
 CM-7 (4):
   family: CM
   name: Unauthorized Software / Blacklisting
@@ -1648,15 +1646,14 @@ CM-8:
 CM-8 (1):
   family: CM
   name: Updates During Installations / Removals
-  description: '"The organization updates the inventory of information system components
+  description: The organization updates the inventory of information system components
     as an integral part of component installations, removals, and information system
-    updates."'
+    updates.
 CM-8 (2):
   family: CM
   name: Automated Maintenance
-  description: '"The organization employs automated mechanisms to help maintain an
-    up-to-date, complete, accurate, and readily available inventory of information
-    system components."'
+  description: The organization employs automated mechanisms to help maintain an up-to-date,
+    complete, accurate, and readily available inventory of information system components.
 CM-8 (3):
   family: CM
   name: Automated Unauthorized Component Detection
@@ -1667,31 +1664,31 @@ CM-8 (3):
 CM-8 (4):
   family: CM
   name: Accountability Information
-  description: '"The organization includes in the information system component inventory
+  description: 'The organization includes in the information system component inventory
     information, a means for identifying by [Selection (one or more): name; position;
-    role], individuals responsible/accountable for administering those components."'
+    role], individuals responsible/accountable for administering those components.'
 CM-8 (5):
   family: CM
   name: No Duplicate Accounting Of Components
-  description: '"The organization verifies that all components within the authorization
+  description: The organization verifies that all components within the authorization
     boundary of the information system are not duplicated in other information system
-    component inventories."'
+    component inventories.
 CM-8 (6):
   family: CM
   name: Assessed Configurations / Approved Deviations
-  description: '"The organization includes assessed component configurations and any
+  description: The organization includes assessed component configurations and any
     approved deviations to current deployed configurations in the information system
-    component inventory."'
+    component inventory.
 CM-8 (7):
   family: CM
   name: Centralized Repository
-  description: '"The organization provides a centralized repository for the inventory
-    of information system components."'
+  description: The organization provides a centralized repository for the inventory
+    of information system components.
 CM-8 (8):
   family: CM
   name: Automated Location Tracking
-  description: '"The organization employs automated mechanisms to support tracking
-    of information system components by geographic location."'
+  description: The organization employs automated mechanisms to support tracking of
+    information system components by geographic location.
 CM-8 (9):
   family: CM
   name: Assignment Of Components To Systems
@@ -1711,9 +1708,9 @@ CM-9:
 CM-9 (1):
   family: CM
   name: Assignment Of Responsibility
-  description: '"The organization assigns responsibility for developing the configuration
+  description: The organization assigns responsibility for developing the configuration
     management process to organizational personnel that are not directly involved
-    in information system development."'
+    in information system development.
 CM-10:
   family: CM
   name: Software Usage Restrictions
@@ -1725,8 +1722,8 @@ CM-10:
 CM-10 (1):
   family: CM
   name: Open Source Software
-  description: '"The organization establishes the following restrictions on the use
-    of open source software: [Assignment: organization-defined restrictions]."'
+  description: 'The organization establishes the following restrictions on the use
+    of open source software: [Assignment: organization-defined restrictions].'
 CM-11:
   family: CM
   name: User-Installed Software
@@ -1738,13 +1735,13 @@ CM-11:
 CM-11 (1):
   family: CM
   name: Alerts For Unauthorized Installations
-  description: '"The information system alerts [Assignment: organization-defined personnel
-    or roles] when the unauthorized installation of software is detected."'
+  description: 'The information system alerts [Assignment: organization-defined personnel
+    or roles] when the unauthorized installation of software is detected.'
 CM-11 (2):
   family: CM
   name: Prohibit Installation Without Privileged Status
-  description: '"The information system prohibits user installation of software without
-    explicit privileged status."'
+  description: The information system prohibits user installation of software without
+    explicit privileged status.
 CP-1:
   family: CP
   name: Contingency Planning Policy And Procedures
@@ -1777,51 +1774,51 @@ CP-2:
 CP-2 (1):
   family: CP
   name: Coordinate With Related Plans
-  description: '"The organization coordinates contingency plan development with organizational
-    elements responsible for related plans."'
+  description: The organization coordinates contingency plan development with organizational
+    elements responsible for related plans.
 CP-2 (2):
   family: CP
   name: Capacity Planning
-  description: '"The organization conducts capacity planning so that necessary capacity
+  description: The organization conducts capacity planning so that necessary capacity
     for information processing, telecommunications, and environmental support exists
-    during contingency operations."'
+    during contingency operations.
 CP-2 (3):
   family: CP
   name: Resume Essential Missions / Business Functions
-  description: '"The organization plans for the resumption of essential missions and
+  description: 'The organization plans for the resumption of essential missions and
     business functions within [Assignment: organization-defined time period] of contingency
-    plan activation."'
+    plan activation.'
 CP-2 (4):
   family: CP
   name: Resume All Missions / Business Functions
-  description: '"The organization plans for the resumption of all missions and business
+  description: 'The organization plans for the resumption of all missions and business
     functions within [Assignment: organization-defined time period] of contingency
-    plan activation."'
+    plan activation.'
 CP-2 (5):
   family: CP
   name: Continue  Essential Missions / Business Functions
-  description: '"The organization plans for the continuance of essential missions
-    and business functions with little or no loss of operational continuity and sustains
+  description: The organization plans for the continuance of essential missions and
+    business functions with little or no loss of operational continuity and sustains
     that continuity until full information system restoration at primary processing
-    and/or storage sites."'
+    and/or storage sites.
 CP-2 (6):
   family: CP
   name: Alternate Processing / Storage Site
-  description: '"The organization plans for the transfer of essential missions and
-    business functions to alternate processing and/or storage sites with little or
-    no loss of operational continuity and sustains that continuity through information
-    system restoration to primary processing and/or storage sites."'
+  description: The organization plans for the transfer of essential missions and business
+    functions to alternate processing and/or storage sites with little or no loss
+    of operational continuity and sustains that continuity through information system
+    restoration to primary processing and/or storage sites.
 CP-2 (7):
   family: CP
   name: Coordinate  With External Service Providers
-  description: '"The organization coordinates its contingency plan with the contingency
+  description: The organization coordinates its contingency plan with the contingency
     plans of external service providers to ensure that contingency requirements can
-    be satisfied."'
+    be satisfied.
 CP-2 (8):
   family: CP
   name: Identify Critical Assets
-  description: '"The organization identifies critical information system assets supporting
-    essential missions and business functions."'
+  description: The organization identifies critical information system assets supporting
+    essential missions and business functions.
 CP-3:
   family: CP
   name: Contingency Training
@@ -1833,13 +1830,13 @@ CP-3:
 CP-3 (1):
   family: CP
   name: Simulated Events
-  description: '"The organization incorporates simulated events into contingency training
-    to facilitate effective response by personnel in crisis situations."'
+  description: The organization incorporates simulated events into contingency training
+    to facilitate effective response by personnel in crisis situations.
 CP-3 (2):
   family: CP
   name: Automated Training Environments
-  description: '"The organization employs automated mechanisms to provide a more thorough
-    and realistic contingency training environment."'
+  description: The organization employs automated mechanisms to provide a more thorough
+    and realistic contingency training environment.
 CP-4:
   family: CP
   name: Contingency Plan Testing
@@ -1851,8 +1848,8 @@ CP-4:
 CP-4 (1):
   family: CP
   name: Coordinate With Related Plans
-  description: '"The organization coordinates contingency plan testing with organizational
-    elements responsible for related plans."'
+  description: The organization coordinates contingency plan testing with organizational
+    elements responsible for related plans.
 CP-4 (2):
   family: CP
   name: Alternate Processing Site
@@ -1863,13 +1860,13 @@ CP-4 (2):
 CP-4 (3):
   family: CP
   name: Automated Testing
-  description: '"The organization employs automated mechanisms to more thoroughly
-    and effectively test the contingency plan."'
+  description: The organization employs automated mechanisms to more thoroughly and
+    effectively test the contingency plan.
 CP-4 (4):
   family: CP
   name: Full Recovery / Reconstitution
-  description: '"The organization includes a full recovery and reconstitution of the
-    information system to a known state as part of contingency plan testing."'
+  description: The organization includes a full recovery and reconstitution of the
+    information system to a known state as part of contingency plan testing.
 CP-5:
   family: CP
   name: Contingency Plan Update
@@ -1884,19 +1881,19 @@ CP-6:
 CP-6 (1):
   family: CP
   name: Separation From Primary Site
-  description: '"The organization identifies an alternate storage site that is separated
-    from the primary storage site to reduce susceptibility to the same threats."'
+  description: The organization identifies an alternate storage site that is separated
+    from the primary storage site to reduce susceptibility to the same threats.
 CP-6 (2):
   family: CP
   name: Recovery Time / Point Objectives
-  description: '"The organization configures the alternate storage site to facilitate
-    recovery operations in accordance with recovery time and recovery point objectives."'
+  description: The organization configures the alternate storage site to facilitate
+    recovery operations in accordance with recovery time and recovery point objectives.
 CP-6 (3):
   family: CP
   name: Accessibility
-  description: '"The organization identifies potential accessibility problems to the
+  description: The organization identifies potential accessibility problems to the
     alternate storage site in the event of an area-wide disruption or disaster and
-    outlines explicit mitigation actions."'
+    outlines explicit mitigation actions.
 CP-7:
   family: CP
   name: Alternate Processing Site
@@ -1908,36 +1905,35 @@ CP-7:
 CP-7 (1):
   family: CP
   name: Separation From Primary Site
-  description: '"The organization identifies an alternate processing site that is
-    separated from the primary processing site to reduce susceptibility to the same
-    threats."'
+  description: The organization identifies an alternate processing site that is separated
+    from the primary processing site to reduce susceptibility to the same threats.
 CP-7 (2):
   family: CP
   name: Accessibility
-  description: '"The organization identifies potential accessibility problems to the
+  description: The organization identifies potential accessibility problems to the
     alternate processing site in the event of an area-wide disruption or disaster
-    and outlines explicit mitigation actions."'
+    and outlines explicit mitigation actions.
 CP-7 (3):
   family: CP
   name: Priority Of Service
-  description: '"The organization develops alternate processing site agreements that
+  description: The organization develops alternate processing site agreements that
     contain priority-of-service provisions in accordance with organizational availability
-    requirements (including recovery time objectives)."'
+    requirements (including recovery time objectives).
 CP-7 (4):
   family: CP
   name: Preparation For Use
-  description: '"The organization prepares the alternate processing site so that the
+  description: The organization prepares the alternate processing site so that the
     site is ready to be used as the operational site supporting essential missions
-    and business functions."'
+    and business functions.
 CP-7 (5):
   family: CP
   name: Equivalent Information Security Safeguards
-  description: '"[Withdrawn: Incorporated into CP-7]."'
+  description: '[Withdrawn: Incorporated into CP-7].'
 CP-7 (6):
   family: CP
   name: Inability To Return To Primary Site
-  description: '"The organization plans and prepares for circumstances that preclude
-    returning to the primary processing site."'
+  description: The organization plans and prepares for circumstances that preclude
+    returning to the primary processing site.
 CP-8:
   family: CP
   name: Telecommunications Services
@@ -1957,15 +1953,15 @@ CP-8 (1):
 CP-8 (2):
   family: CP
   name: Single Points Of Failure
-  description: '"The organization obtains alternate telecommunications services to
-    reduce the likelihood of sharing a single point of failure with primary telecommunications
-    services."'
+  description: The organization obtains alternate telecommunications services to reduce
+    the likelihood of sharing a single point of failure with primary telecommunications
+    services.
 CP-8 (3):
   family: CP
   name: Separation Of Primary / Alternate Providers
-  description: '"The organization obtains alternate telecommunications services from
+  description: The organization obtains alternate telecommunications services from
     providers that are separated from primary service providers to reduce susceptibility
-    to the same threats."'
+    to the same threats.
 CP-8 (4):
   family: CP
   name: Provider Contingency Plan
@@ -1977,8 +1973,8 @@ CP-8 (4):
 CP-8 (5):
   family: CP
   name: Alternate Telecommunication Service Testing
-  description: '"The organization tests alternate telecommunication services [Assignment:
-    organization-defined frequency]."'
+  description: 'The organization tests alternate telecommunication services [Assignment:
+    organization-defined frequency].'
 CP-9:
   family: CP
   name: Information System Backup
@@ -1991,41 +1987,41 @@ CP-9:
 CP-9 (1):
   family: CP
   name: Testing For Reliability / Integrity
-  description: '"The organization tests backup information [Assignment: organization-defined
-    frequency] to verify media reliability and information integrity."'
+  description: 'The organization tests backup information [Assignment: organization-defined
+    frequency] to verify media reliability and information integrity.'
 CP-9 (2):
   family: CP
   name: Test Restoration Using Sampling
-  description: '"The organization uses a sample of backup information in the restoration
-    of selected information system functions as part of contingency plan testing."'
+  description: The organization uses a sample of backup information in the restoration
+    of selected information system functions as part of contingency plan testing.
 CP-9 (3):
   family: CP
   name: Separate Storage For Critical Information
-  description: '"The organization stores backup copies of [Assignment: organization-defined
+  description: 'The organization stores backup copies of [Assignment: organization-defined
     critical information system software and other security-related information] in
     a separate facility or in a fire-rated container that is not collocated with the
-    operational system."'
+    operational system.'
 CP-9 (4):
   family: CP
   name: Protection From Unauthorized Modification
-  description: '"[Withdrawn: Incorporated into CP-9]."'
+  description: '[Withdrawn: Incorporated into CP-9].'
 CP-9 (5):
   family: CP
   name: Transfer To Alternate Storage Site
-  description: '"The organization transfers information system backup information
-    to the alternate storage site [Assignment: organization-defined time period and
-    transfer rate consistent with the recovery time and recovery point objectives]."'
+  description: 'The organization transfers information system backup information to
+    the alternate storage site [Assignment: organization-defined time period and transfer
+    rate consistent with the recovery time and recovery point objectives].'
 CP-9 (6):
   family: CP
   name: Redundant Secondary System
-  description: '"The organization accomplishes information system backup by maintaining
+  description: The organization accomplishes information system backup by maintaining
     a redundant secondary system that is not collocated with the primary system and
-    that can be activated without loss of information or disruption to operations."'
+    that can be activated without loss of information or disruption to operations.
 CP-9 (7):
   family: CP
   name: Dual Authorization
-  description: '"The organization enforces dual authorization for the deletion or
-    destruction of [Assignment: organization-defined backup information]."'
+  description: 'The organization enforces dual authorization for the deletion or destruction
+    of [Assignment: organization-defined backup information].'
 CP-10:
   family: CP
   name: Information System Recovery And Reconstitution
@@ -2034,32 +2030,32 @@ CP-10:
 CP-10 (1):
   family: CP
   name: Contingency Plan Testing
-  description: '"[Withdrawn: Incorporated into CP-4]."'
+  description: '[Withdrawn: Incorporated into CP-4].'
 CP-10 (2):
   family: CP
   name: Transaction Recovery
-  description: '"The information system implements transaction recovery for systems
-    that are transaction-based."'
+  description: The information system implements transaction recovery for systems
+    that are transaction-based.
 CP-10 (3):
   family: CP
   name: Compensating Security Controls
-  description: '"[Withdrawn: Addressed through tailoring procedures]."'
+  description: '[Withdrawn: Addressed through tailoring procedures].'
 CP-10 (4):
   family: CP
   name: Restore Within Time Period
-  description: '"The organization provides the capability to restore information system
+  description: 'The organization provides the capability to restore information system
     components within [Assignment: organization-defined restoration time-periods]
     from configuration-controlled and integrity-protected information representing
-    a known, operational state for the components."'
+    a known, operational state for the components.'
 CP-10 (5):
   family: CP
   name: Failover Capability
-  description: '"[Withdrawn: Incorporated into SI-13]."'
+  description: '[Withdrawn: Incorporated into SI-13].'
 CP-10 (6):
   family: CP
   name: Component Protection
-  description: '"The organization protects backup and restoration hardware, firmware,
-    and software."'
+  description: The organization protects backup and restoration hardware, firmware,
+    and software.
 CP-11:
   family: CP
   name: Alternate Communications Protocols
@@ -2098,74 +2094,74 @@ IA-2:
 IA-2 (1):
   family: IA
   name: Network Access To Privileged Accounts
-  description: '"The information system implements multifactor authentication for
-    network access to privileged accounts."'
+  description: The information system implements multifactor authentication for network
+    access to privileged accounts.
 IA-2 (2):
   family: IA
   name: Network Access To Non-Privileged Accounts
-  description: '"The information system implements multifactor authentication for
-    network access to non-privileged accounts."'
+  description: The information system implements multifactor authentication for network
+    access to non-privileged accounts.
 IA-2 (3):
   family: IA
   name: Local Access To Privileged Accounts
-  description: '"The information system implements multifactor authentication for
-    local access to privileged accounts."'
+  description: The information system implements multifactor authentication for local
+    access to privileged accounts.
 IA-2 (4):
   family: IA
   name: Local Access To Non-Privileged Accounts
-  description: '"The information system implements multifactor authentication for
-    local access to non-privileged accounts."'
+  description: The information system implements multifactor authentication for local
+    access to non-privileged accounts.
 IA-2 (5):
   family: IA
   name: Group Authentication
-  description: '"The organization requires individuals to be authenticated with an
-    individual authenticator when a group authenticator is employed."'
+  description: The organization requires individuals to be authenticated with an individual
+    authenticator when a group authenticator is employed.
 IA-2 (6):
   family: IA
   name: Network Access To Privileged Accounts - Separate Device
-  description: '"The information system implements multifactor authentication for
-    network access to privileged accounts such that one of the factors is provided
-    by a device separate from the system gaining access and the device meets [Assignment:
-    organization-defined strength of mechanism requirements]."'
+  description: 'The information system implements multifactor authentication for network
+    access to privileged accounts such that one of the factors is provided by a device
+    separate from the system gaining access and the device meets [Assignment: organization-defined
+    strength of mechanism requirements].'
 IA-2 (7):
   family: IA
   name: Network Access To Non-Privileged Accounts - Separate Device
-  description: '"The information system implements multifactor authentication for
-    network access to non-privileged accounts such that one of the factors is provided
-    by a device separate from the system gaining access and the device meets [Assignment:
-    organization-defined strength of mechanism requirements]."'
+  description: 'The information system implements multifactor authentication for network
+    access to non-privileged accounts such that one of the factors is provided by
+    a device separate from the system gaining access and the device meets [Assignment:
+    organization-defined strength of mechanism requirements].'
 IA-2 (8):
   family: IA
   name: Network Access To Privileged Accounts - Replay Resistant
-  description: '"The information system implements replay-resistant authentication
-    mechanisms for network access to privileged accounts."'
+  description: The information system implements replay-resistant authentication mechanisms
+    for network access to privileged accounts.
 IA-2 (9):
   family: IA
   name: Network Access To Non-Privileged Accounts - Replay Resistant
-  description: '"The information system implements replay-resistant authentication
-    mechanisms for network access to non-privileged accounts."'
+  description: The information system implements replay-resistant authentication mechanisms
+    for network access to non-privileged accounts.
 IA-2 (10):
   family: IA
   name: Single Sign-On
-  description: '"The information system provides a single sign-on capability for [Assignment:
-    organization-defined information system accounts and services]."'
+  description: 'The information system provides a single sign-on capability for [Assignment:
+    organization-defined information system accounts and services].'
 IA-2 (11):
   family: IA
   name: Remote Access  - Separate Device
-  description: '"The information system implements multifactor authentication for
-    remote access to privileged and non-privileged accounts such that one of the factors
+  description: 'The information system implements multifactor authentication for remote
+    access to privileged and non-privileged accounts such that one of the factors
     is provided by a device separate from the system gaining access and the device
-    meets [Assignment: organization-defined strength of mechanism requirements]."'
+    meets [Assignment: organization-defined strength of mechanism requirements].'
 IA-2 (12):
   family: IA
   name: Acceptance Of Piv Credentials
-  description: '"The information system accepts and electronically verifies Personal
-    Identity Verification (PIV) credentials."'
+  description: The information system accepts and electronically verifies Personal
+    Identity Verification (PIV) credentials.
 IA-2 (13):
   family: IA
   name: Out-Of-Band Authentication
-  description: '"The information system implements [Assignment: organization-defined
-    out-of-band authentication] under [Assignment: organization-defined conditions]."'
+  description: 'The information system implements [Assignment: organization-defined
+    out-of-band authentication] under [Assignment: organization-defined conditions].'
 IA-3:
   family: IA
   name: Device Identification And Authentication
@@ -2175,14 +2171,14 @@ IA-3:
 IA-3 (1):
   family: IA
   name: Cryptographic Bidirectional Authentication
-  description: '"The information system authenticates [Assignment: organization-defined
+  description: 'The information system authenticates [Assignment: organization-defined
     specific devices and/or types of devices] before establishing [Selection (one
     or more): local; remote; network] connection using bidirectional authentication
-    that is cryptographically based."'
+    that is cryptographically based.'
 IA-3 (2):
   family: IA
   name: Cryptographic Bidirectional Network Authentication
-  description: '"[Withdrawn: Incorporated into IA-3 (1)]."'
+  description: '[Withdrawn: Incorporated into IA-3 (1)].'
 IA-3 (3):
   family: IA
   name: Dynamic Address Allocation
@@ -2193,9 +2189,9 @@ IA-3 (3):
 IA-3 (4):
   family: IA
   name: Device Attestation
-  description: '"The organization ensures that device identification and authentication
+  description: 'The organization ensures that device identification and authentication
     based on attestation is handled by [Assignment: organization-defined configuration
-    management process]."'
+    management process].'
 IA-4:
   family: IA
   name: Identifier Management
@@ -2209,40 +2205,39 @@ IA-4:
 IA-4 (1):
   family: IA
   name: Prohibit Account Identifiers As Public Identifiers
-  description: '"The organization prohibits the use of information system account
-    identifiers that are the same as public identifiers for individual electronic
-    mail accounts."'
+  description: The organization prohibits the use of information system account identifiers
+    that are the same as public identifiers for individual electronic mail accounts.
 IA-4 (2):
   family: IA
   name: Supervisor Authorization
-  description: '"The organization requires that the registration process to receive
-    an individual identifier includes supervisor authorization."'
+  description: The organization requires that the registration process to receive
+    an individual identifier includes supervisor authorization.
 IA-4 (3):
   family: IA
   name: Multiple Forms Of Certification
-  description: '"The organization requires multiple forms of certification of individual
-    identification be presented to the registration authority."'
+  description: The organization requires multiple forms of certification of individual
+    identification be presented to the registration authority.
 IA-4 (4):
   family: IA
   name: Identify User Status
-  description: '"The organization manages individual identifiers by uniquely identifying
+  description: 'The organization manages individual identifiers by uniquely identifying
     each individual as [Assignment: organization-defined characteristic identifying
-    individual status]."'
+    individual status].'
 IA-4 (5):
   family: IA
   name: Dynamic Management
-  description: '"The information system dynamically manages identifiers."'
+  description: The information system dynamically manages identifiers.
 IA-4 (6):
   family: IA
   name: Cross-Organization Management
-  description: '"The organization coordinates with [Assignment: organization-defined
-    external organizations] for cross-organization management of identifiers."'
+  description: 'The organization coordinates with [Assignment: organization-defined
+    external organizations] for cross-organization management of identifiers.'
 IA-4 (7):
   family: IA
   name: In-Person Registration
-  description: '"The organization requires that the registration process to receive
+  description: The organization requires that the registration process to receive
     an individual identifier be conducted in person before a designated registration
-    authority."'
+    authority.
 IA-5:
   family: IA
   name: Authenticator Management
@@ -2281,75 +2276,74 @@ IA-5 (2):
 IA-5 (3):
   family: IA
   name: In-Person Or Trusted Third-Party Registration
-  description: '"The organization requires that the registration process to receive
+  description: 'The organization requires that the registration process to receive
     [Assignment: organization-defined types of and/or specific authenticators] be
     conducted [Selection: in person; by a trusted third party] before [Assignment:
     organization-defined registration authority] with authorization by [Assignment:
-    organization-defined personnel or roles]."'
+    organization-defined personnel or roles].'
 IA-5 (4):
   family: IA
   name: Automated Support  For Password Strength Determination
-  description: '"The organization employs automated tools to determine if password
+  description: 'The organization employs automated tools to determine if password
     authenticators are sufficiently strong to satisfy [Assignment: organization-defined
-    requirements]."'
+    requirements].'
 IA-5 (5):
   family: IA
   name: Change Authenticators Prior To Delivery
-  description: '"The organization requires developers/installers of information system
+  description: The organization requires developers/installers of information system
     components to provide unique authenticators or change default authenticators prior
-    to delivery/installation."'
+    to delivery/installation.
 IA-5 (6):
   family: IA
   name: Protection Of Authenticators
-  description: '"The organization protects authenticators commensurate with the security
-    category of the information to which use of the authenticator permits access."'
+  description: The organization protects authenticators commensurate with the security
+    category of the information to which use of the authenticator permits access.
 IA-5 (7):
   family: IA
   name: No Embedded Unencrypted Static Authenticators
-  description: '"The organization ensures that unencrypted static authenticators are
-    not embedded in applications or access scripts or stored on function keys."'
+  description: The organization ensures that unencrypted static authenticators are
+    not embedded in applications or access scripts or stored on function keys.
 IA-5 (8):
   family: IA
   name: Multiple Information System Accounts
-  description: '"The organization implements [Assignment: organization-defined security
+  description: 'The organization implements [Assignment: organization-defined security
     safeguards] to manage the risk of compromise due to individuals having accounts
-    on multiple information systems."'
+    on multiple information systems.'
 IA-5 (9):
   family: IA
   name: Cross-Organization Credential Management
-  description: '"The organization coordinates with [Assignment: organization-defined
-    external organizations] for cross-organization management of credentials."'
+  description: 'The organization coordinates with [Assignment: organization-defined
+    external organizations] for cross-organization management of credentials.'
 IA-5 (10):
   family: IA
   name: Dynamic Credential Association
-  description: '"The information system dynamically provisions identities."'
+  description: The information system dynamically provisions identities.
 IA-5 (11):
   family: IA
   name: Hardware Token-Based Authentication
-  description: '"The information system, for hardware token-based authentication,
-    employs mechanisms that satisfy [Assignment: organization-defined token quality
-    requirements]."'
+  description: 'The information system, for hardware token-based authentication, employs
+    mechanisms that satisfy [Assignment: organization-defined token quality requirements].'
 IA-5 (12):
   family: IA
   name: Biometric-Based Authentication
-  description: '"The information system, for biometric-based authentication, employs
-    mechanisms that satisfy [Assignment: organization-defined biometric quality requirements]."'
+  description: 'The information system, for biometric-based authentication, employs
+    mechanisms that satisfy [Assignment: organization-defined biometric quality requirements].'
 IA-5 (13):
   family: IA
   name: Expiration Of Cached Authenticators
-  description: '"The information system prohibits the use of cached authenticators
-    after [Assignment: organization-defined time period]."'
+  description: 'The information system prohibits the use of cached authenticators
+    after [Assignment: organization-defined time period].'
 IA-5 (14):
   family: IA
   name: Managing Content Of Pki Trust Stores
-  description: '"The organization, for PKI-based authentication, employs a deliberate
+  description: The organization, for PKI-based authentication, employs a deliberate
     organization-wide methodology for managing the content of PKI trust stores installed
-    across all platforms including networks, operating systems, browsers, and applications."'
+    across all platforms including networks, operating systems, browsers, and applications.
 IA-5 (15):
   family: IA
   name: Ficam-Approved Products And Services
-  description: '"The organization uses only FICAM-approved path discovery and validation
-    products and services."'
+  description: The organization uses only FICAM-approved path discovery and validation
+    products and services.
 IA-6:
   family: IA
   name: Authenticator Feedback
@@ -2371,27 +2365,27 @@ IA-8:
 IA-8 (1):
   family: IA
   name: Acceptance Of Piv Credentials From Other Agencies
-  description: '"The information system accepts and electronically verifies Personal
-    Identity Verification (PIV) credentials from other federal agencies."'
+  description: The information system accepts and electronically verifies Personal
+    Identity Verification (PIV) credentials from other federal agencies.
 IA-8 (2):
   family: IA
   name: Acceptance Of Third-Party Credentials
-  description: '"The information system accepts only FICAM-approved third-party credentials."'
+  description: The information system accepts only FICAM-approved third-party credentials.
 IA-8 (3):
   family: IA
   name: Use Of Ficam-Approved Products
-  description: '"The organization employs only FICAM-approved information system components
+  description: 'The organization employs only FICAM-approved information system components
     in [Assignment: organization-defined information systems] to accept third-party
-    credentials."'
+    credentials.'
 IA-8 (4):
   family: IA
   name: Use Of Ficam-Issued Profiles
-  description: '"The information system conforms to FICAM-issued profiles."'
+  description: The information system conforms to FICAM-issued profiles.
 IA-8 (5):
   family: IA
   name: Acceptance Of Piv-I Credentials
-  description: '"The information system accepts and electronically verifies Personal
-    Identity Verification-I (PIV-I) credentials."'
+  description: The information system accepts and electronically verifies Personal
+    Identity Verification-I (PIV-I) credentials.
 IA-9:
   family: IA
   name: Service Identification And Authentication
@@ -2401,14 +2395,14 @@ IA-9:
 IA-9 (1):
   family: IA
   name: Information Exchange
-  description: '"The organization ensures that service providers receive, validate,
-    and transmit identification and authentication information."'
+  description: The organization ensures that service providers receive, validate,
+    and transmit identification and authentication information.
 IA-9 (2):
   family: IA
   name: Transmission Of Decisions
-  description: '"The organization ensures that identification and authentication decisions
+  description: 'The organization ensures that identification and authentication decisions
     are transmitted between [Assignment: organization-defined services] consistent
-    with organizational policies."'
+    with organizational policies.'
 IA-10:
   family: IA
   name: Adaptive Identification And Authentication
@@ -2443,13 +2437,13 @@ IR-2:
 IR-2 (1):
   family: IR
   name: Simulated Events
-  description: '"The organization incorporates simulated events into incident response
-    training to facilitate effective response by personnel in crisis situations."'
+  description: The organization incorporates simulated events into incident response
+    training to facilitate effective response by personnel in crisis situations.
 IR-2 (2):
   family: IR
   name: Automated Training Environments
-  description: '"The organization employs automated mechanisms to provide a more thorough
-    and realistic incident response training environment."'
+  description: The organization employs automated mechanisms to provide a more thorough
+    and realistic incident response training environment.
 IR-3:
   family: IR
   name: Incident Response Testing
@@ -2459,13 +2453,13 @@ IR-3:
 IR-3 (1):
   family: IR
   name: Automated Testing
-  description: '"The organization employs automated mechanisms to more thoroughly
-    and effectively test the incident response capability."'
+  description: The organization employs automated mechanisms to more thoroughly and
+    effectively test the incident response capability.
 IR-3 (2):
   family: IR
   name: Coordination With Related Plans
-  description: '"The organization coordinates incident response testing with organizational
-    elements responsible for related plans."'
+  description: The organization coordinates incident response testing with organizational
+    elements responsible for related plans.
 IR-4:
   family: IR
   name: Incident Handling
@@ -2477,61 +2471,61 @@ IR-4:
 IR-4 (1):
   family: IR
   name: Automated Incident Handling Processes
-  description: '"The organization employs automated mechanisms to support the incident
-    handling process."'
+  description: The organization employs automated mechanisms to support the incident
+    handling process.
 IR-4 (2):
   family: IR
   name: Dynamic Reconfiguration
-  description: '"The organization includes dynamic reconfiguration of [Assignment:
+  description: 'The organization includes dynamic reconfiguration of [Assignment:
     organization-defined information system components] as part of the incident response
-    capability."'
+    capability.'
 IR-4 (3):
   family: IR
   name: Continuity Of Operations
-  description: '"The organization identifies [Assignment: organization-defined classes
+  description: 'The organization identifies [Assignment: organization-defined classes
     of incidents] and [Assignment: organization-defined actions to take in response
     to classes of incidents] to ensure continuation of organizational missions and
-    business functions."'
+    business functions.'
 IR-4 (4):
   family: IR
   name: Information Correlation
-  description: '"The organization correlates incident information and individual incident
+  description: The organization correlates incident information and individual incident
     responses to achieve an organization-wide perspective on incident awareness and
-    response."'
+    response.
 IR-4 (5):
   family: IR
   name: Automatic Disabling Of Information System
-  description: '"The organization implements a configurable capability to automatically
+  description: 'The organization implements a configurable capability to automatically
     disable the information system if [Assignment: organization-defined security violations]
-    are detected."'
+    are detected.'
 IR-4 (6):
   family: IR
   name: Insider Threats - Specific Capabilities
-  description: '"The organization implements incident handling capability for insider
-    threats."'
+  description: The organization implements incident handling capability for insider
+    threats.
 IR-4 (7):
   family: IR
   name: Insider Threats - Intra-Organization Coordination
-  description: '"The organization coordinates incident handling capability for insider
+  description: 'The organization coordinates incident handling capability for insider
     threats across [Assignment: organization-defined components or elements of the
-    organization]."'
+    organization].'
 IR-4 (8):
   family: IR
   name: Correlation With External Organizations
-  description: '"The organization coordinates with [Assignment: organization-defined
+  description: 'The organization coordinates with [Assignment: organization-defined
     external organizations] to correlate and share [Assignment: organization-defined
     incident information] to achieve a cross-organization perspective on incident
-    awareness and more effective incident responses."'
+    awareness and more effective incident responses.'
 IR-4 (9):
   family: IR
   name: Dynamic Response Capability
-  description: '"The organization employs [Assignment: organization-defined dynamic
-    response capabilities] to effectively respond to security incidents."'
+  description: 'The organization employs [Assignment: organization-defined dynamic
+    response capabilities] to effectively respond to security incidents.'
 IR-4 (10):
   family: IR
   name: Supply Chain Coordination
-  description: '"The organization coordinates incident handling activities involving
-    supply chain events with other organizations involved in the supply chain."'
+  description: The organization coordinates incident handling activities involving
+    supply chain events with other organizations involved in the supply chain.
 IR-5:
   family: IR
   name: Incident Monitoring
@@ -2540,8 +2534,8 @@ IR-5:
 IR-5 (1):
   family: IR
   name: Automated Tracking / Data Collection / Analysis
-  description: '"The organization employs automated mechanisms to assist in the tracking
-    of security incidents and in the collection and analysis of incident information."'
+  description: The organization employs automated mechanisms to assist in the tracking
+    of security incidents and in the collection and analysis of incident information.
 IR-6:
   family: IR
   name: Incident Reporting
@@ -2552,20 +2546,20 @@ IR-6:
 IR-6 (1):
   family: IR
   name: Automated Reporting
-  description: '"The organization employs automated mechanisms to assist in the reporting
-    of security incidents."'
+  description: The organization employs automated mechanisms to assist in the reporting
+    of security incidents.
 IR-6 (2):
   family: IR
   name: Vulnerabilities Related To Incidents
-  description: '"The organization reports information system vulnerabilities associated
+  description: 'The organization reports information system vulnerabilities associated
     with reported security incidents to [Assignment: organization-defined personnel
-    or roles]."'
+    or roles].'
 IR-6 (3):
   family: IR
   name: Coordination With Supply Chain
-  description: '"The organization provides security incident information to other
-    organizations involved in the supply chain for information systems or information
-    system components related to the incident."'
+  description: The organization provides security incident information to other organizations
+    involved in the supply chain for information systems or information system components
+    related to the incident.
 IR-7:
   family: IR
   name: Incident Response Assistance
@@ -2576,8 +2570,8 @@ IR-7:
 IR-7 (1):
   family: IR
   name: Automation Support For Availability Of Information / Support
-  description: '"The organization employs automated mechanisms to increase the availability
-    of incident response-related information and support."'
+  description: The organization employs automated mechanisms to increase the availability
+    of incident response-related information and support.
 IR-7 (2):
   family: IR
   name: Coordination With External Providers
@@ -2618,25 +2612,25 @@ IR-9:
 IR-9 (1):
   family: IR
   name: Responsible Personnel
-  description: '"The organization assigns [Assignment: organization-defined personnel
-    or roles] with responsibility for responding to information spills."'
+  description: 'The organization assigns [Assignment: organization-defined personnel
+    or roles] with responsibility for responding to information spills.'
 IR-9 (2):
   family: IR
   name: Training
-  description: '"The organization provides information spillage response training
-    [Assignment: organization-defined frequency]."'
+  description: 'The organization provides information spillage response training [Assignment:
+    organization-defined frequency].'
 IR-9 (3):
   family: IR
   name: Post-Spill Operations
-  description: '"The organization implements [Assignment: organization-defined procedures]
+  description: 'The organization implements [Assignment: organization-defined procedures]
     to ensure that organizational personnel impacted by information spills can continue
     to carry out assigned tasks while contaminated systems are undergoing corrective
-    actions."'
+    actions.'
 IR-9 (4):
   family: IR
   name: Exposure To Unauthorized Personnel
-  description: '"The organization employs [Assignment: organization-defined security
-    safeguards] for personnel exposed to information not within assigned access authorizations."'
+  description: 'The organization employs [Assignment: organization-defined security
+    safeguards] for personnel exposed to information not within assigned access authorizations.'
 IR-10:
   family: IR
   name: Integrated Information Security Analysis Team
@@ -2667,7 +2661,7 @@ MA-2:
 MA-2 (1):
   family: MA
   name: Record Content
-  description: '"[Withdrawn: Incorporated into MA-2]."'
+  description: '[Withdrawn: Incorporated into MA-2].'
 MA-2 (2):
   family: MA
   name: Automated Maintenance Activities
@@ -2683,13 +2677,13 @@ MA-3:
 MA-3 (1):
   family: MA
   name: Inspect Tools
-  description: '"The organization inspects the maintenance tools carried into a facility
-    by maintenance personnel for improper or unauthorized modifications."'
+  description: The organization inspects the maintenance tools carried into a facility
+    by maintenance personnel for improper or unauthorized modifications.
 MA-3 (2):
   family: MA
   name: Inspect Media
-  description: '"The organization checks media containing diagnostic and test programs
-    for malicious code before the media are used in the information system."'
+  description: The organization checks media containing diagnostic and test programs
+    for malicious code before the media are used in the information system.
 MA-3 (3):
   family: MA
   name: Prevent Unauthorized Removal
@@ -2702,8 +2696,8 @@ MA-3 (3):
 MA-3 (4):
   family: MA
   name: Restricted Tool Use
-  description: '"The information system restricts the use of maintenance tools to
-    authorized personnel only."'
+  description: The information system restricts the use of maintenance tools to authorized
+    personnel only.
 MA-4:
   family: MA
   name: Nonlocal Maintenance
@@ -2724,9 +2718,9 @@ MA-4 (1):
 MA-4 (2):
   family: MA
   name: Document Nonlocal Maintenance
-  description: '"The organization documents in the security plan for the information
+  description: The organization documents in the security plan for the information
     system, the policies and procedures for the establishment and use of nonlocal
-    maintenance and diagnostic connections."'
+    maintenance and diagnostic connections.
 MA-4 (3):
   family: MA
   name: Comparable Security / Sanitization
@@ -2753,13 +2747,13 @@ MA-4 (5):
 MA-4 (6):
   family: MA
   name: Cryptographic Protection
-  description: '"The information system implements cryptographic mechanisms to protect
-    the integrity and confidentiality of nonlocal maintenance and diagnostic communications."'
+  description: The information system implements cryptographic mechanisms to protect
+    the integrity and confidentiality of nonlocal maintenance and diagnostic communications.
 MA-4 (7):
   family: MA
   name: Remote Disconnect Verification
-  description: '"The information system implements remote disconnect verification
-    at the termination of nonlocal maintenance and diagnostic sessions."'
+  description: The information system implements remote disconnect verification at
+    the termination of nonlocal maintenance and diagnostic sessions.
 MA-5:
   family: MA
   name: Maintenance Personnel
@@ -2780,17 +2774,17 @@ MA-5 (1):
 MA-5 (2):
   family: MA
   name: Security Clearances For Classified Systems
-  description: '"The organization ensures that personnel performing maintenance and
+  description: The organization ensures that personnel performing maintenance and
     diagnostic activities on an information system processing, storing, or transmitting
     classified information possess security clearances and formal access approvals
     for at least the highest classification level and for all compartments of information
-    on the system."'
+    on the system.
 MA-5 (3):
   family: MA
   name: Citizenship Requirements For Classified Systems
-  description: '"The organization ensures that personnel performing maintenance and
+  description: The organization ensures that personnel performing maintenance and
     diagnostic activities on an information system processing, storing, or transmitting
-    classified information are U.S. citizens."'
+    classified information are U.S. citizens.
 MA-5 (4):
   family: MA
   name: Foreign Nationals
@@ -2801,9 +2795,9 @@ MA-5 (4):
 MA-5 (5):
   family: MA
   name: Nonsystem-Related Maintenance
-  description: '"The organization ensures that non-escorted personnel performing maintenance
+  description: The organization ensures that non-escorted personnel performing maintenance
     activities not directly associated with the information system but in the physical
-    proximity of the system, have required access authorizations."'
+    proximity of the system, have required access authorizations.
 MA-6:
   family: MA
   name: Timely Maintenance
@@ -2813,20 +2807,18 @@ MA-6:
 MA-6 (1):
   family: MA
   name: Preventive Maintenance
-  description: '"The organization performs preventive maintenance on [Assignment:
-    organization-defined information system components] at [Assignment: organization-defined
-    time intervals]."'
+  description: 'The organization performs preventive maintenance on [Assignment: organization-defined
+    information system components] at [Assignment: organization-defined time intervals].'
 MA-6 (2):
   family: MA
   name: Predictive Maintenance
-  description: '"The organization performs predictive maintenance on [Assignment:
-    organization-defined information system components] at [Assignment: organization-defined
-    time intervals]."'
+  description: 'The organization performs predictive maintenance on [Assignment: organization-defined
+    information system components] at [Assignment: organization-defined time intervals].'
 MA-6 (3):
   family: MA
   name: Automated Support For Predictive Maintenance
-  description: '"The organization employs automated mechanisms to transfer predictive
-    maintenance data to a computerized maintenance management system."'
+  description: The organization employs automated mechanisms to transfer predictive
+    maintenance data to a computerized maintenance management system.
 MP-1:
   family: MP
   name: Media Protection Policy And Procedures
@@ -2847,11 +2839,11 @@ MP-2:
 MP-2 (1):
   family: MP
   name: Automated Restricted Access
-  description: '"[Withdrawn: Incorporated into MP-4 (2)]."'
+  description: '[Withdrawn: Incorporated into MP-4 (2)].'
 MP-2 (2):
   family: MP
   name: Cryptographic Protection
-  description: '"[Withdrawn: Incorporated into SC-28 (1)]."'
+  description: '[Withdrawn: Incorporated into SC-28 (1)].'
 MP-3:
   family: MP
   name: Media Marking
@@ -2869,12 +2861,12 @@ MP-4:
 MP-4 (1):
   family: MP
   name: Cryptographic Protection
-  description: '"[Withdrawn: Incorporated into SC-28 (1)]."'
+  description: '[Withdrawn: Incorporated into SC-28 (1)].'
 MP-4 (2):
   family: MP
   name: Automated Restricted Access
-  description: '"The organization employs automated mechanisms to restrict access
-    to media storage areas and to audit access attempts and access granted."'
+  description: The organization employs automated mechanisms to restrict access to
+    media storage areas and to audit access attempts and access granted.
 MP-5:
   family: MP
   name: Media Transport
@@ -2887,22 +2879,22 @@ MP-5:
 MP-5 (1):
   family: MP
   name: Protection Outside Of Controlled Areas
-  description: '"[Withdrawn: Incorporated into MP-5]."'
+  description: '[Withdrawn: Incorporated into MP-5].'
 MP-5 (2):
   family: MP
   name: Documentation Of Activities
-  description: '"[Withdrawn: Incorporated into MP-5]."'
+  description: '[Withdrawn: Incorporated into MP-5].'
 MP-5 (3):
   family: MP
   name: Custodians
-  description: '"The organization employs an identified custodian during transport
-    of information system media outside of controlled areas."'
+  description: The organization employs an identified custodian during transport of
+    information system media outside of controlled areas.
 MP-5 (4):
   family: MP
   name: Cryptographic Protection
-  description: '"The information system implements cryptographic mechanisms to protect
+  description: The information system implements cryptographic mechanisms to protect
     the confidentiality and integrity of information stored on digital media during
-    transport outside of controlled areas."'
+    transport outside of controlled areas.
 MP-6:
   family: MP
   name: Media Sanitization
@@ -2913,45 +2905,45 @@ MP-6:
 MP-6 (1):
   family: MP
   name: Review / Approve / Track / Document / Verify
-  description: '"The organization reviews, approves, tracks, documents, and verifies
-    media sanitization and disposal actions."'
+  description: The organization reviews, approves, tracks, documents, and verifies
+    media sanitization and disposal actions.
 MP-6 (2):
   family: MP
   name: Equipment Testing
-  description: '"The organization tests sanitization equipment and procedures [Assignment:
+  description: 'The organization tests sanitization equipment and procedures [Assignment:
     organization-defined frequency] to verify that the intended sanitization is being
-    achieved."'
+    achieved.'
 MP-6 (3):
   family: MP
   name: Nondestructive Techniques
-  description: '"The organization applies nondestructive sanitization techniques to
+  description: 'The organization applies nondestructive sanitization techniques to
     portable storage devices prior to connecting such devices to the information system
     under the following circumstances: [Assignment: organization-defined circumstances
-    requiring sanitization of portable storage devices]."'
+    requiring sanitization of portable storage devices].'
 MP-6 (4):
   family: MP
   name: Controlled Unclassified Information
-  description: '"[Withdrawn: Incorporated into MP-6]."'
+  description: '[Withdrawn: Incorporated into MP-6].'
 MP-6 (5):
   family: MP
   name: Classified Information
-  description: '"[Withdrawn: Incorporated into MP-6]."'
+  description: '[Withdrawn: Incorporated into MP-6].'
 MP-6 (6):
   family: MP
   name: Media Destruction
-  description: '"[Withdrawn: Incorporated into MP-6]."'
+  description: '[Withdrawn: Incorporated into MP-6].'
 MP-6 (7):
   family: MP
   name: Dual Authorization
-  description: '"The organization enforces dual authorization for the sanitization
-    of [Assignment: organization-defined information system media]."'
+  description: 'The organization enforces dual authorization for the sanitization
+    of [Assignment: organization-defined information system media].'
 MP-6 (8):
   family: MP
   name: Remote Purging / Wiping Of Information
-  description: '"The organization provides the capability to purge/wipe information
+  description: 'The organization provides the capability to purge/wipe information
     from [Assignment: organization-defined information systems, system components,
     or devices] either remotely or under the following conditions: [Assignment: organization-defined
-    conditions]."'
+    conditions].'
 MP-7:
   family: MP
   name: Media Use
@@ -2962,13 +2954,13 @@ MP-7:
 MP-7 (1):
   family: MP
   name: Prohibit Use Without Owner
-  description: '"The organization prohibits the use of portable storage devices in
-    organizational information systems when such devices have no identifiable owner."'
+  description: The organization prohibits the use of portable storage devices in organizational
+    information systems when such devices have no identifiable owner.
 MP-7 (2):
   family: MP
   name: Prohibit Use Of Sanitization-Resistant Media
-  description: '"The organization prohibits the use of sanitization-resistant media
-    in organizational information systems."'
+  description: The organization prohibits the use of sanitization-resistant media
+    in organizational information systems.
 MP-8:
   family: MP
   name: Media Downgrading
@@ -2981,26 +2973,26 @@ MP-8:
 MP-8 (1):
   family: MP
   name: Documentation Of Process
-  description: '"The organization documents information system media downgrading actions."'
+  description: The organization documents information system media downgrading actions.
 MP-8 (2):
   family: MP
   name: Equipment Testing
-  description: '"The organization employs [Assignment: organization-defined tests]
+  description: 'The organization employs [Assignment: organization-defined tests]
     of downgrading equipment and procedures to verify correct performance [Assignment:
-    organization-defined frequency]."'
+    organization-defined frequency].'
 MP-8 (3):
   family: MP
   name: Controlled Unclassified Information
-  description: '"The organization downgrades information system media containing [Assignment:
+  description: 'The organization downgrades information system media containing [Assignment:
     organization-defined Controlled Unclassified Information (CUI)] prior to public
     release in accordance with applicable federal and organizational standards and
-    policies."'
+    policies.'
 MP-8 (4):
   family: MP
   name: Classified Information
-  description: '"The organization downgrades information system media containing classified
+  description: The organization downgrades information system media containing classified
     information prior to release to individuals without required access authorizations
-    in accordance with NSA standards and policies."'
+    in accordance with NSA standards and policies.
 PE-1:
   family: PE
   name: Physical And Environmental Protection Policy And Procedures
@@ -3024,22 +3016,22 @@ PE-2:
 PE-2 (1):
   family: PE
   name: Access By Position / Role
-  description: '"The organization authorizes physical access to the facility where
-    the information system resides based on position or role."'
+  description: The organization authorizes physical access to the facility where the
+    information system resides based on position or role.
 PE-2 (2):
   family: PE
   name: Two Forms Of Identification
-  description: '"The organization requires two forms of identification from [Assignment:
+  description: 'The organization requires two forms of identification from [Assignment:
     organization-defined list of acceptable forms of identification] for visitor access
-    to the facility where the information system resides."'
+    to the facility where the information system resides.'
 PE-2 (3):
   family: PE
   name: Restrict Unescorted Access
-  description: '"The organization restricts unescorted access to the facility where
+  description: 'The organization restricts unescorted access to the facility where
     the information system resides to personnel with [Selection (one or more): security
     clearances for all information contained within the system; formal access authorizations
     for all information contained within the system; need for access to all information
-    contained within the system; [Assignment: organization-defined credentials]]."'
+    contained within the system; [Assignment: organization-defined credentials]].'
 PE-3:
   family: PE
   name: Physical Access Control
@@ -3057,41 +3049,41 @@ PE-3:
 PE-3 (1):
   family: PE
   name: Information System Access
-  description: '"The organization enforces physical access authorizations to the information
+  description: 'The organization enforces physical access authorizations to the information
     system in addition to the physical access controls for the facility at [Assignment:
     organization-defined physical spaces containing one or more components of the
-    information system]."'
+    information system].'
 PE-3 (2):
   family: PE
   name: Facility / Information System Boundaries
-  description: '"The organization performs security checks [Assignment: organization-defined
+  description: 'The organization performs security checks [Assignment: organization-defined
     frequency] at the physical boundary of the facility or information system for
-    unauthorized exfiltration of information or removal of information system components."'
+    unauthorized exfiltration of information or removal of information system components.'
 PE-3 (3):
   family: PE
   name: Continuous Guards / Alarms / Monitoring
-  description: '"The organization employs guards and/or alarms to monitor every physical
+  description: The organization employs guards and/or alarms to monitor every physical
     access point to the facility where the information system resides 24 hours per
-    day, 7 days per week."'
+    day, 7 days per week.
 PE-3 (4):
   family: PE
   name: Lockable Casings
-  description: '"The organization uses lockable physical casings to protect [Assignment:
+  description: 'The organization uses lockable physical casings to protect [Assignment:
     organization-defined information system components] from unauthorized physical
-    access."'
+    access.'
 PE-3 (5):
   family: PE
   name: Tamper Protection
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to [Selection (one or more): detect; prevent] physical tampering or
     alteration of [Assignment: organization-defined hardware components] within the
-    information system."'
+    information system.'
 PE-3 (6):
   family: PE
   name: Facility Penetration Testing
-  description: '"The organization employs a penetration testing process that includes
+  description: 'The organization employs a penetration testing process that includes
     [Assignment: organization-defined frequency], unannounced attempts to bypass or
-    circumvent security controls associated with physical access points to the facility."'
+    circumvent security controls associated with physical access points to the facility.'
 PE-4:
   family: PE
   name: Access Control For Transmission Medium
@@ -3120,9 +3112,9 @@ PE-5 (2):
 PE-5 (3):
   family: PE
   name: Marking Output Devices
-  description: '"The organization marks [Assignment: organization-defined information
+  description: 'The organization marks [Assignment: organization-defined information
     system output devices] indicating the appropriate security marking of the information
-    permitted to be output from the device."'
+    permitted to be output from the device.'
 PE-6:
   family: PE
   name: Monitoring Physical Access
@@ -3134,27 +3126,27 @@ PE-6:
 PE-6 (1):
   family: PE
   name: Intrusion Alarms / Surveillance Equipment
-  description: '"The organization monitors physical intrusion alarms and surveillance
-    equipment."'
+  description: The organization monitors physical intrusion alarms and surveillance
+    equipment.
 PE-6 (2):
   family: PE
   name: Automated Intrusion Recognition / Responses
-  description: '"The organization employs automated mechanisms to recognize [Assignment:
+  description: 'The organization employs automated mechanisms to recognize [Assignment:
     organization-defined classes/types of intrusions] and initiate [Assignment: organization-defined
-    response actions]."'
+    response actions].'
 PE-6 (3):
   family: PE
   name: Video Surveillance
-  description: '"The organization employs video surveillance of [Assignment: organization-defined
+  description: 'The organization employs video surveillance of [Assignment: organization-defined
     operational areas] and retains video recordings for [Assignment: organization-defined
-    time period]."'
+    time period].'
 PE-6 (4):
   family: PE
   name: Monitoring Physical Access To Information Systems
-  description: '"The organization monitors physical access to the information system
+  description: 'The organization monitors physical access to the information system
     in addition to the physical access monitoring of the facility as [Assignment:
     organization-defined physical spaces containing one or more components of the
-    information system]."'
+    information system].'
 PE-7:
   family: PE
   name: Visitor Control
@@ -3169,12 +3161,12 @@ PE-8:
 PE-8 (1):
   family: PE
   name: Automated Records Maintenance / Review
-  description: '"The organization employs automated mechanisms to facilitate the maintenance
-    and review of visitor access records."'
+  description: The organization employs automated mechanisms to facilitate the maintenance
+    and review of visitor access records.
 PE-8 (2):
   family: PE
   name: Physical Access Records
-  description: '"[Withdrawn: Incorporated into PE-2]."'
+  description: '[Withdrawn: Incorporated into PE-2].'
 PE-9:
   family: PE
   name: Power Equipment And Cabling
@@ -3183,13 +3175,13 @@ PE-9:
 PE-9 (1):
   family: PE
   name: Redundant Cabling
-  description: '"The organization employs redundant power cabling paths that are physically
-    separated by [Assignment: organization-defined distance]."'
+  description: 'The organization employs redundant power cabling paths that are physically
+    separated by [Assignment: organization-defined distance].'
 PE-9 (2):
   family: PE
   name: Automatic Voltage Controls
-  description: '"The organization employs automatic voltage controls for [Assignment:
-    organization-defined critical information system components]."'
+  description: 'The organization employs automatic voltage controls for [Assignment:
+    organization-defined critical information system components].'
 PE-10:
   family: PE
   name: Emergency Shutoff
@@ -3201,7 +3193,7 @@ PE-10:
 PE-10 (1):
   family: PE
   name: Accidental / Unauthorized Activation
-  description: '"[Withdrawn: Incorporated into PE-10]."'
+  description: '[Withdrawn: Incorporated into PE-10].'
 PE-11:
   family: PE
   name: Emergency Power
@@ -3212,9 +3204,9 @@ PE-11:
 PE-11 (1):
   family: PE
   name: Long-Term Alternate Power Supply - Minimal Operational Capability
-  description: '"The organization provides a long-term alternate power supply for
-    the information system that is capable of maintaining minimally required operational
-    capability in the event of an extended loss of the primary power source."'
+  description: The organization provides a long-term alternate power supply for the
+    information system that is capable of maintaining minimally required operational
+    capability in the event of an extended loss of the primary power source.
 PE-11 (2):
   family: PE
   name: Long-Term Alternate Power Supply - Self-Contained
@@ -3232,8 +3224,8 @@ PE-12:
 PE-12 (1):
   family: PE
   name: Essential Missions / Business Functions
-  description: '"The organization provides emergency lighting for all areas within
-    the facility supporting essential missions and business functions."'
+  description: The organization provides emergency lighting for all areas within the
+    facility supporting essential missions and business functions.
 PE-13:
   family: PE
   name: Fire Protection
@@ -3243,29 +3235,29 @@ PE-13:
 PE-13 (1):
   family: PE
   name: Detection Devices / Systems
-  description: '"The organization employs fire detection devices/systems for the information
+  description: 'The organization employs fire detection devices/systems for the information
     system that activate automatically and notify [Assignment: organization-defined
     personnel or roles] and [Assignment: organization-defined emergency responders]
-    in the event of a fire."'
+    in the event of a fire.'
 PE-13 (2):
   family: PE
   name: Suppression Devices / Systems
-  description: '"The organization employs fire suppression devices/systems for the
+  description: 'The organization employs fire suppression devices/systems for the
     information system that provide automatic notification of any activation to Assignment:
     organization-defined personnel or roles] and [Assignment: organization-defined
-    emergency responders]."'
+    emergency responders].'
 PE-13 (3):
   family: PE
   name: Automatic Fire Suppression
-  description: '"The organization employs an automatic fire suppression capability
-    for the information system when the facility is not staffed on a continuous basis."'
+  description: The organization employs an automatic fire suppression capability for
+    the information system when the facility is not staffed on a continuous basis.
 PE-13 (4):
   family: PE
   name: Inspections
-  description: '"The organization ensures that the facility undergoes [Assignment:
+  description: 'The organization ensures that the facility undergoes [Assignment:
     organization-defined frequency] inspections by authorized and qualified inspectors
     and resolves identified deficiencies within [Assignment: organization-defined
-    time period]."'
+    time period].'
 PE-14:
   family: PE
   name: Temperature And Humidity Controls
@@ -3276,15 +3268,14 @@ PE-14:
 PE-14 (1):
   family: PE
   name: Automatic Controls
-  description: '"The organization employs automatic temperature and humidity controls
+  description: The organization employs automatic temperature and humidity controls
     in the facility to prevent fluctuations potentially harmful to the information
-    system."'
+    system.
 PE-14 (2):
   family: PE
   name: Monitoring With Alarms / Notifications
-  description: '"The organization employs temperature and humidity monitoring that
-    provides an alarm or notification of changes potentially harmful to personnel
-    or equipment."'
+  description: The organization employs temperature and humidity monitoring that provides
+    an alarm or notification of changes potentially harmful to personnel or equipment.
 PE-15:
   family: PE
   name: Water Damage Protection
@@ -3294,9 +3285,9 @@ PE-15:
 PE-15 (1):
   family: PE
   name: Automation Support
-  description: '"The organization employs automated mechanisms to detect the presence
+  description: 'The organization employs automated mechanisms to detect the presence
     of water in the vicinity of the information system and alerts [Assignment: organization-defined
-    personnel or roles]."'
+    personnel or roles].'
 PE-16:
   family: PE
   name: Delivery And Removal
@@ -3320,10 +3311,10 @@ PE-18:
 PE-18 (1):
   family: PE
   name: Facility Site
-  description: '"The organization plans the location or site of the facility where
-    the information system resides with regard to physical and environmental hazards
-    and for existing facilities, considers the physical and environmental hazards
-    in its risk mitigation strategy."'
+  description: The organization plans the location or site of the facility where the
+    information system resides with regard to physical and environmental hazards and
+    for existing facilities, considers the physical and environmental hazards in its
+    risk mitigation strategy.
 PE-19:
   family: PE
   name: Information Leakage
@@ -3332,10 +3323,10 @@ PE-19:
 PE-19 (1):
   family: PE
   name: National Emissions / Tempest Policies And Procedures
-  description: '"The organization ensures that information system components, associated
+  description: The organization ensures that information system components, associated
     data communications, and networks are protected in accordance with national emissions
     and TEMPEST policies and procedures based on the security category or classification
-    of the information."'
+    of the information.
 PE-20:
   family: PE
   name: Asset Monitoring And Tracking
@@ -3376,18 +3367,18 @@ PL-2:
 PL-2 (1):
   family: PL
   name: Concept Of Operations
-  description: '"[Withdrawn: Incorporated into PL-7]."'
+  description: '[Withdrawn: Incorporated into PL-7].'
 PL-2 (2):
   family: PL
   name: Functional Architecture
-  description: '"[Withdrawn: Incorporated into PL-8]."'
+  description: '[Withdrawn: Incorporated into PL-8].'
 PL-2 (3):
   family: PL
   name: Plan / Coordinate With Other Organizational Entities
-  description: '"The organization plans and coordinates security-related activities
+  description: 'The organization plans and coordinates security-related activities
     affecting the information system with [Assignment: organization-defined individuals
     or groups] before conducting such activities in order to reduce the impact on
-    other organizational entities."'
+    other organizational entities.'
 PL-3:
   family: PL
   name: System Security Plan Update
@@ -3404,9 +3395,9 @@ PL-4:
 PL-4 (1):
   family: PL
   name: Social Media And Networking Restrictions
-  description: '"The organization includes in the rules of behavior, explicit restrictions
+  description: The organization includes in the rules of behavior, explicit restrictions
     on the use of social media/networking sites and posting organizational information
-    on public websites."'
+    on public websites.
 PL-5:
   family: PL
   name: Privacy Impact Assessment
@@ -3443,9 +3434,9 @@ PL-8 (1):
 PL-8 (2):
   family: PL
   name: Supplier Diversity
-  description: '"The organization requires that [Assignment: organization-defined
-    security safeguards] allocated to [Assignment: organization-defined locations
-    and architectural layers] are obtained from different suppliers."'
+  description: 'The organization requires that [Assignment: organization-defined security
+    safeguards] allocated to [Assignment: organization-defined locations and architectural
+    layers] are obtained from different suppliers.'
 PL-9:
   family: PL
   name: Central Management
@@ -3594,17 +3585,17 @@ PS-3:
 PS-3 (1):
   family: PS
   name: Classified Information
-  description: '"The organization ensures that individuals accessing an information
+  description: The organization ensures that individuals accessing an information
     system processing, storing, or transmitting classified information are cleared
     and indoctrinated to the highest classification level of the information to which
-    they have access on the system."'
+    they have access on the system.
 PS-3 (2):
   family: PS
   name: Formal Indoctrination
-  description: '"The organization ensures that individuals accessing an information
+  description: The organization ensures that individuals accessing an information
     system processing, storing, or transmitting types of classified information which
     require formal indoctrination, are formally indoctrinated for all of the relevant
-    types of information to which they have access on the system."'
+    types of information to which they have access on the system.
 PS-3 (3):
   family: PS
   name: Information With Special Protection Measures
@@ -3633,8 +3624,8 @@ PS-4 (1):
 PS-4 (2):
   family: PS
   name: Automated Notification
-  description: '"The organization employs automated mechanisms to notify [Assignment:
-    organization-defined personnel or roles] upon termination of an individual."'
+  description: 'The organization employs automated mechanisms to notify [Assignment:
+    organization-defined personnel or roles] upon termination of an individual.'
 PS-5:
   family: PS
   name: Personnel Transfer
@@ -3657,7 +3648,7 @@ PS-6:
 PS-6 (1):
   family: PS
   name: Information Requiring Special Protection
-  description: '"[Withdrawn: Incorporated into PS-3]."'
+  description: '[Withdrawn: Incorporated into PS-3].'
 PS-6 (2):
   family: PS
   name: Classified Information Requiring Special Protection
@@ -3739,56 +3730,56 @@ RA-5:
 RA-5 (1):
   family: RA
   name: Update Tool Capability
-  description: '"The organization employs vulnerability scanning tools that include
+  description: The organization employs vulnerability scanning tools that include
     the capability to readily update the information system vulnerabilities to be
-    scanned."'
+    scanned.
 RA-5 (2):
   family: RA
   name: Update By Frequency / Prior To New Scan / When Identified
-  description: '"The organization updates the information system vulnerabilities scanned
+  description: 'The organization updates the information system vulnerabilities scanned
     [Selection (one or more): [Assignment: organization-defined frequency]; prior
-    to a new scan; when new vulnerabilities are identified and reported]."'
+    to a new scan; when new vulnerabilities are identified and reported].'
 RA-5 (3):
   family: RA
   name: Breadth / Depth Of Coverage
-  description: '"The organization employs vulnerability scanning procedures that can
+  description: The organization employs vulnerability scanning procedures that can
     identify the breadth and depth of coverage (i.e., information system components
-    scanned and vulnerabilities checked)."'
+    scanned and vulnerabilities checked).
 RA-5 (4):
   family: RA
   name: Discoverable Information
-  description: '"The organization determines what information about the information
+  description: 'The organization determines what information about the information
     system is discoverable by adversaries and subsequently takes [Assignment: organization-defined
-    corrective actions]."'
+    corrective actions].'
 RA-5 (5):
   family: RA
   name: Privileged Access
-  description: '"The information system implements privileged access authorization
+  description: 'The information system implements privileged access authorization
     to [Assignment: organization-identified information system components] for selected
-    [Assignment: organization-defined vulnerability scanning activities]."'
+    [Assignment: organization-defined vulnerability scanning activities].'
 RA-5 (6):
   family: RA
   name: Automated Trend Analyses
-  description: '"The organization employs automated mechanisms to compare the results
-    of vulnerability scans over time to determine trends in information system vulnerabilities."'
+  description: The organization employs automated mechanisms to compare the results
+    of vulnerability scans over time to determine trends in information system vulnerabilities.
 RA-5 (7):
   family: RA
   name: Automated Detection And Notification Of Unauthorized Components
-  description: '"[Withdrawn: Incorporated into CM-8]."'
+  description: '[Withdrawn: Incorporated into CM-8].'
 RA-5 (8):
   family: RA
   name: Review Historic Audit Logs
-  description: '"The organization reviews historic audit logs to determine if a vulnerability
-    identified in the information system has been previously exploited."'
+  description: The organization reviews historic audit logs to determine if a vulnerability
+    identified in the information system has been previously exploited.
 RA-5 (9):
   family: RA
   name: Penetration Testing And Analyses
-  description: '"[Withdrawn: Incorporated into CA-8]."'
+  description: '[Withdrawn: Incorporated into CA-8].'
 RA-5 (10):
   family: RA
   name: Correlate Scanning Information
-  description: '"The organization correlates the output from vulnerability scanning
-    tools to determine the presence of multi-vulnerability/multi-hop attack vectors."'
+  description: The organization correlates the output from vulnerability scanning
+    tools to determine the presence of multi-vulnerability/multi-hop attack vectors.
 RA-6:
   family: RA
   name: Technical Surveillance Countermeasures Survey
@@ -3839,31 +3830,31 @@ SA-4:
 SA-4 (1):
   family: SA
   name: Functional Properties Of Security Controls
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to provide a description of the
-    functional properties of the security controls to be employed."'
+    functional properties of the security controls to be employed.
 SA-4 (2):
   family: SA
   name: Design / Implementation Information For Security Controls
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to provide design and implementation
     information for the security controls to be employed that includes: [Selection
     (one or more): security-relevant external system interfaces; high-level design;
     low-level design; source code or hardware schematics; [Assignment: organization-defined
     design/implementation information]] at [Assignment: organization-defined level
-    of detail]."'
+    of detail].'
 SA-4 (3):
   family: SA
   name: Development Methods / Techniques / Practices
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to demonstrate the use of a system
     development life cycle that includes [Assignment: organization-defined state-of-the-practice
     system/security engineering methods, software development methods, testing/evaluation/validation
-    techniques, and quality control processes]."'
+    techniques, and quality control processes].'
 SA-4 (4):
   family: SA
   name: Assignment Of Components To Systems
-  description: '"[Withdrawn: Incorporated into CM-8 (9)]."'
+  description: '[Withdrawn: Incorporated into CM-8 (9)].'
 SA-4 (5):
   family: SA
   name: System / Component / Service Configurations
@@ -3888,23 +3879,23 @@ SA-4 (7):
 SA-4 (8):
   family: SA
   name: Continuous Monitoring Plan
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to produce a plan for the continuous
     monitoring of security control effectiveness that contains [Assignment: organization-defined
-    level of detail]."'
+    level of detail].'
 SA-4 (9):
   family: SA
   name: Functions / Ports / Protocols / Services In Use
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to identify early in the system
     development life cycle, the functions, ports, protocols, and services intended
-    for organizational use."'
+    for organizational use.
 SA-4 (10):
   family: SA
   name: Use Of Approved Piv Products
-  description: '"The organization employs only information technology products on
-    the FIPS 201-approved products list for Personal Identity Verification (PIV) capability
-    implemented within organizational information systems."'
+  description: The organization employs only information technology products on the
+    FIPS 201-approved products list for Personal Identity Verification (PIV) capability
+    implemented within organizational information systems.
 SA-5:
   family: SA
   name: Information System Documentation
@@ -3924,23 +3915,23 @@ SA-5:
 SA-5 (1):
   family: SA
   name: Functional Properties Of Security Controls
-  description: '"[Withdrawn: Incorporated into SA-4 (1)]."'
+  description: '[Withdrawn: Incorporated into SA-4 (1)].'
 SA-5 (2):
   family: SA
   name: Security-Relevant External System Interfaces
-  description: '"[Withdrawn: Incorporated into SA-4 (2)]."'
+  description: '[Withdrawn: Incorporated into SA-4 (2)].'
 SA-5 (3):
   family: SA
   name: High-Level Design
-  description: '"[Withdrawn: Incorporated into SA-4 (2)]."'
+  description: '[Withdrawn: Incorporated into SA-4 (2)].'
 SA-5 (4):
   family: SA
   name: Low-Level Design
-  description: '"[Withdrawn: Incorporated into SA-4 (2)]."'
+  description: '[Withdrawn: Incorporated into SA-4 (2)].'
 SA-5 (5):
   family: SA
   name: Source Code
-  description: '"[Withdrawn: Incorporated into SA-4 (2)]."'
+  description: '[Withdrawn: Incorporated into SA-4 (2)].'
 SA-6:
   family: SA
   name: Software Usage Restrictions
@@ -3973,28 +3964,28 @@ SA-9 (1):
 SA-9 (2):
   family: SA
   name: Identification Of Functions / Ports / Protocols / Services
-  description: '"The organization requires providers of [Assignment: organization-defined
+  description: 'The organization requires providers of [Assignment: organization-defined
     external information system services] to identify the functions, ports, protocols,
-    and other services required for the use of such services."'
+    and other services required for the use of such services.'
 SA-9 (3):
   family: SA
   name: Establish / Maintain Trust Relationship With Providers
-  description: '"The organization establishes, documents, and maintains trust relationships
+  description: 'The organization establishes, documents, and maintains trust relationships
     with external service providers based on [Assignment: organization-defined security
-    requirements, properties, factors, or conditions defining acceptable trust relationships]."'
+    requirements, properties, factors, or conditions defining acceptable trust relationships].'
 SA-9 (4):
   family: SA
   name: Consistent Interests Of Consumers And Providers
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to ensure that the interests of [Assignment: organization-defined
-    external service providers] are consistent with and reflect organizational interests."'
+    external service providers] are consistent with and reflect organizational interests.'
 SA-9 (5):
   family: SA
   name: Processing, Storage, And Service Location
-  description: '"The organization restricts the location of [Selection (one or more):
+  description: 'The organization restricts the location of [Selection (one or more):
     information processing; information/data; information system services] to [Assignment:
     organization-defined locations] based on [Assignment: organization-defined requirements
-    or conditions]."'
+    or conditions].'
 SA-10:
   family: SA
   name: Developer Configuration Management
@@ -4058,16 +4049,16 @@ SA-11:
 SA-11 (1):
   family: SA
   name: Static Code Analysis
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to employ static code analysis
-    tools to identify common flaws and document the results of the analysis."'
+    tools to identify common flaws and document the results of the analysis.
 SA-11 (2):
   family: SA
   name: Threat And Vulnerability Analyses
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to perform threat and vulnerability
     analyses and subsequent testing/evaluation of the as-built system, component,
-    or service."'
+    or service.
 SA-11 (3):
   family: SA
   name: Independent Verification Of Assessment Plans / Evidence
@@ -4078,35 +4069,35 @@ SA-11 (3):
 SA-11 (4):
   family: SA
   name: Manual Code Reviews
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to perform a manual code review
     of [Assignment: organization-defined specific code] using [Assignment: organization-defined
-    processes, procedures, and/or techniques]."'
+    processes, procedures, and/or techniques].'
 SA-11 (5):
   family: SA
   name: Penetration Testing
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to perform penetration testing
     at [Assignment: organization-defined breadth/depth] and with [Assignment: organization-defined
-    constraints]."'
+    constraints].'
 SA-11 (6):
   family: SA
   name: Attack Surface Reviews
-  description: '"The organization requires the developer of the information system,
-    system component, or information system service to perform attack surface reviews."'
+  description: The organization requires the developer of the information system,
+    system component, or information system service to perform attack surface reviews.
 SA-11 (7):
   family: SA
   name: Verify Scope Of Testing / Evaluation
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to verify that the scope of security
     testing/evaluation provides complete coverage of required security controls at
-    [Assignment: organization-defined depth of testing/evaluation]."'
+    [Assignment: organization-defined depth of testing/evaluation].'
 SA-11 (8):
   family: SA
   name: Dynamic Code Analysis
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to employ dynamic code analysis
-    tools to identify common flaws and document the results of the analysis."'
+    tools to identify common flaws and document the results of the analysis.
 SA-12:
   family: SA
   name: Supply Chain Protection
@@ -4117,91 +4108,91 @@ SA-12:
 SA-12 (1):
   family: SA
   name: Acquisition Strategies / Tools / Methods
-  description: '"The organization employs [Assignment: organization-defined tailored
+  description: 'The organization employs [Assignment: organization-defined tailored
     acquisition strategies, contract tools, and procurement methods] for the purchase
     of the information system, system component, or information system service from
-    suppliers."'
+    suppliers.'
 SA-12 (2):
   family: SA
   name: Supplier Reviews
-  description: '"The organization conducts a supplier review prior to entering into
+  description: The organization conducts a supplier review prior to entering into
     a contractual agreement to acquire the information system, system component, or
-    information system service."'
+    information system service.
 SA-12 (3):
   family: SA
   name: Trusted Shipping And Warehousing
-  description: '"[Withdrawn: Incorporated into SA-12 (1)]."'
+  description: '[Withdrawn: Incorporated into SA-12 (1)].'
 SA-12 (4):
   family: SA
   name: Diversity Of Suppliers
-  description: '"[Withdrawn: Incorporated into SA-12 (13)]."'
+  description: '[Withdrawn: Incorporated into SA-12 (13)].'
 SA-12 (5):
   family: SA
   name: Limitation Of Harm
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to limit harm from potential adversaries identifying and targeting
-    the organizational supply chain."'
+    the organizational supply chain.'
 SA-12 (6):
   family: SA
   name: Minimizing Procurement Time
-  description: '"[Withdrawn: Incorporated into SA-12 (1)]."'
+  description: '[Withdrawn: Incorporated into SA-12 (1)].'
 SA-12 (7):
   family: SA
   name: Assessments Prior To Selection / Acceptance / Update
-  description: '"The organization conducts an assessment of the information system,
+  description: The organization conducts an assessment of the information system,
     system component, or information system service prior to selection, acceptance,
-    or update."'
+    or update.
 SA-12 (8):
   family: SA
   name: Use Of All-Source Intelligence
-  description: '"The organization uses all-source intelligence analysis of suppliers
+  description: The organization uses all-source intelligence analysis of suppliers
     and potential suppliers of the information system, system component, or information
-    system service."'
+    system service.
 SA-12 (9):
   family: SA
   name: Operations Security
-  description: '"The organization employs [Assignment: organization-defined Operations
+  description: 'The organization employs [Assignment: organization-defined Operations
     Security (OPSEC) safeguards] in accordance with classification guides to protect
     supply chain-related information for the information system, system component,
-    or information system service."'
+    or information system service.'
 SA-12 (10):
   family: SA
   name: Validate As Genuine And Not Altered
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to validate that the information system or system component received
-    is genuine and has not been altered."'
+    is genuine and has not been altered.'
 SA-12 (11):
   family: SA
   name: Penetration Testing / Analysis Of Elements, Processes, And Actors
-  description: '"The organization employs [Selection (one or more): organizational
+  description: 'The organization employs [Selection (one or more): organizational
     analysis, independent third-party analysis, organizational penetration testing,
     independent third-party penetration testing] of [Assignment: organization-defined
     supply chain elements, processes, and actors] associated with the information
-    system, system component, or information system service."'
+    system, system component, or information system service.'
 SA-12 (12):
   family: SA
   name: Inter-Organizational Agreements
-  description: '"The organization establishes inter-organizational agreements and
-    procedures with entities involved in the supply chain for the information system,
-    system component, or information system service."'
+  description: The organization establishes inter-organizational agreements and procedures
+    with entities involved in the supply chain for the information system, system
+    component, or information system service.
 SA-12 (13):
   family: SA
   name: Critical Information System Components
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to ensure an adequate supply of [Assignment: organization-defined
-    critical information system components]."'
+    critical information system components].'
 SA-12 (14):
   family: SA
   name: Identity And Traceability
-  description: '"The organization establishes and retains unique identification of
+  description: 'The organization establishes and retains unique identification of
     [Assignment: organization-defined supply chain elements, processes, and actors]
-    for the information system, system component, or information system service."'
+    for the information system, system component, or information system service.'
 SA-12 (15):
   family: SA
   name: Processes To Address Weaknesses Or Deficiencies
-  description: '"The organization establishes a process to address weaknesses or deficiencies
+  description: The organization establishes a process to address weaknesses or deficiencies
     in supply chain elements identified during independent or organizational assessments
-    of such elements."'
+    of such elements.
 SA-13:
   family: SA
   name: Trustworthiness
@@ -4220,7 +4211,7 @@ SA-14:
 SA-14 (1):
   family: SA
   name: Critical Components With  No Viable Alternative Sourcing
-  description: '"[Withdrawn: Incorporated into SA-20]."'
+  description: '[Withdrawn: Incorporated into SA-20].'
 SA-15:
   family: SA
   name: Development Process, Standards, And Tools
@@ -4242,16 +4233,16 @@ SA-15 (1):
 SA-15 (2):
   family: SA
   name: Security Tracking Tools
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to select and employ a security
-    tracking tool for use during the development process."'
+    tracking tool for use during the development process.
 SA-15 (3):
   family: SA
   name: Criticality Analysis
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to perform a criticality analysis
     at [Assignment: organization-defined breadth/depth] and at [Assignment: organization-defined
-    decision points in the system development life cycle]."'
+    decision points in the system development life cycle].'
 SA-15 (4):
   family: SA
   name: Threat Modeling / Vulnerability Analysis
@@ -4263,15 +4254,15 @@ SA-15 (4):
 SA-15 (5):
   family: SA
   name: Attack Surface Reduction
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to reduce attack surfaces to [Assignment:
-    organization-defined thresholds]."'
+    organization-defined thresholds].'
 SA-15 (6):
   family: SA
   name: Continuous Improvement
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to implement an explicit process
-    to continuously improve the development process."'
+    to continuously improve the development process.
 SA-15 (7):
   family: SA
   name: Automated Vulnerability Analysis
@@ -4284,28 +4275,28 @@ SA-15 (7):
 SA-15 (8):
   family: SA
   name: Reuse Of Threat / Vulnerability Information
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to use threat modeling and vulnerability
     analyses from similar systems, components, or services to inform the current development
-    process."'
+    process.
 SA-15 (9):
   family: SA
   name: Use Of Live Data
-  description: '"The organization approves, documents, and controls the use of live
+  description: The organization approves, documents, and controls the use of live
     data in development and test environments for the information system, system component,
-    or information system service."'
+    or information system service.
 SA-15 (10):
   family: SA
   name: Incident Response Plan
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to provide an incident response
-    plan."'
+    plan.
 SA-15 (11):
   family: SA
   name: Archive Information System / Component
-  description: '"The organization requires the developer of the information system
-    or system component to archive the system or component to be released or delivered
-    together with the corresponding evidence supporting the final security review."'
+  description: The organization requires the developer of the information system or
+    system component to archive the system or component to be released or delivered
+    together with the corresponding evidence supporting the final security review.
 SA-16:
   family: SA
   name: Developer-Provided Training
@@ -4365,15 +4356,15 @@ SA-17 (5):
 SA-17 (6):
   family: SA
   name: Structure For Testing
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to structure security-relevant
-    hardware, software, and firmware to facilitate testing."'
+    hardware, software, and firmware to facilitate testing.
 SA-17 (7):
   family: SA
   name: Structure For Least Privilege
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to structure security-relevant
-    hardware, software, and firmware to facilitate controlling access with least privilege."'
+    hardware, software, and firmware to facilitate controlling access with least privilege.
 SA-18:
   family: SA
   name: Tamper Resistance And Detection
@@ -4382,16 +4373,16 @@ SA-18:
 SA-18 (1):
   family: SA
   name: Multiple Phases Of Sdlc
-  description: '"The organization employs anti-tamper technologies and techniques
-    during multiple phases in the system development life cycle including design,
-    development, integration, operations, and maintenance."'
+  description: The organization employs anti-tamper technologies and techniques during
+    multiple phases in the system development life cycle including design, development,
+    integration, operations, and maintenance.
 SA-18 (2):
   family: SA
   name: Inspection Of Information Systems, Components, Or Devices
-  description: '"The organization inspects [Assignment: organization-defined information
+  description: 'The organization inspects [Assignment: organization-defined information
     systems, system components, or devices] [Selection (one or more): at random; at
     [Assignment: organization-defined frequency], upon [Assignment: organization-defined
-    indications of need for inspection]] to detect tampering."'
+    indications of need for inspection]] to detect tampering.'
 SA-19:
   family: SA
   name: Component Authenticity
@@ -4402,25 +4393,25 @@ SA-19:
 SA-19 (1):
   family: SA
   name: Anti-Counterfeit Training
-  description: '"The organization trains [Assignment: organization-defined personnel
+  description: 'The organization trains [Assignment: organization-defined personnel
     or roles] to detect counterfeit information system components (including hardware,
-    software, and firmware)."'
+    software, and firmware).'
 SA-19 (2):
   family: SA
   name: Configuration Control For Component Service / Repair
-  description: '"The organization maintains configuration control over [Assignment:
+  description: 'The organization maintains configuration control over [Assignment:
     organization-defined information system components] awaiting service/repair and
-    serviced/repaired components awaiting return to service."'
+    serviced/repaired components awaiting return to service.'
 SA-19 (3):
   family: SA
   name: Component Disposal
-  description: '"The organization disposes of information system components using
-    [Assignment: organization-defined techniques and methods]."'
+  description: 'The organization disposes of information system components using [Assignment:
+    organization-defined techniques and methods].'
 SA-19 (4):
   family: SA
   name: Anti-Counterfeit Scanning
-  description: '"The organization scans for counterfeit information system components
-    [Assignment: organization-defined frequency]."'
+  description: 'The organization scans for counterfeit information system components
+    [Assignment: organization-defined frequency].'
 SA-20:
   family: SA
   name: Customized Development Of Critical Components
@@ -4436,10 +4427,10 @@ SA-21:
 SA-21 (1):
   family: SA
   name: Validation Of Screening
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service take [Assignment: organization-defined
     actions] to ensure that the required access authorizations and screening criteria
-    are satisfied."'
+    are satisfied.'
 SA-22:
   family: SA
   name: Unsupported System Components
@@ -4450,9 +4441,9 @@ SA-22:
 SA-22 (1):
   family: SA
   name: Alternative Sources For Continued Support
-  description: '"The organization provides [Selection (one or more): in-house support;
+  description: 'The organization provides [Selection (one or more): in-house support;
     [Assignment: organization-defined support from external providers]] for unsupported
-    information system components."'
+    information system components.'
 SC-1:
   family: SC
   name: System And Communications Protection Policy And Procedures
@@ -4472,8 +4463,8 @@ SC-2:
 SC-2 (1):
   family: SC
   name: Interfaces For Non-Privileged Users
-  description: '"The information system prevents the presentation of information system
-    management-related functionality at an interface for non-privileged users."'
+  description: The information system prevents the presentation of information system
+    management-related functionality at an interface for non-privileged users.
 SC-3:
   family: SC
   name: Security Function Isolation
@@ -4482,31 +4473,31 @@ SC-3:
 SC-3 (1):
   family: SC
   name: Hardware Separation
-  description: '"The information system utilizes underlying hardware separation mechanisms
-    to implement security function isolation."'
+  description: The information system utilizes underlying hardware separation mechanisms
+    to implement security function isolation.
 SC-3 (2):
   family: SC
   name: Access / Flow Control Functions
-  description: '"The information system isolates security functions enforcing access
+  description: The information system isolates security functions enforcing access
     and information flow control from nonsecurity functions and from other security
-    functions."'
+    functions.
 SC-3 (3):
   family: SC
   name: Minimize Nonsecurity Functionality
-  description: '"The organization minimizes the number of nonsecurity functions included
-    within the isolation boundary containing security functions."'
+  description: The organization minimizes the number of nonsecurity functions included
+    within the isolation boundary containing security functions.
 SC-3 (4):
   family: SC
   name: Module Coupling And Cohesiveness
-  description: '"The organization implements security functions as largely independent
+  description: The organization implements security functions as largely independent
     modules that maximize internal cohesiveness within modules and minimize coupling
-    between modules."'
+    between modules.
 SC-3 (5):
   family: SC
   name: Layered Structures
-  description: '"The organization implements security functions as a layered structure
+  description: The organization implements security functions as a layered structure
     minimizing interactions between layers of the design and avoiding any dependence
-    by lower layers on the functionality or correctness of higher layers."'
+    by lower layers on the functionality or correctness of higher layers.
 SC-4:
   family: SC
   name: Information In Shared Resources
@@ -4515,14 +4506,14 @@ SC-4:
 SC-4 (1):
   family: SC
   name: Security Levels
-  description: '"[Withdrawn: Incorporated into SC-4]."'
+  description: '[Withdrawn: Incorporated into SC-4].'
 SC-4 (2):
   family: SC
   name: Periods Processing
-  description: '"The information system prevents unauthorized information transfer
+  description: 'The information system prevents unauthorized information transfer
     via shared resources in accordance with [Assignment: organization-defined procedures]
     when system processing explicitly switches between different information classification
-    levels or security categories."'
+    levels or security categories.'
 SC-5:
   family: SC
   name: Denial Of Service Protection
@@ -4533,14 +4524,14 @@ SC-5:
 SC-5 (1):
   family: SC
   name: Restrict Internal Users
-  description: '"The information system restricts the ability of individuals to launch
+  description: 'The information system restricts the ability of individuals to launch
     [Assignment: organization-defined denial of service attacks] against other information
-    systems."'
+    systems.'
 SC-5 (2):
   family: SC
   name: Excess Capacity / Bandwidth / Redundancy
-  description: '"The information system manages excess capacity, bandwidth, or other
-    redundancy to limit the effects of information flooding denial of service attacks."'
+  description: The information system manages excess capacity, bandwidth, or other
+    redundancy to limit the effects of information flooding denial of service attacks.
 SC-5 (3):
   family: SC
   name: Detection / Monitoring
@@ -4565,16 +4556,16 @@ SC-7:
 SC-7 (1):
   family: SC
   name: Physically Separated Subnetworks
-  description: '"[Withdrawn: Incorporated into SC-7]."'
+  description: '[Withdrawn: Incorporated into SC-7].'
 SC-7 (2):
   family: SC
   name: Public Access
-  description: '"[Withdrawn: Incorporated into SC-7]."'
+  description: '[Withdrawn: Incorporated into SC-7].'
 SC-7 (3):
   family: SC
   name: Access Points
-  description: '"The organization limits the number of external network connections
-    to the information system."'
+  description: The organization limits the number of external network connections
+    to the information system.
 SC-7 (4):
   family: SC
   name: External Telecommunications Services
@@ -4588,25 +4579,25 @@ SC-7 (4):
 SC-7 (5):
   family: SC
   name: Deny By Default / Allow By Exception
-  description: '"The information system at managed interfaces denies network communications
+  description: The information system at managed interfaces denies network communications
     traffic by default and allows network communications traffic by exception (i.e.,
-    deny all, permit by exception)."'
+    deny all, permit by exception).
 SC-7 (6):
   family: SC
   name: Response To Recognized Failures
-  description: '"[Withdrawn: Incorporated into SC-7 (18)]."'
+  description: '[Withdrawn: Incorporated into SC-7 (18)].'
 SC-7 (7):
   family: SC
   name: Prevent Split Tunneling For Remote Devices
-  description: '"The information system, in conjunction with a remote device, prevents
+  description: The information system, in conjunction with a remote device, prevents
     the device from simultaneously establishing non-remote connections with the system
-    and communicating via some other connection to resources in external networks."'
+    and communicating via some other connection to resources in external networks.
 SC-7 (8):
   family: SC
   name: Route Traffic To Authenticated Proxy Servers
-  description: '"The information system routes [Assignment: organization-defined internal
+  description: 'The information system routes [Assignment: organization-defined internal
     communications traffic] to [Assignment: organization-defined external networks]
-    through authenticated proxy servers at managed interfaces."'
+    through authenticated proxy servers at managed interfaces.'
 SC-7 (9):
   family: SC
   name: Restrict Threatening Outgoing Communications Traffic
@@ -4617,79 +4608,79 @@ SC-7 (9):
 SC-7 (10):
   family: SC
   name: Prevent Unauthorized Exfiltration
-  description: '"The organization prevents the unauthorized exfiltration of information
-    across managed interfaces."'
+  description: The organization prevents the unauthorized exfiltration of information
+    across managed interfaces.
 SC-7 (11):
   family: SC
   name: Restrict Incoming Communications Traffic
-  description: '"The information system only allows incoming communications from [Assignment:
+  description: 'The information system only allows incoming communications from [Assignment:
     organization-defined authorized sources] to be routed to [Assignment: organization-defined
-    authorized destinations]."'
+    authorized destinations].'
 SC-7 (12):
   family: SC
   name: Host-Based Protection
-  description: '"The organization implements [Assignment: organization-defined host-based
+  description: 'The organization implements [Assignment: organization-defined host-based
     boundary protection mechanisms] at [Assignment: organization-defined information
-    system components]."'
+    system components].'
 SC-7 (13):
   family: SC
   name: Isolation Of Security Tools / Mechanisms / Support Components
-  description: '"The organization isolates [Assignment: organization-defined information
+  description: 'The organization isolates [Assignment: organization-defined information
     security tools, mechanisms, and support components] from other internal information
     system components by implementing physically separate subnetworks with managed
-    interfaces to other components of the system."'
+    interfaces to other components of the system.'
 SC-7 (14):
   family: SC
   name: Protects Against Unauthorized Physical Connections
-  description: '"The organization protects against unauthorized physical connections
-    at [Assignment: organization-defined managed interfaces]."'
+  description: 'The organization protects against unauthorized physical connections
+    at [Assignment: organization-defined managed interfaces].'
 SC-7 (15):
   family: SC
   name: Route Privileged Network Accesses
-  description: '"The information system routes all networked, privileged accesses
-    through a dedicated, managed interface for purposes of access control and auditing."'
+  description: The information system routes all networked, privileged accesses through
+    a dedicated, managed interface for purposes of access control and auditing.
 SC-7 (16):
   family: SC
   name: Prevent Discovery Of Components / Devices
-  description: '"The information system prevents discovery of specific system components
-    composing a managed interface."'
+  description: The information system prevents discovery of specific system components
+    composing a managed interface.
 SC-7 (17):
   family: SC
   name: Automated Enforcement Of Protocol Formats
-  description: '"The information system enforces adherence to protocol formats."'
+  description: The information system enforces adherence to protocol formats.
 SC-7 (18):
   family: SC
   name: Fail Secure
-  description: '"The information system fails securely in the event of an operational
-    failure of a boundary protection device."'
+  description: The information system fails securely in the event of an operational
+    failure of a boundary protection device.
 SC-7 (19):
   family: SC
   name: Blocks Communication From Non-Organizationally Configured Hosts
-  description: '"The information system blocks both inbound and outbound communications
+  description: 'The information system blocks both inbound and outbound communications
     traffic between [Assignment: organization-defined communication clients] that
-    are independently configured by end users and external service providers."'
+    are independently configured by end users and external service providers.'
 SC-7 (20):
   family: SC
   name: Dynamic Isolation / Segregation
-  description: '"The information system provides the capability to dynamically isolate/segregate
+  description: 'The information system provides the capability to dynamically isolate/segregate
     [Assignment: organization-defined information system components] from other components
-    of the system."'
+    of the system.'
 SC-7 (21):
   family: SC
   name: Isolation Of Information System Components
-  description: '"The organization employs boundary protection mechanisms to separate
+  description: 'The organization employs boundary protection mechanisms to separate
     [Assignment: organization-defined information system components] supporting [Assignment:
-    organization-defined missions and/or business functions]."'
+    organization-defined missions and/or business functions].'
 SC-7 (22):
   family: SC
   name: Separate Subnets For Connecting To Different Security Domains
-  description: '"The information system implements separate network addresses (i.e.,
-    different subnets) to connect to systems in different security domains."'
+  description: The information system implements separate network addresses (i.e.,
+    different subnets) to connect to systems in different security domains.
 SC-7 (23):
   family: SC
   name: Disable Sender Feedback On Protocol Validation Failure
-  description: '"The information system disables feedback to senders on protocol format
-    validation failure."'
+  description: The information system disables feedback to senders on protocol format
+    validation failure.
 SC-8:
   family: SC
   name: Transmission Confidentiality And Integrity
@@ -4698,27 +4689,27 @@ SC-8:
 SC-8 (1):
   family: SC
   name: Cryptographic Or Alternate Physical Protection
-  description: '"The information system implements cryptographic mechanisms to [Selection
+  description: 'The information system implements cryptographic mechanisms to [Selection
     (one or more): prevent unauthorized disclosure of information; detect changes
     to information] during transmission unless otherwise protected by [Assignment:
-    organization-defined alternative physical safeguards]."'
+    organization-defined alternative physical safeguards].'
 SC-8 (2):
   family: SC
   name: Pre / Post Transmission Handling
-  description: '"The information system maintains the [Selection (one or more): confidentiality;
-    integrity] of information during preparation for transmission and during reception."'
+  description: 'The information system maintains the [Selection (one or more): confidentiality;
+    integrity] of information during preparation for transmission and during reception.'
 SC-8 (3):
   family: SC
   name: Cryptographic Protection For Message Externals
-  description: '"The information system implements cryptographic mechanisms to protect
+  description: 'The information system implements cryptographic mechanisms to protect
     message externals unless otherwise protected by [Assignment: organization-defined
-    alternative physical safeguards]."'
+    alternative physical safeguards].'
 SC-8 (4):
   family: SC
   name: Conceal / Randomize Communications
-  description: '"The information system implements cryptographic mechanisms to conceal
+  description: 'The information system implements cryptographic mechanisms to conceal
     or randomize communication patterns unless otherwise protected by [Assignment:
-    organization-defined alternative physical safeguards]."'
+    organization-defined alternative physical safeguards].'
 SC-9:
   family: SC
   name: Transmission Confidentiality
@@ -4739,8 +4730,8 @@ SC-11:
 SC-11 (1):
   family: SC
   name: Logical Isolation
-  description: '"The information system provides a trusted communications path that
-    is logically isolated and distinguishable from other paths."'
+  description: The information system provides a trusted communications path that
+    is logically isolated and distinguishable from other paths.
 SC-12:
   family: SC
   name: Cryptographic Key Establishment And Management
@@ -4751,30 +4742,30 @@ SC-12:
 SC-12 (1):
   family: SC
   name: Availability
-  description: '"The organization maintains availability of information in the event
-    of the loss of cryptographic keys by users."'
+  description: The organization maintains availability of information in the event
+    of the loss of cryptographic keys by users.
 SC-12 (2):
   family: SC
   name: Symmetric Keys
-  description: '"The organization produces, controls, and distributes symmetric cryptographic
+  description: 'The organization produces, controls, and distributes symmetric cryptographic
     keys using [Selection: NIST FIPS-compliant; NSA-approved] key management technology
-    and processes."'
+    and processes.'
 SC-12 (3):
   family: SC
   name: Asymmetric Keys
-  description: '"The organization produces, controls, and distributes asymmetric cryptographic
+  description: 'The organization produces, controls, and distributes asymmetric cryptographic
     keys using [Selection: NSA-approved key management technology and processes; approved
     PKI Class 3 certificates or prepositioned keying material; approved PKI Class
-    3 or Class 4 certificates and hardware security tokens that protect the user�s
-    private key]."'
+    3 or Class 4 certificates and hardware security tokens that protect the user''s
+    private key].'
 SC-12 (4):
   family: SC
   name: Pki Certificates
-  description: '"[Withdrawn: Incorporated into SC-12]."'
+  description: '[Withdrawn: Incorporated into SC-12].'
 SC-12 (5):
   family: SC
   name: Pki Certificates / Hardware Tokens
-  description: '"[Withdrawn: Incorporated into SC-12]."'
+  description: '[Withdrawn: Incorporated into SC-12].'
 SC-13:
   family: SC
   name: Cryptographic Protection
@@ -4785,19 +4776,19 @@ SC-13:
 SC-13 (1):
   family: SC
   name: Fips-Validated Cryptography
-  description: '"[Withdrawn: Incorporated into SC-13]."'
+  description: '[Withdrawn: Incorporated into SC-13].'
 SC-13 (2):
   family: SC
   name: Nsa-Approved Cryptography
-  description: '"[Withdrawn: Incorporated into SC-13]."'
+  description: '[Withdrawn: Incorporated into SC-13].'
 SC-13 (3):
   family: SC
   name: Individuals Without Formal Access  Approvals
-  description: '"[Withdrawn: Incorporated into SC-13]."'
+  description: '[Withdrawn: Incorporated into SC-13].'
 SC-13 (4):
   family: SC
   name: Digital Signatures
-  description: '"[Withdrawn: Incorporated into SC-13]."'
+  description: '[Withdrawn: Incorporated into SC-13].'
 SC-14:
   family: SC
   name: Public Access Protections
@@ -4813,23 +4804,23 @@ SC-15:
 SC-15 (1):
   family: SC
   name: Physical Disconnect
-  description: '"The information system provides physical disconnect of collaborative
-    computing devices in a manner that supports ease of use."'
+  description: The information system provides physical disconnect of collaborative
+    computing devices in a manner that supports ease of use.
 SC-15 (2):
   family: SC
   name: Blocking Inbound / Outbound Communications Traffic
-  description: '"[Withdrawn: Incorporated into SC-7]."'
+  description: '[Withdrawn: Incorporated into SC-7].'
 SC-15 (3):
   family: SC
   name: Disabling / Removal In Secure Work Areas
-  description: '"The organization disables or removes collaborative computing devices
+  description: 'The organization disables or removes collaborative computing devices
     from [Assignment: organization-defined information systems or information system
-    components] in [Assignment: organization-defined secure work areas]."'
+    components] in [Assignment: organization-defined secure work areas].'
 SC-15 (4):
   family: SC
   name: Explicitly Indicate Current Participants
-  description: '"The information system provides an explicit indication of current
-    participants in [Assignment: organization-defined online meetings and teleconferences]."'
+  description: 'The information system provides an explicit indication of current
+    participants in [Assignment: organization-defined online meetings and teleconferences].'
 SC-16:
   family: SC
   name: Transmission Of Security Attributes
@@ -4839,8 +4830,8 @@ SC-16:
 SC-16 (1):
   family: SC
   name: Integrity Validation
-  description: '"The information system validates the integrity of transmitted security
-    attributes."'
+  description: The information system validates the integrity of transmitted security
+    attributes.
 SC-17:
   family: SC
   name: Public Key Infrastructure Certificates
@@ -4858,31 +4849,31 @@ SC-18:
 SC-18 (1):
   family: SC
   name: Identify Unacceptable Code / Take Corrective Actions
-  description: '"The information system identifies [Assignment: organization-defined
+  description: 'The information system identifies [Assignment: organization-defined
     unacceptable mobile code] and takes [Assignment: organization-defined corrective
-    actions]."'
+    actions].'
 SC-18 (2):
   family: SC
   name: Acquisition / Development / Use
-  description: '"The organization ensures that the acquisition, development, and use
+  description: 'The organization ensures that the acquisition, development, and use
     of mobile code to be deployed in the information system meets [Assignment: organization-defined
-    mobile code requirements]."'
+    mobile code requirements].'
 SC-18 (3):
   family: SC
   name: Prevent Downloading / Execution
-  description: '"The information system prevents the download and execution of [Assignment:
-    organization-defined unacceptable mobile code]."'
+  description: 'The information system prevents the download and execution of [Assignment:
+    organization-defined unacceptable mobile code].'
 SC-18 (4):
   family: SC
   name: Prevent Automatic Execution
-  description: '"The information system prevents the automatic execution of mobile
+  description: 'The information system prevents the automatic execution of mobile
     code in [Assignment: organization-defined software applications] and enforces
-    [Assignment: organization-defined actions] prior to executing the code."'
+    [Assignment: organization-defined actions] prior to executing the code.'
 SC-18 (5):
   family: SC
   name: Allow Execution Only In Confined Environments
-  description: '"The organization allows execution of permitted mobile code only in
-    confined virtual machine environments."'
+  description: The organization allows execution of permitted mobile code only in
+    confined virtual machine environments.
 SC-19:
   family: SC
   name: Voice Over Internet Protocol
@@ -4900,12 +4891,12 @@ SC-20:
 SC-20 (1):
   family: SC
   name: Child Subspaces
-  description: '"[Withdrawn: Incorporated into SC-20]."'
+  description: '[Withdrawn: Incorporated into SC-20].'
 SC-20 (2):
   family: SC
   name: Data Origin / Integrity
-  description: '"The information system provides data origin and integrity protection
-    artifacts for internal name/address resolution queries."'
+  description: The information system provides data origin and integrity protection
+    artifacts for internal name/address resolution queries.
 SC-21:
   family: SC
   name: Secure Name / Address Resolution Service (Recursive Or Caching Resolver)
@@ -4915,7 +4906,7 @@ SC-21:
 SC-21 (1):
   family: SC
   name: Data Origin / Integrity
-  description: '"[Withdrawn: Incorporated into SC-21]."'
+  description: '[Withdrawn: Incorporated into SC-21].'
 SC-22:
   family: SC
   name: Architecture And Provisioning For Name / Address Resolution Service
@@ -4930,27 +4921,27 @@ SC-23:
 SC-23 (1):
   family: SC
   name: Invalidate Session Identifiers At Logout
-  description: '"The information system invalidates session identifiers upon user
-    logout or other session termination."'
+  description: The information system invalidates session identifiers upon user logout
+    or other session termination.
 SC-23 (2):
   family: SC
   name: User-Initiated Logouts / Message Displays
-  description: '"[Withdrawn: Incorporated into AC-12 (1)]."'
+  description: '[Withdrawn: Incorporated into AC-12 (1)].'
 SC-23 (3):
   family: SC
   name: Unique Session Identifiers With Randomization
-  description: '"The information system generates a unique session identifier for
-    each session with [Assignment: organization-defined randomness requirements] and
-    recognizes only session identifiers that are system-generated."'
+  description: 'The information system generates a unique session identifier for each
+    session with [Assignment: organization-defined randomness requirements] and recognizes
+    only session identifiers that are system-generated.'
 SC-23 (4):
   family: SC
   name: Unique Session Identifiers With Randomization
-  description: '"[Withdrawn: Incorporated into SC-23 (3)]."'
+  description: '[Withdrawn: Incorporated into SC-23 (3)].'
 SC-23 (5):
   family: SC
   name: Allowed Certificate Authorities
-  description: '"The information system only allows the use of [Assignment: organization-defined
-    certificate authorities] for verification of the establishment of protected sessions."'
+  description: 'The information system only allows the use of [Assignment: organization-defined
+    certificate authorities] for verification of the establishment of protected sessions.'
 SC-24:
   family: SC
   name: Fail In Known State
@@ -4971,7 +4962,7 @@ SC-26:
 SC-26 (1):
   family: SC
   name: Detection Of Malicious Code
-  description: '"[Withdrawn: Incorporated into SC-35]."'
+  description: '[Withdrawn: Incorporated into SC-35].'
 SC-27:
   family: SC
   name: Platform-Independent Applications
@@ -4985,14 +4976,14 @@ SC-28:
 SC-28 (1):
   family: SC
   name: Cryptographic Protection
-  description: '"The information system implements cryptographic mechanisms to prevent
+  description: 'The information system implements cryptographic mechanisms to prevent
     unauthorized disclosure and modification of [Assignment: organization-defined
-    information] on [Assignment: organization-defined information system components]."'
+    information] on [Assignment: organization-defined information system components].'
 SC-28 (2):
   family: SC
   name: Off-Line Storage
-  description: '"The organization removes from online storage and stores off-line
-    in a secure location [Assignment: organization-defined information]."'
+  description: 'The organization removes from online storage and stores off-line in
+    a secure location [Assignment: organization-defined information].'
 SC-29:
   family: SC
   name: Heterogeneity
@@ -5002,9 +4993,9 @@ SC-29:
 SC-29 (1):
   family: SC
   name: Virtualization Techniques
-  description: '"The organization employs virtualization techniques to support the
+  description: 'The organization employs virtualization techniques to support the
     deployment of a diversity of operating systems and applications that are changed
-    [Assignment: organization-defined frequency]."'
+    [Assignment: organization-defined frequency].'
 SC-30:
   family: SC
   name: Concealment And Misdirection
@@ -5015,29 +5006,29 @@ SC-30:
 SC-30 (1):
   family: SC
   name: Virtualization Techniques
-  description: '"[Withdrawn: Incorporated into SC-29 (1)]."'
+  description: '[Withdrawn: Incorporated into SC-29 (1)].'
 SC-30 (2):
   family: SC
   name: Randomness
-  description: '"The organization employs [Assignment: organization-defined techniques]
-    to introduce randomness into organizational operations and assets."'
+  description: 'The organization employs [Assignment: organization-defined techniques]
+    to introduce randomness into organizational operations and assets.'
 SC-30 (3):
   family: SC
   name: Change Processing / Storage Locations
-  description: '"The organization changes the location of [Assignment: organization-defined
+  description: 'The organization changes the location of [Assignment: organization-defined
     processing and/or storage] [Selection: [Assignment: organization-defined time
-    frequency]; at random time intervals]]."'
+    frequency]; at random time intervals]].'
 SC-30 (4):
   family: SC
   name: Misleading Information
-  description: '"The organization employs realistic, but misleading information in
+  description: 'The organization employs realistic, but misleading information in
     [Assignment: organization-defined information system components] with regard to
-    its security state or posture."'
+    its security state or posture.'
 SC-30 (5):
   family: SC
   name: Concealment Of System Components
-  description: '"The organization employs [Assignment: organization-defined techniques]
-    to hide or conceal [Assignment: organization-defined information system components]."'
+  description: 'The organization employs [Assignment: organization-defined techniques]
+    to hide or conceal [Assignment: organization-defined information system components].'
 SC-31:
   family: SC
   name: Covert Channel Analysis
@@ -5048,20 +5039,20 @@ SC-31:
 SC-31 (1):
   family: SC
   name: Test Covert Channels For Exploitability
-  description: '"The organization tests a subset of the identified covert channels
-    to determine which channels are exploitable."'
+  description: The organization tests a subset of the identified covert channels to
+    determine which channels are exploitable.
 SC-31 (2):
   family: SC
   name: Maximum Bandwidth
-  description: '"The organization reduces the maximum bandwidth for identified covert
+  description: 'The organization reduces the maximum bandwidth for identified covert
     [Selection (one or more); storage; timing] channels to [Assignment: organization-defined
-    values]."'
+    values].'
 SC-31 (3):
   family: SC
   name: Measure Bandwidth In Operational Environments
-  description: '"The organization measures the bandwidth of [Assignment: organization-defined
+  description: 'The organization measures the bandwidth of [Assignment: organization-defined
     subset of identified covert channels] in the operational environment of the information
-    system."'
+    system.'
 SC-32:
   family: SC
   name: Information System Partitioning
@@ -5083,15 +5074,15 @@ SC-34:
 SC-34 (1):
   family: SC
   name: No Writable Storage
-  description: '"The organization employs [Assignment: organization-defined information
+  description: 'The organization employs [Assignment: organization-defined information
     system components] with no writeable storage that is persistent across component
-    restart or power on/off."'
+    restart or power on/off.'
 SC-34 (2):
   family: SC
   name: Integrity Protection / Read-Only Media
-  description: '"The organization protects the integrity of information prior to storage
+  description: The organization protects the integrity of information prior to storage
     on read-only media and controls the media after such information has been recorded
-    onto the media."'
+    onto the media.
 SC-34 (3):
   family: SC
   name: Hardware-Based Protection
@@ -5112,9 +5103,9 @@ SC-36:
 SC-36 (1):
   family: SC
   name: Polling Techniques
-  description: '"The organization employs polling techniques to identify potential
+  description: 'The organization employs polling techniques to identify potential
     faults, errors, or compromises to [Assignment: organization-defined distributed
-    processing and storage components]."'
+    processing and storage components].'
 SC-37:
   family: SC
   name: Out-Of-Band Channels
@@ -5125,10 +5116,10 @@ SC-37:
 SC-37 (1):
   family: SC
   name: Ensure Delivery / Transmission
-  description: '"The organization employs [Assignment: organization-defined security
+  description: 'The organization employs [Assignment: organization-defined security
     safeguards] to ensure that only [Assignment: organization-defined individuals
     or information systems] receive the [Assignment: organization-defined information,
-    information system components, or devices]."'
+    information system components, or devices].'
 SC-38:
   family: SC
   name: Operations Security
@@ -5143,13 +5134,13 @@ SC-39:
 SC-39 (1):
   family: SC
   name: Hardware Separation
-  description: '"The information system implements underlying hardware separation
-    mechanisms to facilitate process separation."'
+  description: The information system implements underlying hardware separation mechanisms
+    to facilitate process separation.
 SC-39 (2):
   family: SC
   name: Thread Isolation
-  description: '"The information system maintains a separate execution domain for
-    each thread in [Assignment: organization-defined multi-threaded processing]."'
+  description: 'The information system maintains a separate execution domain for each
+    thread in [Assignment: organization-defined multi-threaded processing].'
 SC-40:
   family: SC
   name: Wireless Link Protection
@@ -5159,27 +5150,27 @@ SC-40:
 SC-40 (1):
   family: SC
   name: Electromagnetic Interference
-  description: '"The information system implements cryptographic mechanisms that achieve
+  description: 'The information system implements cryptographic mechanisms that achieve
     [Assignment: organization-defined level of protection] against the effects of
-    intentional electromagnetic interference."'
+    intentional electromagnetic interference.'
 SC-40 (2):
   family: SC
   name: Reduce Detection Potential
-  description: '"The information system implements cryptographic mechanisms to reduce
+  description: 'The information system implements cryptographic mechanisms to reduce
     the detection potential of wireless links to [Assignment: organization-defined
-    level of reduction]."'
+    level of reduction].'
 SC-40 (3):
   family: SC
   name: Imitative Or Manipulative Communications Deception
-  description: '"The information system implements cryptographic mechanisms to identify
+  description: The information system implements cryptographic mechanisms to identify
     and reject wireless transmissions that are deliberate attempts to achieve imitative
-    or manipulative communications deception based on signal parameters."'
+    or manipulative communications deception based on signal parameters.
 SC-40 (4):
   family: SC
   name: Signal Parameter Identification
-  description: '"The information system implements cryptographic mechanisms to prevent
+  description: 'The information system implements cryptographic mechanisms to prevent
     the identification of [Assignment: organization-defined wireless transmitters]
-    by using the transmitter signal parameters."'
+    by using the transmitter signal parameters.'
 SC-41:
   family: SC
   name: Port And I/O Device Access
@@ -5196,21 +5187,21 @@ SC-42:
 SC-42 (1):
   family: SC
   name: Reporting To Authorized Individuals Or Roles
-  description: '"The organization ensures that the information system is configured
+  description: 'The organization ensures that the information system is configured
     so that data or information collected by the [Assignment: organization-defined
-    sensors] is only reported to authorized individuals or roles."'
+    sensors] is only reported to authorized individuals or roles.'
 SC-42 (2):
   family: SC
   name: Authorized Use
-  description: '"The organization employs the following measures: [Assignment: organization-defined
+  description: 'The organization employs the following measures: [Assignment: organization-defined
     measures], so that data or information collected by [Assignment: organization-defined
-    sensors] is only used for authorized purposes."'
+    sensors] is only used for authorized purposes.'
 SC-42 (3):
   family: SC
   name: Prohibit Use Of Devices
-  description: '"The organization prohibits the use of devices possessing [Assignment:
+  description: 'The organization prohibits the use of devices possessing [Assignment:
     organization-defined environmental sensing capabilities] in [Assignment: organization-defined
-    facilities, areas, or systems]."'
+    facilities, areas, or systems].'
 SC-43:
   family: SC
   name: Usage Restrictions
@@ -5246,13 +5237,13 @@ SI-2:
 SI-2 (1):
   family: SI
   name: Central Management
-  description: '"The organization centrally manages the flaw remediation process."'
+  description: The organization centrally manages the flaw remediation process.
 SI-2 (2):
   family: SI
   name: Automated Flaw Remediation Status
-  description: '"The organization employs automated mechanisms [Assignment: organization-defined
+  description: 'The organization employs automated mechanisms [Assignment: organization-defined
     frequency] to determine the state of information system components with regard
-    to flaw remediation."'
+    to flaw remediation.'
 SI-2 (3):
   family: SI
   name: Time To Remediate Flaws / Benchmarks For Corrective Actions
@@ -5263,18 +5254,18 @@ SI-2 (3):
 SI-2 (4):
   family: SI
   name: Automated Patch Management Tools
-  description: '"[Withdrawn: Incorporated into SI-2]."'
+  description: '[Withdrawn: Incorporated into SI-2].'
 SI-2 (5):
   family: SI
   name: Automatic Software / Firmware Updates
-  description: '"The organization installs [Assignment: organization-defined security-relevant
+  description: 'The organization installs [Assignment: organization-defined security-relevant
     software and firmware updates] automatically to [Assignment: organization-defined
-    information system components]."'
+    information system components].'
 SI-2 (6):
   family: SI
   name: Removal Of Previous Versions Of Software / Firmware
-  description: '"The organization removes [Assignment: organization-defined software
-    and firmware components] after updated versions have been installed."'
+  description: 'The organization removes [Assignment: organization-defined software
+    and firmware components] after updated versions have been installed.'
 SI-3:
   family: SI
   name: Malicious Code Protection
@@ -5289,25 +5280,25 @@ SI-3:
 SI-3 (1):
   family: SI
   name: Central Management
-  description: '"The organization centrally manages malicious code protection mechanisms."'
+  description: The organization centrally manages malicious code protection mechanisms.
 SI-3 (2):
   family: SI
   name: Automatic Updates
-  description: '"The information system automatically updates malicious code protection
-    mechanisms."'
+  description: The information system automatically updates malicious code protection
+    mechanisms.
 SI-3 (3):
   family: SI
   name: Non-Privileged Users
-  description: '"[Withdrawn: Incorporated into AC-6 (10)]."'
+  description: '[Withdrawn: Incorporated into AC-6 (10)].'
 SI-3 (4):
   family: SI
   name: Updates Only By Privileged Users
-  description: '"The information system updates malicious code protection mechanisms
-    only when directed by a privileged user."'
+  description: The information system updates malicious code protection mechanisms
+    only when directed by a privileged user.
 SI-3 (5):
   family: SI
   name: Portable Storage Devices
-  description: '"[Withdrawn: Incorporated into MP-7]."'
+  description: '[Withdrawn: Incorporated into MP-7].'
 SI-3 (6):
   family: SI
   name: Testing / Verification
@@ -5318,22 +5309,22 @@ SI-3 (6):
 SI-3 (7):
   family: SI
   name: Nonsignature-Based Detection
-  description: '"The information system implements nonsignature-based malicious code
-    detection mechanisms."'
+  description: The information system implements nonsignature-based malicious code
+    detection mechanisms.
 SI-3 (8):
   family: SI
   name: Detect Unauthorized Commands
-  description: '"The information system detects [Assignment: organization-defined
-    unauthorized operating system commands] through the kernel application programming
-    interface at [Assignment: organization-defined information system hardware components]
-    and [Selection (one or more): issues a warning; audits the command execution;
-    prevents the execution of the command]."'
+  description: 'The information system detects [Assignment: organization-defined unauthorized
+    operating system commands] through the kernel application programming interface
+    at [Assignment: organization-defined information system hardware components] and
+    [Selection (one or more): issues a warning; audits the command execution; prevents
+    the execution of the command].'
 SI-3 (9):
   family: SI
   name: Authenticate Remote Commands
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     security safeguards] to authenticate [Assignment: organization-defined remote
-    commands]."'
+    commands].'
 SI-3 (10):
   family: SI
   name: Malicious Code Analysis
@@ -5360,71 +5351,71 @@ SI-4:
 SI-4 (1):
   family: SI
   name: System-Wide Intrusion Detection System
-  description: '"The organization connects and configures individual intrusion detection
-    tools into an information system-wide intrusion detection system."'
+  description: The organization connects and configures individual intrusion detection
+    tools into an information system-wide intrusion detection system.
 SI-4 (2):
   family: SI
   name: Automated Tools For Real-Time Analysis
-  description: '"The organization employs automated tools to support near real-time
-    analysis of events."'
+  description: The organization employs automated tools to support near real-time
+    analysis of events.
 SI-4 (3):
   family: SI
   name: Automated Tool Integration
-  description: '"The organization employs automated tools to integrate intrusion detection
+  description: The organization employs automated tools to integrate intrusion detection
     tools into access control and flow control mechanisms for rapid response to attacks
     by enabling reconfiguration of these mechanisms in support of attack isolation
-    and elimination."'
+    and elimination.
 SI-4 (4):
   family: SI
   name: Inbound And Outbound Communications Traffic
-  description: '"The information system monitors inbound and outbound communications
+  description: 'The information system monitors inbound and outbound communications
     traffic [Assignment: organization-defined frequency] for unusual or unauthorized
-    activities or conditions."'
+    activities or conditions.'
 SI-4 (5):
   family: SI
   name: System-Generated Alerts
-  description: '"The information system alerts [Assignment: organization-defined personnel
+  description: 'The information system alerts [Assignment: organization-defined personnel
     or roles] when the following indications of compromise or potential compromise
-    occur: [Assignment: organization-defined compromise indicators]."'
+    occur: [Assignment: organization-defined compromise indicators].'
 SI-4 (6):
   family: SI
   name: Restrict Non-Privileged Users
-  description: '"[Withdrawn: Incorporated into AC-6 (10)]."'
+  description: '[Withdrawn: Incorporated into AC-6 (10)].'
 SI-4 (7):
   family: SI
   name: Automated Response To Suspicious Events
-  description: '"The information system notifies [Assignment: organization-defined
+  description: 'The information system notifies [Assignment: organization-defined
     incident response personnel (identified by name and/or by role)] of detected suspicious
     events and takes [Assignment: organization-defined least-disruptive actions to
-    terminate suspicious events]."'
+    terminate suspicious events].'
 SI-4 (8):
   family: SI
   name: Protection Of Monitoring Information
-  description: '"[Withdrawn: Incorporated into SI-4]."'
+  description: '[Withdrawn: Incorporated into SI-4].'
 SI-4 (9):
   family: SI
   name: Testing Of Monitoring Tools
-  description: '"The organization tests intrusion-monitoring tools [Assignment: organization-defined
-    frequency]."'
+  description: 'The organization tests intrusion-monitoring tools [Assignment: organization-defined
+    frequency].'
 SI-4 (10):
   family: SI
   name: Visibility Of Encrypted Communications
-  description: '"The organization makes provisions so that [Assignment: organization-defined
+  description: 'The organization makes provisions so that [Assignment: organization-defined
     encrypted communications traffic] is visible to [Assignment: organization-defined
-    information system monitoring tools]."'
+    information system monitoring tools].'
 SI-4 (11):
   family: SI
   name: Analyze Communications Traffic Anomalies
-  description: '"The organization analyzes outbound communications traffic at the
-    external boundary of the information system and selected [Assignment: organization-defined
+  description: 'The organization analyzes outbound communications traffic at the external
+    boundary of the information system and selected [Assignment: organization-defined
     interior points within the system (e.g., subnetworks, subsystems)] to discover
-    anomalies."'
+    anomalies.'
 SI-4 (12):
   family: SI
   name: Automated Alerts
-  description: '"The organization employs automated mechanisms to alert security personnel
+  description: 'The organization employs automated mechanisms to alert security personnel
     of the following inappropriate or unusual activities with security implications:
-    [Assignment: organization-defined activities that trigger alerts]."'
+    [Assignment: organization-defined activities that trigger alerts].'
 SI-4 (13):
   family: SI
   name: Analyze Traffic / Event Patterns
@@ -5436,68 +5427,67 @@ SI-4 (13):
 SI-4 (14):
   family: SI
   name: Wireless Intrusion Detection
-  description: '"The organization employs a wireless intrusion detection system to
-    identify rogue wireless devices and to detect attack attempts and potential compromises/breaches
-    to the information system."'
+  description: The organization employs a wireless intrusion detection system to identify
+    rogue wireless devices and to detect attack attempts and potential compromises/breaches
+    to the information system.
 SI-4 (15):
   family: SI
   name: Wireless To Wireline Communications
-  description: '"The organization employs an intrusion detection system to monitor
-    wireless communications traffic as the traffic passes from wireless to wireline
-    networks."'
+  description: The organization employs an intrusion detection system to monitor wireless
+    communications traffic as the traffic passes from wireless to wireline networks.
 SI-4 (16):
   family: SI
   name: Correlate Monitoring Information
-  description: '"The organization correlates information from monitoring tools employed
-    throughout the information system."'
+  description: The organization correlates information from monitoring tools employed
+    throughout the information system.
 SI-4 (17):
   family: SI
   name: Integrated Situational Awareness
-  description: '"The organization correlates information from monitoring physical,
-    cyber, and supply chain activities to achieve integrated, organization-wide situational
-    awareness."'
+  description: The organization correlates information from monitoring physical, cyber,
+    and supply chain activities to achieve integrated, organization-wide situational
+    awareness.
 SI-4 (18):
   family: SI
   name: Analyze Traffic / Covert Exfiltration
-  description: '"The organization analyzes outbound communications traffic at the
-    external boundary of the information system (i.e., system perimeter) and at [Assignment:
+  description: 'The organization analyzes outbound communications traffic at the external
+    boundary of the information system (i.e., system perimeter) and at [Assignment:
     organization-defined interior points within the system (e.g., subsystems, subnetworks)]
-    to detect covert exfiltration of information."'
+    to detect covert exfiltration of information.'
 SI-4 (19):
   family: SI
   name: Individuals Posing Greater Risk
-  description: '"The organization implements [Assignment: organization-defined additional
+  description: 'The organization implements [Assignment: organization-defined additional
     monitoring] of individuals who have been identified by [Assignment: organization-defined
-    sources] as posing an increased level of risk."'
+    sources] as posing an increased level of risk.'
 SI-4 (20):
   family: SI
   name: Privileged Users
-  description: '"The organization implements [Assignment: organization-defined additional
-    monitoring] of privileged users."'
+  description: 'The organization implements [Assignment: organization-defined additional
+    monitoring] of privileged users.'
 SI-4 (21):
   family: SI
   name: Probationary Periods
-  description: '"The organization implements [Assignment: organization-defined additional
+  description: 'The organization implements [Assignment: organization-defined additional
     monitoring] of individuals during [Assignment: organization-defined probationary
-    period]."'
+    period].'
 SI-4 (22):
   family: SI
   name: Unauthorized Network Services
-  description: '"The information system detects network services that have not been
+  description: 'The information system detects network services that have not been
     authorized or approved by [Assignment: organization-defined authorization or approval
     processes] and [Selection (one or more): audits; alerts [Assignment: organization-defined
-    personnel or roles]]."'
+    personnel or roles]].'
 SI-4 (23):
   family: SI
   name: Host-Based Devices
-  description: '"The organization implements [Assignment: organization-defined host-based
+  description: 'The organization implements [Assignment: organization-defined host-based
     monitoring mechanisms] at [Assignment: organization-defined information system
-    components]."'
+    components].'
 SI-4 (24):
   family: SI
   name: Indicators Of Compromise
-  description: '"The information system discovers, collects, distributes, and uses
-    indicators of compromise."'
+  description: The information system discovers, collects, distributes, and uses indicators
+    of compromise.
 SI-5:
   family: SI
   name: Security Alerts, Advisories, And Directives
@@ -5510,8 +5500,8 @@ SI-5:
 SI-5 (1):
   family: SI
   name: Automated Alerts And Advisories
-  description: '"The organization employs automated mechanisms to make security alert
-    and advisory information available throughout the organization."'
+  description: The organization employs automated mechanisms to make security alert
+    and advisory information available throughout the organization.
 SI-6:
   family: SI
   name: Security Function Verification
@@ -5524,17 +5514,17 @@ SI-6:
 SI-6 (1):
   family: SI
   name: Notification Of Failed Security Tests
-  description: '"[Withdrawn: Incorporated into SI-6]."'
+  description: '[Withdrawn: Incorporated into SI-6].'
 SI-6 (2):
   family: SI
   name: Automation Support For Distributed Testing
-  description: '"The information system implements automated mechanisms to support
-    the management of distributed security testing."'
+  description: The information system implements automated mechanisms to support the
+    management of distributed security testing.
 SI-6 (3):
   family: SI
   name: Report Verification Results
-  description: '"The organization reports the results of security function verification
-    to [Assignment: organization-defined personnel or roles]."'
+  description: 'The organization reports the results of security function verification
+    to [Assignment: organization-defined personnel or roles].'
 SI-7:
   family: SI
   name: Software, Firmware, And Information Integrity
@@ -5543,79 +5533,78 @@ SI-7:
 SI-7 (1):
   family: SI
   name: Integrity Checks
-  description: '"The information system performs an integrity check of [Assignment:
+  description: 'The information system performs an integrity check of [Assignment:
     organization-defined software, firmware, and information] [Selection (one or more):
     at startup; at [Assignment: organization-defined transitional states or security-relevant
-    events]; [Assignment: organization-defined frequency]]."'
+    events]; [Assignment: organization-defined frequency]].'
 SI-7 (2):
   family: SI
   name: Automated Notifications Of Integrity Violations
-  description: '"The organization employs automated tools that provide notification
+  description: 'The organization employs automated tools that provide notification
     to [Assignment: organization-defined personnel or roles] upon discovering discrepancies
-    during integrity verification."'
+    during integrity verification.'
 SI-7 (3):
   family: SI
   name: Centrally-Managed Integrity Tools
-  description: '"The organization employs centrally managed integrity verification
-    tools."'
+  description: The organization employs centrally managed integrity verification tools.
 SI-7 (4):
   family: SI
   name: Tamper-Evident Packaging
-  description: '"[Withdrawn: Incorporated into SA-12]."'
+  description: '[Withdrawn: Incorporated into SA-12].'
 SI-7 (5):
   family: SI
   name: Automated Response To Integrity Violations
-  description: '"The information system automatically [Selection (one or more): shuts
+  description: 'The information system automatically [Selection (one or more): shuts
     the information system down; restarts the information system; implements [Assignment:
-    organization-defined security safeguards]] when integrity violations are discovered."'
+    organization-defined security safeguards]] when integrity violations are discovered.'
 SI-7 (6):
   family: SI
   name: Cryptographic Protection
-  description: '"The information system implements cryptographic mechanisms to detect
-    unauthorized changes to software, firmware, and information."'
+  description: The information system implements cryptographic mechanisms to detect
+    unauthorized changes to software, firmware, and information.
 SI-7 (7):
   family: SI
   name: Integration Of Detection And Response
-  description: '"The organization incorporates the detection of unauthorized [Assignment:
+  description: 'The organization incorporates the detection of unauthorized [Assignment:
     organization-defined security-relevant changes to the information system] into
-    the organizational incident response capability."'
+    the organizational incident response capability.'
 SI-7 (8):
   family: SI
   name: Auditing Capability For Significant Events
-  description: '"The information system, upon detection of a potential integrity violation,
+  description: 'The information system, upon detection of a potential integrity violation,
     provides the capability to audit the event and initiates the following actions:
     [Selection (one or more): generates an audit record; alerts current user; alerts
     [Assignment: organization-defined personnel or roles]; [Assignment: organization-defined
-    other actions]]."'
+    other actions]].'
 SI-7 (9):
   family: SI
   name: Verify Boot Process
-  description: '"The information system verifies the integrity of the boot process
-    of [Assignment: organization-defined devices]."'
+  description: 'The information system verifies the integrity of the boot process
+    of [Assignment: organization-defined devices].'
 SI-7 (10):
   family: SI
   name: Protection Of Boot Firmware
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     security safeguards] to protect the integrity of boot firmware in [Assignment:
-    organization-defined devices]."'
+    organization-defined devices].'
 SI-7 (11):
   family: SI
   name: Confined Environments With Limited Privileges
-  description: '"The organization requires that [Assignment: organization-defined
-    user-installed software] execute in a confined physical or virtual machine environment
-    with limited privileges."'
+  description: 'The organization requires that [Assignment: organization-defined user-installed
+    software] execute in a confined physical or virtual machine environment with limited
+    privileges.'
 SI-7 (12):
   family: SI
   name: Integrity Verification
-  description: '"The organization requires that the integrity of [Assignment: organization-defined
-    user-installed software] be verified prior to execution."'
+  description: 'The organization requires that the integrity of [Assignment: organization-defined
+    user-installed software] be verified prior to execution.'
 SI-7 (13):
   family: SI
   name: Code Execution In Protected Environments
-  description: '"The organization allows execution of binary or machine-executable
+  description: 'The organization allows execution of binary or machine-executable
     code obtained from sources with limited or no warranty and without the provision
     of source code only in confined physical or virtual machine environments and with
-    the explicit approval of [Assignment: organization-defined personnel or roles]."'
+    the explicit approval of [Assignment: organization-defined personnel or roles].'
 SI-7 (14):
   family: SI
   name: Binary Or Machine Executable Code
@@ -5626,13 +5615,13 @@ SI-7 (14):
 SI-7 (15):
   family: SI
   name: Code Authentication
-  description: '"The information system implements cryptographic mechanisms to authenticate
-    [Assignment: organization-defined software or firmware components] prior to installation."'
+  description: 'The information system implements cryptographic mechanisms to authenticate
+    [Assignment: organization-defined software or firmware components] prior to installation.'
 SI-7 (16):
   family: SI
   name: Time Limit On Process Execution W/O Supervision
-  description: '"The organization does not allow processes to execute without supervision
-    for more than [Assignment: organization-defined time period]."'
+  description: 'The organization does not allow processes to execute without supervision
+    for more than [Assignment: organization-defined time period].'
 SI-8:
   family: SI
   name: Spam Protection
@@ -5643,16 +5632,16 @@ SI-8:
 SI-8 (1):
   family: SI
   name: Central Management
-  description: '"The organization centrally manages spam protection mechanisms."'
+  description: The organization centrally manages spam protection mechanisms.
 SI-8 (2):
   family: SI
   name: Automatic Updates
-  description: '"The information system automatically updates spam protection mechanisms."'
+  description: The information system automatically updates spam protection mechanisms.
 SI-8 (3):
   family: SI
   name: Continuous Learning Capability
-  description: '"The information system implements spam protection mechanisms with
-    a learning capability to more effectively identify legitimate communications traffic."'
+  description: The information system implements spam protection mechanisms with a
+    learning capability to more effectively identify legitimate communications traffic.
 SI-9:
   family: SI
   name: Information Input Restrictions
@@ -5673,24 +5662,24 @@ SI-10 (1):
 SI-10 (2):
   family: SI
   name: Review / Resolution Of Errors
-  description: '"The organization ensures that input validation errors are reviewed
-    and resolved within [Assignment: organization-defined time period]."'
+  description: 'The organization ensures that input validation errors are reviewed
+    and resolved within [Assignment: organization-defined time period].'
 SI-10 (3):
   family: SI
   name: Predictable Behavior
-  description: '"The information system behaves in a predictable and documented manner
-    that reflects organizational and system objectives when invalid inputs are received."'
+  description: The information system behaves in a predictable and documented manner
+    that reflects organizational and system objectives when invalid inputs are received.
 SI-10 (4):
   family: SI
   name: Review / Timing Interactions
-  description: '"The organization accounts for timing interactions among information
-    system components in determining appropriate responses for invalid inputs."'
+  description: The organization accounts for timing interactions among information
+    system components in determining appropriate responses for invalid inputs.
 SI-10 (5):
   family: SI
   name: Restrict Inputs To Trusted Sources And Approved Formats
-  description: '"The organization restricts the use of information inputs to [Assignment:
+  description: 'The organization restricts the use of information inputs to [Assignment:
     organization-defined trusted sources] and/or [Assignment: organization-defined
-    formats]."'
+    formats].'
 SI-11:
   family: SI
   name: Error Handling
@@ -5715,19 +5704,19 @@ SI-13:
 SI-13 (1):
   family: SI
   name: Transferring Component Responsibilities
-  description: '"The organization takes information system components out of service
+  description: 'The organization takes information system components out of service
     by transferring component responsibilities to substitute components no later than
-    [Assignment: organization-defined fraction or percentage] of mean time to failure."'
+    [Assignment: organization-defined fraction or percentage] of mean time to failure.'
 SI-13 (2):
   family: SI
   name: Time Limit On Process Execution Without Supervision
-  description: '"[Withdrawn: Incorporated into SI-7 (16)]."'
+  description: '[Withdrawn: Incorporated into SI-7 (16)].'
 SI-13 (3):
   family: SI
   name: Manual Transfer Between Components
-  description: '"The organization manually initiates transfers between active and
-    standby information system components [Assignment: organization-defined frequency]
-    if the mean time to failure exceeds [Assignment: organization-defined time period]."'
+  description: 'The organization manually initiates transfers between active and standby
+    information system components [Assignment: organization-defined frequency] if
+    the mean time to failure exceeds [Assignment: organization-defined time period].'
 SI-13 (4):
   family: SI
   name: Standby Component Installation / Notification
@@ -5738,8 +5727,8 @@ SI-13 (4):
 SI-13 (5):
   family: SI
   name: Failover Capability
-  description: '"The organization provides [Selection: real-time; near real-time]
-    [Assignment: organization-defined failover capability] for the information system."'
+  description: 'The organization provides [Selection: real-time; near real-time] [Assignment:
+    organization-defined failover capability] for the information system.'
 SI-14:
   family: SI
   name: Non-Persistence
@@ -5750,9 +5739,9 @@ SI-14:
 SI-14 (1):
   family: SI
   name: Refresh From Trusted Sources
-  description: '"The organization ensures that software and data employed during information
+  description: 'The organization ensures that software and data employed during information
     system component and service refreshes are obtained from [Assignment: organization-defined
-    trusted sources]."'
+    trusted sources].'
 SI-15:
   family: SI
   name: Information Output Filtering

--- a/nist-800-53-rev4.yaml
+++ b/nist-800-53-rev4.yaml
@@ -110,9 +110,9 @@ AC-2 (13):
 AC-3:
   family: AC
   name: Access Enforcement
-  description: '"The information system enforces approved authorizations for logical
+  description: The information system enforces approved authorizations for logical
     access to information           and system resources in accordance with applicable
-    access control policies."'
+    access control policies.
 AC-3 (1):
   family: AC
   name: Restricted Access To Privileged Functions
@@ -182,9 +182,9 @@ AC-3 (10):
 AC-4:
   family: AC
   name: Information Flow Enforcement
-  description: '"The information system enforces approved authorizations for controlling
+  description: 'The information system enforces approved authorizations for controlling
     the flow of information within the system and between interconnected systems based
-    on [Assignment: organization-defined information flow control policies]."'
+    on [Assignment: organization-defined information flow control policies].'
 AC-4 (1):
   family: AC
   name: Object Security Attributes
@@ -319,17 +319,17 @@ AC-5:
   family: AC
   name: Separation Of Duties
   description: |-
-    "The organization:
+    The organization:
       a.  Separates [Assignment: organization-defined duties of individuals];
       b.  Documents separation of duties of individuals; and
-      c.  Defines information system access authorizations to support separation of duties."
+      c.  Defines information system access authorizations to support separation of duties.
 AC-6:
   family: AC
   name: Least Privilege
-  description: '"The organization employs the principle of least privilege, allowing
+  description: The organization employs the principle of least privilege, allowing
     only authorized accesses for users (or processes acting on behalf of users) which
     are necessary to accomplish assigned tasks in accordance with organizational missions
-    and business functions."'
+    and business functions.
 AC-6 (1):
   family: AC
   name: Authorize Access To Security Functions
@@ -423,8 +423,8 @@ AC-8:
 AC-9:
   family: AC
   name: Previous Logon (Access) Notification
-  description: '"The information system notifies the user, upon successful logon (access)
-    to the system, of the date and time of the last logon (access)."'
+  description: The information system notifies the user, upon successful logon (access)
+    to the system, of the date and time of the last logon (access).
 AC-9 (1):
   family: AC
   name: Unsuccessful Logons
@@ -452,9 +452,9 @@ AC-9 (4):
 AC-10:
   family: AC
   name: Concurrent Session Control
-  description: '"The information system limits the number of concurrent sessions for
+  description: 'The information system limits the number of concurrent sessions for
     each [Assignment: organization-defined account and/or account type] to [Assignment:
-    organization-defined number]."'
+    organization-defined number].'
 AC-11:
   family: AC
   name: Session Lock
@@ -470,9 +470,9 @@ AC-11 (1):
 AC-12:
   family: AC
   name: Session Termination
-  description: '"The information system automatically terminates a user session after
+  description: 'The information system automatically terminates a user session after
     [Assignment: organization-defined conditions or trigger events requiring session
-    disconnect]."'
+    disconnect].'
 AC-12 (1):
   family: AC
   name: User-Initiated Logouts / Message Displays
@@ -483,7 +483,7 @@ AC-12 (1):
 AC-13:
   family: AC
   name: Supervision And Review - Access Control
-  description: '"[Withdrawn: Incorporated into AC-2 and AU-6]."'
+  description: '[Withdrawn: Incorporated into AC-2 and AU-6].'
 AC-14:
   family: AC
   name: Permitted Actions Without Identification Or Authentication
@@ -498,7 +498,7 @@ AC-14 (1):
 AC-15:
   family: AC
   name: Automated Marking
-  description: '"[Withdrawn: Incorporated into MP-3]."'
+  description: '[Withdrawn: Incorporated into MP-3].'
 AC-16:
   family: AC
   name: Security Attributes
@@ -751,14 +751,14 @@ AC-22:
 AC-23:
   family: AC
   name: Data Mining Protection
-  description: '"The organization employs [Assignment: organization-defined data mining
+  description: 'The organization employs [Assignment: organization-defined data mining
     prevention and detection techniques] for [Assignment: organization-defined data
-    storage objects] to adequately detect and protect against data mining."'
+    storage objects] to adequately detect and protect against data mining.'
 AC-24:
   family: AC
   name: Access Control Decisions
-  description: '"The organization establishes procedures to ensure [Assignment: organization-defined
-    access control decisions] are applied to each access request prior to access enforcement."'
+  description: 'The organization establishes procedures to ensure [Assignment: organization-defined
+    access control decisions] are applied to each access request prior to access enforcement.'
 AC-24 (1):
   family: AC
   name: Transmit Access Authorization Information
@@ -775,10 +775,10 @@ AC-24 (2):
 AC-25:
   family: AC
   name: Reference Monitor
-  description: '"The information system implements a reference monitor for [Assignment:
+  description: 'The information system implements a reference monitor for [Assignment:
     organization-defined access control policies] that is tamperproof, always invoked,
     and small enough to be subject to analysis and testing, the completeness of which
-    can be assured."'
+    can be assured.'
 AT-1:
   family: AT
   name: Security Awareness And Training Policy And Procedures
@@ -849,7 +849,7 @@ AT-4:
 AT-5:
   family: AT
   name: Contacts With Security Groups And Associations
-  description: '"[Withdrawn: Incorporated into PM-15]."'
+  description: '[Withdrawn: Incorporated into PM-15].'
 AU-1:
   family: AU
   name: Audit And Accountability Policy And Procedures
@@ -890,10 +890,10 @@ AU-2 (4):
 AU-3:
   family: AU
   name: Content Of Audit Records
-  description: '"The information system generates audit records containing information
+  description: The information system generates audit records containing information
     that establishes what type of event occurred, when the event occurred, where the
     event occurred, the source of the event, the outcome of the event, and the identity
-    of any individuals or subjects associated with the event."'
+    of any individuals or subjects associated with the event.
 AU-3 (1):
   family: AU
   name: Additional Audit Information
@@ -909,8 +909,8 @@ AU-3 (2):
 AU-4:
   family: AU
   name: Audit Storage Capacity
-  description: '"The organization allocates audit record storage capacity in accordance
-    with [Assignment: organization-defined audit record storage requirements]."'
+  description: 'The organization allocates audit record storage capacity in accordance
+    with [Assignment: organization-defined audit record storage requirements].'
 AU-4 (1):
   family: AU
   name: Transfer To Alternate Storage
@@ -1056,8 +1056,8 @@ AU-8 (2):
 AU-9:
   family: AU
   name: Protection Of Audit Information
-  description: '"The information system protects audit information and audit tools
-    from unauthorized access, modification, and deletion."'
+  description: The information system protects audit information and audit tools from
+    unauthorized access, modification, and deletion.
 AU-9 (1):
   family: AU
   name: Hardware Write-Once Media
@@ -1092,9 +1092,9 @@ AU-9 (6):
 AU-10:
   family: AU
   name: Non-Repudiation
-  description: '"The information system protects against an individual (or process
+  description: 'The information system protects against an individual (or process
     acting on behalf of an individual) falsely denying having performed [Assignment:
-    organization-defined actions to be covered by non-repudiation]."'
+    organization-defined actions to be covered by non-repudiation].'
 AU-10 (1):
   family: AU
   name: Association Of Identities
@@ -1128,10 +1128,10 @@ AU-10 (5):
 AU-11:
   family: AU
   name: Audit Record Retention
-  description: '"The organization retains audit records for [Assignment: organization-defined
+  description: 'The organization retains audit records for [Assignment: organization-defined
     time period consistent with records retention policy] to provide support for after-the-fact
     investigations of security incidents and to meet regulatory and organizational
-    information retention requirements."'
+    information retention requirements.'
 AU-11 (1):
   family: AU
   name: Long-Term Retrieval Capability
@@ -1169,9 +1169,9 @@ AU-12 (3):
 AU-13:
   family: AU
   name: Monitoring For Information Disclosure
-  description: '"The organization monitors [Assignment: organization-defined open
-    source information and/or information sites] [Assignment: organization-defined
-    frequency] for evidence of unauthorized disclosure of organizational information."'
+  description: 'The organization monitors [Assignment: organization-defined open source
+    information and/or information sites] [Assignment: organization-defined frequency]
+    for evidence of unauthorized disclosure of organizational information.'
 AU-13 (1):
   family: AU
   name: Use Of Automated Tools
@@ -1185,8 +1185,8 @@ AU-13 (2):
 AU-14:
   family: AU
   name: Session Audit
-  description: '"The information system provides the capability for authorized users
-    to select a user session to capture/record or view/hear."'
+  description: The information system provides the capability for authorized users
+    to select a user session to capture/record or view/hear.
 AU-14 (1):
   family: AU
   name: System Start-Up
@@ -1205,15 +1205,15 @@ AU-14 (3):
 AU-15:
   family: AU
   name: Alternate Audit Capability
-  description: '"The organization provides an alternate audit capability in the event
+  description: 'The organization provides an alternate audit capability in the event
     of a failure in primary audit capability that provides [Assignment: organization-defined
-    alternate audit functionality]."'
+    alternate audit functionality].'
 AU-16:
   family: AU
   name: Cross-Organizational Auditing
-  description: '"The organization employs [Assignment: organization-defined methods]
+  description: 'The organization employs [Assignment: organization-defined methods]
     for coordinating [Assignment: organization-defined audit information] among external
-    organizations when audit information is transmitted across organizational boundaries."'
+    organizations when audit information is transmitted across organizational boundaries.'
 AU-16 (1):
   family: AU
   name: Identity Preservation
@@ -1309,7 +1309,7 @@ CA-3 (5):
 CA-4:
   family: CA
   name: Security Certification
-  description: '"[Withdrawn: Incorporated into CA-2]."'
+  description: '[Withdrawn: Incorporated into CA-2].'
 CA-5:
   family: CA
   name: Plan Of Action And Milestones
@@ -1363,9 +1363,9 @@ CA-7 (3):
 CA-8:
   family: CA
   name: Penetration Testing
-  description: '"The organization conducts penetration testing [Assignment: organization-defined
+  description: 'The organization conducts penetration testing [Assignment: organization-defined
     frequency] on [Assignment: organization-defined information systems or system
-    components]."'
+    components].'
 CA-8 (1):
   family: CA
   name: Independent Penetration Agent Or Team
@@ -1403,8 +1403,8 @@ CM-1:
 CM-2:
   family: CM
   name: Baseline Configuration
-  description: '"The organization develops, documents, and maintains under configuration
-    control, a current baseline configuration of the information system."'
+  description: The organization develops, documents, and maintains under configuration
+    control, a current baseline configuration of the information system.
 CM-2 (1):
   family: CM
   name: Reviews And Updates
@@ -1500,8 +1500,8 @@ CM-3 (6):
 CM-4:
   family: CM
   name: Security Impact Analysis
-  description: '"The organization analyzes changes to the information system to determine
-    potential security impacts prior to change implementation."'
+  description: The organization analyzes changes to the information system to determine
+    potential security impacts prior to change implementation.
 CM-4 (1):
   family: CM
   name: Separate Test Environments
@@ -1519,8 +1519,8 @@ CM-4 (2):
 CM-5:
   family: CM
   name: Access Restrictions For Change
-  description: '"The organization defines, documents, approves, and enforces physical
-    and logical access restrictions associated with changes to the information system."'
+  description: The organization defines, documents, approves, and enforces physical
+    and logical access restrictions associated with changes to the information system.
 CM-5 (1):
   family: CM
   name: Automated Access Enforcement / Auditing
@@ -1870,7 +1870,7 @@ CP-4 (4):
 CP-5:
   family: CP
   name: Contingency Plan Update
-  description: '"[Withdrawn: Incorporated into CP-2]."'
+  description: '[Withdrawn: Incorporated into CP-2].'
 CP-6:
   family: CP
   name: Alternate Storage Site
@@ -1937,12 +1937,12 @@ CP-7 (6):
 CP-8:
   family: CP
   name: Telecommunications Services
-  description: '"The organization establishes alternate telecommunications services
+  description: 'The organization establishes alternate telecommunications services
     including necessary agreements to permit the resumption of [Assignment: organization-defined
     information system operations] for essential missions and business functions within
     [Assignment: organization-defined time period] when the primary telecommunications
     capabilities are unavailable at either the primary or alternate processing or
-    storage sites."'
+    storage sites.'
 CP-8 (1):
   family: CP
   name: Priority Of Service Provisions
@@ -2025,8 +2025,8 @@ CP-9 (7):
 CP-10:
   family: CP
   name: Information System Recovery And Reconstitution
-  description: '"The organization provides for the recovery and reconstitution of
-    the information system to a known state after a disruption, compromise, or failure."'
+  description: The organization provides for the recovery and reconstitution of the
+    information system to a known state after a disruption, compromise, or failure.
 CP-10 (1):
   family: CP
   name: Contingency Plan Testing
@@ -2059,22 +2059,22 @@ CP-10 (6):
 CP-11:
   family: CP
   name: Alternate Communications Protocols
-  description: '"The information system provides the capability to employ [Assignment:
+  description: 'The information system provides the capability to employ [Assignment:
     organization-defined alternative communications protocols] in support of maintaining
-    continuity of operations."'
+    continuity of operations.'
 CP-12:
   family: CP
   name: Safe Mode
-  description: '"The information system, when [Assignment: organization-defined conditions]
+  description: 'The information system, when [Assignment: organization-defined conditions]
     are detected, enters a safe mode of operation with [Assignment: organization-defined
-    restrictions of safe mode of operation]."'
+    restrictions of safe mode of operation].'
 CP-13:
   family: CP
   name: Alternative Security Mechanisms
-  description: '"The organization employs [Assignment: organization-defined alternative
+  description: 'The organization employs [Assignment: organization-defined alternative
     or supplemental security mechanisms] for satisfying [Assignment: organization-defined
     security functions] when the primary means of implementing the security function
-    is unavailable or compromised."'
+    is unavailable or compromised.'
 IA-1:
   family: IA
   name: Identification And Authentication Policy And Procedures
@@ -2089,8 +2089,8 @@ IA-1:
 IA-2:
   family: IA
   name: Identification And Authentication (Organizational Users)
-  description: '"The information system uniquely identifies and authenticates organizational
-    users (or processes acting on behalf of organizational users)."'
+  description: The information system uniquely identifies and authenticates organizational
+    users (or processes acting on behalf of organizational users).
 IA-2 (1):
   family: IA
   name: Network Access To Privileged Accounts
@@ -2165,9 +2165,9 @@ IA-2 (13):
 IA-3:
   family: IA
   name: Device Identification And Authentication
-  description: '"The information system uniquely identifies and authenticates [Assignment:
+  description: 'The information system uniquely identifies and authenticates [Assignment:
     organization-defined specific and/or types of devices] before establishing a [Selection
-    (one or more): local; remote; network] connection."'
+    (one or more): local; remote; network] connection.'
 IA-3 (1):
   family: IA
   name: Cryptographic Bidirectional Authentication
@@ -2347,21 +2347,21 @@ IA-5 (15):
 IA-6:
   family: IA
   name: Authenticator Feedback
-  description: '"The information system obscures feedback of authentication information
+  description: The information system obscures feedback of authentication information
     during the authentication process to protect the information from possible exploitation/use
-    by unauthorized individuals."'
+    by unauthorized individuals.
 IA-7:
   family: IA
   name: Cryptographic Module Authentication
-  description: '"The information system implements mechanisms for authentication to
+  description: The information system implements mechanisms for authentication to
     a cryptographic module that meet the requirements of applicable federal laws,
     Executive Orders, directives, policies, regulations, standards, and guidance for
-    such authentication."'
+    such authentication.
 IA-8:
   family: IA
   name: Identification And Authentication (Non-Organizational Users)
-  description: '"The information system uniquely identifies and authenticates non-organizational
-    users (or processes acting on behalf of non-organizational users)."'
+  description: The information system uniquely identifies and authenticates non-organizational
+    users (or processes acting on behalf of non-organizational users).
 IA-8 (1):
   family: IA
   name: Acceptance Of Piv Credentials From Other Agencies
@@ -2389,9 +2389,9 @@ IA-8 (5):
 IA-9:
   family: IA
   name: Service Identification And Authentication
-  description: '"The organization identifies and authenticates [Assignment: organization-defined
+  description: 'The organization identifies and authenticates [Assignment: organization-defined
     information system services] using [Assignment: organization-defined security
-    safeguards]."'
+    safeguards].'
 IA-9 (1):
   family: IA
   name: Information Exchange
@@ -2406,15 +2406,15 @@ IA-9 (2):
 IA-10:
   family: IA
   name: Adaptive Identification And Authentication
-  description: '"The organization requires that individuals accessing the information
+  description: 'The organization requires that individuals accessing the information
     system employ [Assignment: organization-defined supplemental authentication techniques
     or mechanisms] under specific [Assignment: organization-defined circumstances
-    or situations]."'
+    or situations].'
 IA-11:
   family: IA
   name: Re-Authentication
-  description: '"The organization requires users and devices to re-authenticate when
-    [Assignment: organization-defined circumstances or situations requiring re-authentication]."'
+  description: 'The organization requires users and devices to re-authenticate when
+    [Assignment: organization-defined circumstances or situations requiring re-authentication].'
 IR-1:
   family: IR
   name: Incident Response Policy And Procedures
@@ -2447,9 +2447,9 @@ IR-2 (2):
 IR-3:
   family: IR
   name: Incident Response Testing
-  description: '"The organization tests the incident response capability for the information
+  description: 'The organization tests the incident response capability for the information
     system [Assignment: organization-defined frequency] using [Assignment: organization-defined
-    tests] to determine the incident response effectiveness and documents the results."'
+    tests] to determine the incident response effectiveness and documents the results.'
 IR-3 (1):
   family: IR
   name: Automated Testing
@@ -2529,8 +2529,7 @@ IR-4 (10):
 IR-5:
   family: IR
   name: Incident Monitoring
-  description: '"The organization tracks and documents information system security
-    incidents."'
+  description: The organization tracks and documents information system security incidents.
 IR-5 (1):
   family: IR
   name: Automated Tracking / Data Collection / Analysis
@@ -2563,10 +2562,10 @@ IR-6 (3):
 IR-7:
   family: IR
   name: Incident Response Assistance
-  description: '"The organization provides an incident response support resource,
-    integral to the organizational incident response capability that offers advice
-    and assistance to users of the information system for the handling and reporting
-    of security incidents."'
+  description: The organization provides an incident response support resource, integral
+    to the organizational incident response capability that offers advice and assistance
+    to users of the information system for the handling and reporting of security
+    incidents.
 IR-7 (1):
   family: IR
   name: Automation Support For Availability Of Information / Support
@@ -2634,8 +2633,8 @@ IR-9 (4):
 IR-10:
   family: IR
   name: Integrated Information Security Analysis Team
-  description: '"The organization establishes an integrated team of forensic/malicious
-    code analysts, tool developers, and real-time operations personnel."'
+  description: The organization establishes an integrated team of forensic/malicious
+    code analysts, tool developers, and real-time operations personnel.
 MA-1:
   family: MA
   name: System Maintenance Policy And Procedures
@@ -2672,8 +2671,8 @@ MA-2 (2):
 MA-3:
   family: MA
   name: Maintenance Tools
-  description: '"The organization approves, controls, and monitors information system
-    maintenance tools."'
+  description: The organization approves, controls, and monitors information system
+    maintenance tools.
 MA-3 (1):
   family: MA
   name: Inspect Tools
@@ -2801,9 +2800,9 @@ MA-5 (5):
 MA-6:
   family: MA
   name: Timely Maintenance
-  description: '"The organization obtains maintenance support and/or spare parts for
+  description: 'The organization obtains maintenance support and/or spare parts for
     [Assignment: organization-defined information system components] within [Assignment:
-    organization-defined time period] of failure."'
+    organization-defined time period] of failure.'
 MA-6 (1):
   family: MA
   name: Preventive Maintenance
@@ -2833,9 +2832,9 @@ MP-1:
 MP-2:
   family: MP
   name: Media Access
-  description: '"The organization restricts access to [Assignment: organization-defined
+  description: 'The organization restricts access to [Assignment: organization-defined
     types of digital and/or non-digital media] to [Assignment: organization-defined
-    personnel or roles]."'
+    personnel or roles].'
 MP-2 (1):
   family: MP
   name: Automated Restricted Access
@@ -2947,10 +2946,10 @@ MP-6 (8):
 MP-7:
   family: MP
   name: Media Use
-  description: '"The organization [Selection: restricts; prohibits] the use of [Assignment:
+  description: 'The organization [Selection: restricts; prohibits] the use of [Assignment:
     organization-defined types of information system media] on [Assignment: organization-defined
     information systems or system components] using [Assignment: organization-defined
-    security safeguards]."'
+    security safeguards].'
 MP-7 (1):
   family: MP
   name: Prohibit Use Without Owner
@@ -3087,14 +3086,14 @@ PE-3 (6):
 PE-4:
   family: PE
   name: Access Control For Transmission Medium
-  description: '"The organization controls physical access to [Assignment: organization-defined
+  description: 'The organization controls physical access to [Assignment: organization-defined
     information system distribution and transmission lines] within organizational
-    facilities using [Assignment: organization-defined security safeguards]."'
+    facilities using [Assignment: organization-defined security safeguards].'
 PE-5:
   family: PE
   name: Access Control For Output Devices
-  description: '"The organization controls physical access to information system output
-    devices to prevent unauthorized individuals from obtaining the output."'
+  description: The organization controls physical access to information system output
+    devices to prevent unauthorized individuals from obtaining the output.
 PE-5 (1):
   family: PE
   name: Access To Output By Authorized Individuals
@@ -3150,7 +3149,7 @@ PE-6 (4):
 PE-7:
   family: PE
   name: Visitor Control
-  description: '"[Withdrawn: Incorporated into PE-2 and PE-3]."'
+  description: '[Withdrawn: Incorporated into PE-2 and PE-3].'
 PE-8:
   family: PE
   name: Visitor Access Records
@@ -3170,8 +3169,8 @@ PE-8 (2):
 PE-9:
   family: PE
   name: Power Equipment And Cabling
-  description: '"The organization protects power equipment and power cabling for the
-    information system from damage and destruction."'
+  description: The organization protects power equipment and power cabling for the
+    information system from damage and destruction.
 PE-9 (1):
   family: PE
   name: Redundant Cabling
@@ -3197,10 +3196,10 @@ PE-10 (1):
 PE-11:
   family: PE
   name: Emergency Power
-  description: '"The organization provides a short-term uninterruptible power supply
+  description: 'The organization provides a short-term uninterruptible power supply
     to facilitate [Selection (one or more): an orderly shutdown of the information
     system; transition of the information system to long-term alternate power] in
-    the event of a primary power source loss."'
+    the event of a primary power source loss.'
 PE-11 (1):
   family: PE
   name: Long-Term Alternate Power Supply - Minimal Operational Capability
@@ -3218,9 +3217,9 @@ PE-11 (2):
 PE-12:
   family: PE
   name: Emergency Lighting
-  description: '"The organization employs and maintains automatic emergency lighting
+  description: The organization employs and maintains automatic emergency lighting
     for the information system that activates in the event of a power outage or disruption
-    and that covers emergency exits and evacuation routes within the facility."'
+    and that covers emergency exits and evacuation routes within the facility.
 PE-12 (1):
   family: PE
   name: Essential Missions / Business Functions
@@ -3229,9 +3228,9 @@ PE-12 (1):
 PE-13:
   family: PE
   name: Fire Protection
-  description: '"The organization employs and maintains fire suppression and detection
+  description: The organization employs and maintains fire suppression and detection
     devices/systems for the information system that are supported by an independent
-    energy source."'
+    energy source.
 PE-13 (1):
   family: PE
   name: Detection Devices / Systems
@@ -3279,9 +3278,9 @@ PE-14 (2):
 PE-15:
   family: PE
   name: Water Damage Protection
-  description: '"The organization protects the information system from damage resulting
+  description: The organization protects the information system from damage resulting
     from water leakage by providing master shutoff or isolation valves that are accessible,
-    working properly, and known to key personnel."'
+    working properly, and known to key personnel.
 PE-15 (1):
   family: PE
   name: Automation Support
@@ -3291,9 +3290,9 @@ PE-15 (1):
 PE-16:
   family: PE
   name: Delivery And Removal
-  description: '"The organization authorizes, monitors, and controls [Assignment:
-    organization-defined types of information system components] entering and exiting
-    the facility and maintains records of those items."'
+  description: 'The organization authorizes, monitors, and controls [Assignment: organization-defined
+    types of information system components] entering and exiting the facility and
+    maintains records of those items.'
 PE-17:
   family: PE
   name: Alternate Work Site
@@ -3305,9 +3304,9 @@ PE-17:
 PE-18:
   family: PE
   name: Location Of Information System Components
-  description: '"The organization positions information system components within the
+  description: 'The organization positions information system components within the
     facility to minimize potential damage from [Assignment: organization-defined physical
-    and environmental hazards] and to minimize the opportunity for unauthorized access."'
+    and environmental hazards] and to minimize the opportunity for unauthorized access.'
 PE-18 (1):
   family: PE
   name: Facility Site
@@ -3318,8 +3317,8 @@ PE-18 (1):
 PE-19:
   family: PE
   name: Information Leakage
-  description: '"The organization protects the information system from information
-    leakage due to electromagnetic signals emanations."'
+  description: The organization protects the information system from information leakage
+    due to electromagnetic signals emanations.
 PE-19 (1):
   family: PE
   name: National Emissions / Tempest Policies And Procedures
@@ -3382,7 +3381,7 @@ PL-2 (3):
 PL-3:
   family: PL
   name: System Security Plan Update
-  description: '"[Withdrawn: Incorporated into PL-2]."'
+  description: '[Withdrawn: Incorporated into PL-2].'
 PL-4:
   family: PL
   name: Rules Of Behavior
@@ -3401,11 +3400,11 @@ PL-4 (1):
 PL-5:
   family: PL
   name: Privacy Impact Assessment
-  description: '"[Withdrawn: Incorporated into Appendix J, AR-2]."'
+  description: '[Withdrawn: Incorporated into Appendix J, AR-2].'
 PL-6:
   family: PL
   name: Security-Related Activity Planning
-  description: '"[Withdrawn: Incorporated into PL-2]."'
+  description: '[Withdrawn: Incorporated into PL-2].'
 PL-7:
   family: PL
   name: Security Concept Of Operations
@@ -3440,8 +3439,8 @@ PL-8 (2):
 PL-9:
   family: PL
   name: Central Management
-  description: '"The organization centrally manages [Assignment: organization-defined
-    security controls and related processes]."'
+  description: 'The organization centrally manages [Assignment: organization-defined
+    security controls and related processes].'
 PM-1:
   family: PM
   name: Information Security Program Plan
@@ -3458,9 +3457,9 @@ PM-1:
 PM-2:
   family: PM
   name: Senior Information Security Officer
-  description: '"The organization appoints a senior information security officer with
+  description: The organization appoints a senior information security officer with
     the mission and resources to coordinate, develop, implement, and maintain an organization-wide
-    information security program."'
+    information security program.
 PM-3:
   family: PM
   name: Information Security Resources
@@ -3482,25 +3481,25 @@ PM-4:
 PM-5:
   family: PM
   name: Information System Inventory
-  description: '"The organization develops and maintains an inventory of its information
-    systems."'
+  description: The organization develops and maintains an inventory of its information
+    systems.
 PM-6:
   family: PM
   name: Information Security Measures Of Performance
-  description: '"The organization develops, monitors, and reports on the results of
-    information security measures of performance."'
+  description: The organization develops, monitors, and reports on the results of
+    information security measures of performance.
 PM-7:
   family: PM
   name: Enterprise Architecture
-  description: '"The organization develops an enterprise architecture with consideration
+  description: The organization develops an enterprise architecture with consideration
     for information security and the resulting risk to organizational operations,
-    organizational assets, individuals, other organizations, and the Nation."'
+    organizational assets, individuals, other organizations, and the Nation.
 PM-8:
   family: PM
   name: Critical Infrastructure Plan
-  description: '"The organization addresses information security issues in the development,
+  description: The organization addresses information security issues in the development,
     documentation, and updating of a critical infrastructure and key resources protection
-    plan."'
+    plan.
 PM-9:
   family: PM
   name: Risk Management Strategy
@@ -3527,13 +3526,13 @@ PM-11:
 PM-12:
   family: PM
   name: Insider Threat Program
-  description: '"The organization implements an insider threat program that includes
-    a cross-discipline insider threat incident handling team."'
+  description: The organization implements an insider threat program that includes
+    a cross-discipline insider threat incident handling team.
 PM-13:
   family: PM
   name: Information Security Workforce
-  description: '"The organization establishes an information security workforce development
-    and improvement program."'
+  description: The organization establishes an information security workforce development
+    and improvement program.
 PM-14:
   family: PM
   name: Testing, Training, And Monitoring
@@ -3554,8 +3553,8 @@ PM-15:
 PM-16:
   family: PM
   name: Threat Awareness Program
-  description: '"The organization implements a threat awareness program that includes
-    a cross-organization information-sharing capability."'
+  description: The organization implements a threat awareness program that includes
+    a cross-organization information-sharing capability.
 PS-1:
   family: PS
   name: Personnel Security Policy And Procedures
@@ -3713,7 +3712,7 @@ RA-3:
 RA-4:
   family: RA
   name: Risk Assessment Update
-  description: '"[Withdrawn: Incorporated into RA-3]."'
+  description: '[Withdrawn: Incorporated into RA-3].'
 RA-5:
   family: RA
   name: Vulnerability Scanning
@@ -3783,10 +3782,10 @@ RA-5 (10):
 RA-6:
   family: RA
   name: Technical Surveillance Countermeasures Survey
-  description: '"The organization employs a technical surveillance countermeasures
+  description: 'The organization employs a technical surveillance countermeasures
     survey at [Assignment: organization-defined locations] [Selection (one or more):
     [Assignment: organization-defined frequency]; [Assignment: organization-defined
-    events or indicators occur]]."'
+    events or indicators occur]].'
 SA-1:
   family: SA
   name: System And Services Acquisition Policy And Procedures
@@ -3935,17 +3934,17 @@ SA-5 (5):
 SA-6:
   family: SA
   name: Software Usage Restrictions
-  description: '"[Withdrawn: Incorporated into CM-10 and SI-7]."'
+  description: '[Withdrawn: Incorporated into CM-10 and SI-7].'
 SA-7:
   family: SA
   name: User-Installed Software
-  description: '"[Withdrawn: Incorporated into CM-11 and SI-7]."'
+  description: '[Withdrawn: Incorporated into CM-11 and SI-7].'
 SA-8:
   family: SA
   name: Security Engineering Principles
-  description: '"The organization applies information system security engineering
-    principles in the specification, design, development, implementation, and modification
-    of the information system."'
+  description: The organization applies information system security engineering principles
+    in the specification, design, development, implementation, and modification of
+    the information system.
 SA-9:
   family: SA
   name: External Information System Services
@@ -3999,43 +3998,43 @@ SA-10:
 SA-10 (1):
   family: SA
   name: Software / Firmware Integrity Verification
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to enable integrity verification
-    of software and firmware components."'
+    of software and firmware components.
 SA-10 (2):
   family: SA
   name: Alternative Configuration Management Processes
-  description: '"The organization provides an alternate configuration management process
+  description: The organization provides an alternate configuration management process
     using organizational personnel in the absence of a dedicated developer configuration
-    management team."'
+    management team.
 SA-10 (3):
   family: SA
   name: Hardware Integrity Verification
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to enable integrity verification
-    of hardware components."'
+    of hardware components.
 SA-10 (4):
   family: SA
   name: Trusted Generation
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to employ tools for comparing
     newly generated versions of security-relevant hardware descriptions and software/firmware
-    source and object code with previous versions."'
+    source and object code with previous versions.
 SA-10 (5):
   family: SA
   name: Mapping Integrity For Version Control
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to maintain the integrity of the
     mapping between the  master build data (hardware drawings and software/firmware
     code) describing the current version of security-relevant hardware, software,
-    and firmware and the on-site master copy of the data for the current version."'
+    and firmware and the on-site master copy of the data for the current version.
 SA-10 (6):
   family: SA
   name: Trusted Distribution
-  description: '"The organization requires the developer of the information system,
+  description: The organization requires the developer of the information system,
     system component, or information system service to execute procedures for ensuring
     that security-relevant hardware, software, and firmware updates distributed to
-    the organization are exactly as specified by the master copies."'
+    the organization are exactly as specified by the master copies.
 SA-11:
   family: SA
   name: Developer Security Testing And Evaluation
@@ -4101,10 +4100,10 @@ SA-11 (8):
 SA-12:
   family: SA
   name: Supply Chain Protection
-  description: '"The organization protects against supply chain threats to the information
+  description: 'The organization protects against supply chain threats to the information
     system, system component, or information system service by employing [Assignment:
     organization-defined security safeguards] as part of a comprehensive, defense-in-breadth
-    information security strategy."'
+    information security strategy.'
 SA-12 (1):
   family: SA
   name: Acquisition Strategies / Tools / Methods
@@ -4203,11 +4202,11 @@ SA-13:
 SA-14:
   family: SA
   name: Criticality Analysis
-  description: '"The organization identifies critical information system components
+  description: 'The organization identifies critical information system components
     and functions by performing a criticality analysis for [Assignment: organization-defined
     information systems, information system components, or information system services]
     at [Assignment: organization-defined decision points in the system development
-    life cycle]."'
+    life cycle].'
 SA-14 (1):
   family: SA
   name: Critical Components With  No Viable Alternative Sourcing
@@ -4300,10 +4299,10 @@ SA-15 (11):
 SA-16:
   family: SA
   name: Developer-Provided Training
-  description: '"The organization requires the developer of the information system,
+  description: 'The organization requires the developer of the information system,
     system component, or information system service to provide [Assignment: organization-defined
     training] on the correct use and operation of the implemented security functions,
-    controls, and/or mechanisms."'
+    controls, and/or mechanisms.'
 SA-17:
   family: SA
   name: Developer Security Architecture And Design
@@ -4368,8 +4367,8 @@ SA-17 (7):
 SA-18:
   family: SA
   name: Tamper Resistance And Detection
-  description: '"The organization implements a tamper protection program for the information
-    system, system component, or information system service."'
+  description: The organization implements a tamper protection program for the information
+    system, system component, or information system service.
 SA-18 (1):
   family: SA
   name: Multiple Phases Of Sdlc
@@ -4415,8 +4414,8 @@ SA-19 (4):
 SA-20:
   family: SA
   name: Customized Development Of Critical Components
-  description: '"The organization re-implements or custom develops [Assignment: organization-defined
-    critical information system components]."'
+  description: 'The organization re-implements or custom develops [Assignment: organization-defined
+    critical information system components].'
 SA-21:
   family: SA
   name: Developer Screening
@@ -4458,8 +4457,8 @@ SC-1:
 SC-2:
   family: SC
   name: Application Partitioning
-  description: '"The information system separates user functionality (including user
-    interface services) from information system management functionality."'
+  description: The information system separates user functionality (including user
+    interface services) from information system management functionality.
 SC-2 (1):
   family: SC
   name: Interfaces For Non-Privileged Users
@@ -4468,8 +4467,8 @@ SC-2 (1):
 SC-3:
   family: SC
   name: Security Function Isolation
-  description: '"The information system isolates security functions from nonsecurity
-    functions."'
+  description: The information system isolates security functions from nonsecurity
+    functions.
 SC-3 (1):
   family: SC
   name: Hardware Separation
@@ -4501,8 +4500,8 @@ SC-3 (5):
 SC-4:
   family: SC
   name: Information In Shared Resources
-  description: '"The information system prevents unauthorized and unintended information
-    transfer via shared system resources."'
+  description: The information system prevents unauthorized and unintended information
+    transfer via shared system resources.
 SC-4 (1):
   family: SC
   name: Security Levels
@@ -4517,10 +4516,10 @@ SC-4 (2):
 SC-5:
   family: SC
   name: Denial Of Service Protection
-  description: '"The information system protects against or limits the effects of
-    the following types of denial of service attacks: [Assignment: organization-defined
+  description: 'The information system protects against or limits the effects of the
+    following types of denial of service attacks: [Assignment: organization-defined
     types of denial of service attacks or references to sources for such information]
-    by employing [Assignment: organization-defined security safeguards]."'
+    by employing [Assignment: organization-defined security safeguards].'
 SC-5 (1):
   family: SC
   name: Restrict Internal Users
@@ -4542,9 +4541,9 @@ SC-5 (3):
 SC-6:
   family: SC
   name: Resource Availability
-  description: '"The information system protects the availability of resources by
-    allocating [Assignment: organization-defined resources] by [Selection (one or
-    more); priority; quota; [Assignment: organization-defined security safeguards]]."'
+  description: 'The information system protects the availability of resources by allocating
+    [Assignment: organization-defined resources] by [Selection (one or more); priority;
+    quota; [Assignment: organization-defined security safeguards]].'
 SC-7:
   family: SC
   name: Boundary Protection
@@ -4684,8 +4683,8 @@ SC-7 (23):
 SC-8:
   family: SC
   name: Transmission Confidentiality And Integrity
-  description: '"The information system protects the [Selection (one or more): confidentiality;
-    integrity] of transmitted information."'
+  description: 'The information system protects the [Selection (one or more): confidentiality;
+    integrity] of transmitted information.'
 SC-8 (1):
   family: SC
   name: Cryptographic Or Alternate Physical Protection
@@ -4713,20 +4712,20 @@ SC-8 (4):
 SC-9:
   family: SC
   name: Transmission Confidentiality
-  description: '"[Withdrawn: Incorporated into SC-8]."'
+  description: '[Withdrawn: Incorporated into SC-8].'
 SC-10:
   family: SC
   name: Network Disconnect
-  description: '"The information system terminates the network connection associated
+  description: 'The information system terminates the network connection associated
     with a communications session at the end of the session or after [Assignment:
-    organization-defined time period] of inactivity."'
+    organization-defined time period] of inactivity.'
 SC-11:
   family: SC
   name: Trusted Path
-  description: '"The information system establishes a trusted communications path
-    between the user and the following security functions of the system: [Assignment:
-    organization-defined security functions to include at a minimum, information system
-    authentication and re-authentication]."'
+  description: 'The information system establishes a trusted communications path between
+    the user and the following security functions of the system: [Assignment: organization-defined
+    security functions to include at a minimum, information system authentication
+    and re-authentication].'
 SC-11 (1):
   family: SC
   name: Logical Isolation
@@ -4735,10 +4734,10 @@ SC-11 (1):
 SC-12:
   family: SC
   name: Cryptographic Key Establishment And Management
-  description: '"The organization establishes and manages cryptographic keys for required
+  description: 'The organization establishes and manages cryptographic keys for required
     cryptography employed within the information system in accordance with [Assignment:
     organization-defined requirements for key generation, distribution, storage, access,
-    and destruction]."'
+    and destruction].'
 SC-12 (1):
   family: SC
   name: Availability
@@ -4769,10 +4768,10 @@ SC-12 (5):
 SC-13:
   family: SC
   name: Cryptographic Protection
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     cryptographic uses and type of cryptography required for each use] in accordance
     with applicable federal laws, Executive Orders, directives, policies, regulations,
-    and standards."'
+    and standards.'
 SC-13 (1):
   family: SC
   name: Fips-Validated Cryptography
@@ -4792,8 +4791,8 @@ SC-13 (4):
 SC-14:
   family: SC
   name: Public Access Protections
-  description: '"[Withdrawn: Capability provided by AC-2, AC-3, AC-5, AC-6, SI-3,
-    SI-4, SI-5, SI-7, SI-10]."'
+  description: '[Withdrawn: Capability provided by AC-2, AC-3, AC-5, AC-6, SI-3, SI-4,
+    SI-5, SI-7, SI-10].'
 SC-15:
   family: SC
   name: Collaborative Computing Devices
@@ -4824,9 +4823,9 @@ SC-15 (4):
 SC-16:
   family: SC
   name: Transmission Of Security Attributes
-  description: '"The information system associates [Assignment: organization-defined
+  description: 'The information system associates [Assignment: organization-defined
     security attributes] with information exchanged between information systems and
-    between system components."'
+    between system components.'
 SC-16 (1):
   family: SC
   name: Integrity Validation
@@ -4835,9 +4834,9 @@ SC-16 (1):
 SC-17:
   family: SC
   name: Public Key Infrastructure Certificates
-  description: '"The organization issues public key certificates under an [Assignment:
+  description: 'The organization issues public key certificates under an [Assignment:
     organization-defined certificate policy] or obtains public key certificates from
-    an approved service provider."'
+    an approved service provider.'
 SC-18:
   family: SC
   name: Mobile Code
@@ -4900,9 +4899,9 @@ SC-20 (2):
 SC-21:
   family: SC
   name: Secure Name / Address Resolution Service (Recursive Or Caching Resolver)
-  description: '"The information system requests and performs data origin authentication
+  description: The information system requests and performs data origin authentication
     and data integrity verification on the name/address resolution responses the system
-    receives from authoritative sources."'
+    receives from authoritative sources.
 SC-21 (1):
   family: SC
   name: Data Origin / Integrity
@@ -4910,14 +4909,14 @@ SC-21 (1):
 SC-22:
   family: SC
   name: Architecture And Provisioning For Name / Address Resolution Service
-  description: '"The information systems that collectively provide name/address resolution
+  description: The information systems that collectively provide name/address resolution
     service for an organization are fault-tolerant and implement internal/external
-    role separation."'
+    role separation.
 SC-23:
   family: SC
   name: Session Authenticity
-  description: '"The information system protects the authenticity of communications
-    sessions."'
+  description: The information system protects the authenticity of communications
+    sessions.
 SC-23 (1):
   family: SC
   name: Invalidate Session Identifiers At Logout
@@ -4945,20 +4944,20 @@ SC-23 (5):
 SC-24:
   family: SC
   name: Fail In Known State
-  description: '"The information system fails to a [Assignment: organization-defined
+  description: 'The information system fails to a [Assignment: organization-defined
     known-state] for [Assignment: organization-defined types of failures] preserving
-    [Assignment: organization-defined system state information] in failure."'
+    [Assignment: organization-defined system state information] in failure.'
 SC-25:
   family: SC
   name: Thin Nodes
-  description: '"The organization employs [Assignment: organization-defined information
-    system components] with minimal functionality and information storage."'
+  description: 'The organization employs [Assignment: organization-defined information
+    system components] with minimal functionality and information storage.'
 SC-26:
   family: SC
   name: Honeypots
-  description: '"The information system includes components specifically designed
-    to be the target of malicious attacks for the purpose of detecting, deflecting,
-    and analyzing such attacks."'
+  description: The information system includes components specifically designed to
+    be the target of malicious attacks for the purpose of detecting, deflecting, and
+    analyzing such attacks.
 SC-26 (1):
   family: SC
   name: Detection Of Malicious Code
@@ -4966,13 +4965,13 @@ SC-26 (1):
 SC-27:
   family: SC
   name: Platform-Independent Applications
-  description: '"The information system includes: [Assignment: organization-defined
-    platform-independent applications]."'
+  description: 'The information system includes: [Assignment: organization-defined
+    platform-independent applications].'
 SC-28:
   family: SC
   name: Protection Of Information At Rest
-  description: '"The information system protects the [Selection (one or more): confidentiality;
-    integrity] of [Assignment: organization-defined information at rest]."'
+  description: 'The information system protects the [Selection (one or more): confidentiality;
+    integrity] of [Assignment: organization-defined information at rest].'
 SC-28 (1):
   family: SC
   name: Cryptographic Protection
@@ -4987,9 +4986,9 @@ SC-28 (2):
 SC-29:
   family: SC
   name: Heterogeneity
-  description: '"The organization employs a diverse set of information technologies
+  description: 'The organization employs a diverse set of information technologies
     for [Assignment: organization-defined information system components] in the implementation
-    of the information system."'
+    of the information system.'
 SC-29 (1):
   family: SC
   name: Virtualization Techniques
@@ -4999,10 +4998,10 @@ SC-29 (1):
 SC-30:
   family: SC
   name: Concealment And Misdirection
-  description: '"The organization employs [Assignment: organization-defined concealment
+  description: 'The organization employs [Assignment: organization-defined concealment
     and misdirection techniques] for [Assignment: organization-defined information
     systems] at [Assignment: organization-defined time periods] to confuse and mislead
-    adversaries."'
+    adversaries.'
 SC-30 (1):
   family: SC
   name: Virtualization Techniques
@@ -5056,14 +5055,14 @@ SC-31 (3):
 SC-32:
   family: SC
   name: Information System Partitioning
-  description: '"The organization partitions the information system into [Assignment:
+  description: 'The organization partitions the information system into [Assignment:
     organization-defined information system components] residing in separate physical
     domains or environments based on [Assignment: organization-defined circumstances
-    for physical separation of components]."'
+    for physical separation of components].'
 SC-33:
   family: SC
   name: Transmission Preparation Integrity
-  description: '"[Withdrawn: Incorporated into SC-8]."'
+  description: '[Withdrawn: Incorporated into SC-8].'
 SC-34:
   family: SC
   name: Non-Modifiable Executable Programs
@@ -5093,13 +5092,13 @@ SC-34 (3):
 SC-35:
   family: SC
   name: Honeyclients
-  description: '"The information system includes components that proactively seek
-    to identify malicious websites and/or web-based malicious code."'
+  description: The information system includes components that proactively seek to
+    identify malicious websites and/or web-based malicious code.
 SC-36:
   family: SC
   name: Distributed Processing And Storage
-  description: '"The organization distributes [Assignment: organization-defined processing
-    and storage] across multiple physical locations."'
+  description: 'The organization distributes [Assignment: organization-defined processing
+    and storage] across multiple physical locations.'
 SC-36 (1):
   family: SC
   name: Polling Techniques
@@ -5109,10 +5108,10 @@ SC-36 (1):
 SC-37:
   family: SC
   name: Out-Of-Band Channels
-  description: '"The organization employs [Assignment: organization-defined out-of-band
+  description: 'The organization employs [Assignment: organization-defined out-of-band
     channels] for the physical delivery or electronic transmission of [Assignment:
     organization-defined information, information system components, or devices] to
-    [Assignment: organization-defined individuals or information systems]."'
+    [Assignment: organization-defined individuals or information systems].'
 SC-37 (1):
   family: SC
   name: Ensure Delivery / Transmission
@@ -5123,14 +5122,14 @@ SC-37 (1):
 SC-38:
   family: SC
   name: Operations Security
-  description: '"The organization employs [Assignment: organization-defined operations
+  description: 'The organization employs [Assignment: organization-defined operations
     security safeguards] to protect key organizational information throughout the
-    system development life cycle."'
+    system development life cycle.'
 SC-39:
   family: SC
   name: Process Isolation
-  description: '"The information system maintains a separate execution domain for
-    each executing process."'
+  description: The information system maintains a separate execution domain for each
+    executing process.
 SC-39 (1):
   family: SC
   name: Hardware Separation
@@ -5144,9 +5143,9 @@ SC-39 (2):
 SC-40:
   family: SC
   name: Wireless Link Protection
-  description: '"The information system protects external and internal [Assignment:
+  description: 'The information system protects external and internal [Assignment:
     organization-defined wireless links] from [Assignment: organization-defined types
-    of signal parameter attacks or references to sources for such attacks]."'
+    of signal parameter attacks or references to sources for such attacks].'
 SC-40 (1):
   family: SC
   name: Electromagnetic Interference
@@ -5174,9 +5173,9 @@ SC-40 (4):
 SC-41:
   family: SC
   name: Port And I/O Device Access
-  description: '"The organization physically disables or removes [Assignment: organization-defined
+  description: 'The organization physically disables or removes [Assignment: organization-defined
     connection ports or input/output devices] on [Assignment: organization-defined
-    information systems or information system components]."'
+    information systems or information system components].'
 SC-42:
   family: SC
   name: Sensor Capability And Data
@@ -5212,8 +5211,8 @@ SC-43:
 SC-44:
   family: SC
   name: Detonation Chambers
-  description: '"The organization employs a detonation chamber capability within [Assignment:
-    organization-defined information system, system component, or location]."'
+  description: 'The organization employs a detonation chamber capability within [Assignment:
+    organization-defined information system, system component, or location].'
 SI-1:
   family: SI
   name: System And Information Integrity Policy And Procedures
@@ -5528,8 +5527,8 @@ SI-6 (3):
 SI-7:
   family: SI
   name: Software, Firmware, And Information Integrity
-  description: '"The organization employs integrity verification tools to detect unauthorized
-    changes to [Assignment: organization-defined software, firmware, and information]."'
+  description: 'The organization employs integrity verification tools to detect unauthorized
+    changes to [Assignment: organization-defined software, firmware, and information].'
 SI-7 (1):
   family: SI
   name: Integrity Checks
@@ -5645,12 +5644,12 @@ SI-8 (3):
 SI-9:
   family: SI
   name: Information Input Restrictions
-  description: '"[Withdrawn: Incorporated into AC-2, AC-3, AC-5, AC-6]."'
+  description: '[Withdrawn: Incorporated into AC-2, AC-3, AC-5, AC-6].'
 SI-10:
   family: SI
   name: Information Input Validation
-  description: '"The information system checks the validity of [Assignment: organization-defined
-    information inputs]."'
+  description: 'The information system checks the validity of [Assignment: organization-defined
+    information inputs].'
 SI-10 (1):
   family: SI
   name: Manual Override Capability
@@ -5690,10 +5689,10 @@ SI-11:
 SI-12:
   family: SI
   name: Information Handling And Retention
-  description: '"The organization handles and retains information within the information
+  description: The organization handles and retains information within the information
     system and information output from the system in accordance with applicable federal
     laws, Executive Orders, directives, policies, regulations, standards, and operational
-    requirements."'
+    requirements.
 SI-13:
   family: SI
   name: Predictable Failure Prevention
@@ -5732,10 +5731,10 @@ SI-13 (5):
 SI-14:
   family: SI
   name: Non-Persistence
-  description: '"The organization implements non-persistent [Assignment: organization-defined
+  description: 'The organization implements non-persistent [Assignment: organization-defined
     information system components and services] that are initiated in a known state
     and terminated [Selection (one or more): upon end of session of use; periodically
-    at [Assignment: organization-defined frequency]]."'
+    at [Assignment: organization-defined frequency]].'
 SI-14 (1):
   family: SI
   name: Refresh From Trusted Sources
@@ -5745,17 +5744,17 @@ SI-14 (1):
 SI-15:
   family: SI
   name: Information Output Filtering
-  description: '"The information system validates information output from [Assignment:
+  description: 'The information system validates information output from [Assignment:
     organization-defined software programs and/or applications] to ensure that the
-    information is consistent with the expected content."'
+    information is consistent with the expected content.'
 SI-16:
   family: SI
   name: Memory Protection
-  description: '"The information system implements [Assignment: organization-defined
-    security safeguards] to protect its memory from unauthorized code execution."'
+  description: 'The information system implements [Assignment: organization-defined
+    security safeguards] to protect its memory from unauthorized code execution.'
 SI-17:
   family: SI
   name: Fail-Safe Procedures
-  description: '"The information system implements [Assignment: organization-defined
+  description: 'The information system implements [Assignment: organization-defined
     fail-safe procedures] when [Assignment: organization-defined failure conditions
-    occur]."'
+    occur].'

--- a/utils/parser.go
+++ b/utils/parser.go
@@ -94,7 +94,7 @@ func main() {
 
 		family := parseFamily(xmlControl.Family)
 		name := strings.Title(strings.ToLower(xmlControl.Title))
-		description := "\"" + strings.TrimSuffix(parseDescription(family, xmlControl.Statements), "\n") + "\""
+		description := strings.TrimSuffix(parseDescription(family, xmlControl.Statements), "\n")
 
 		control := Control{
 			Family:      family,


### PR DESCRIPTION
This is follow up on #8 

I found that `./utils/parser.go` cannot be reliably used to rebuild the content as there were hundred of quotation inconsistencies.

This PR takes `./utils/parser.go` outputs and the committed content closer to each other.