### PR TITLE
Convert OpenControl plain-texts to Markdown

### DIFF
--- a/nist-800-53-latest.yaml
+++ b/nist-800-53-latest.yaml
@@ -4,34 +4,34 @@ AC-1:
   name: Access Control Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  An access control policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the access control policy and associated access controls; and
-      b.  Reviews and updates the current:
-        1.  Access control policy [Assignment: organization-defined frequency]; and
-        2.  Access control procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  An access control policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the access control policy and associated access controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Access control policy [Assignment: organization-defined frequency]; and
+       - 2.  Access control procedures [Assignment: organization-defined frequency].
 AC-2:
   family: AC
   name: Account Management
   description: |-
     The organization:
-      a.  Identifies and selects the following types of information system accounts to support organizational missions/business functions: [Assignment: organization-defined information system account types];
-      b.  Assigns account managers for information system accounts;
-      c.  Establishes conditions for group and role membership;
-      d.  Specifies authorized users of the information system, group and role membership, and access authorizations (i.e., privileges) and other attributes (as required) for each account;
-      e.  Requires approvals by [Assignment: organization-defined personnel or roles] for requests to create information system accounts;
-      f.  Creates, enables, modifies, disables, and removes information system accounts in accordance with [Assignment: organization-defined procedures or conditions];
-      g.  Monitors the use of information system accounts;
-      h.  Notifies account managers:
-        1.  When accounts are no longer required;
-        2.  When users are terminated or transferred; and
-        3.  When individual information system usage or need-to-know changes;
-      i.  Authorizes access to the information system based on:
-        1.  A valid access authorization;
-        2.  Intended system usage; and
-        3.  Other attributes as required by the organization or associated missions/business functions;
-      j.  Reviews accounts for compliance with account management requirements [Assignment: organization-defined frequency]; and
-      k.  Establishes a process for reissuing shared/group account credentials (if deployed) when individuals are removed from the group.
+     - a.  Identifies and selects the following types of information system accounts to support organizational missions/business functions: [Assignment: organization-defined information system account types];
+     - b.  Assigns account managers for information system accounts;
+     - c.  Establishes conditions for group and role membership;
+     - d.  Specifies authorized users of the information system, group and role membership, and access authorizations (i.e., privileges) and other attributes (as required) for each account;
+     - e.  Requires approvals by [Assignment: organization-defined personnel or roles] for requests to create information system accounts;
+     - f.  Creates, enables, modifies, disables, and removes information system accounts in accordance with [Assignment: organization-defined procedures or conditions];
+     - g.  Monitors the use of information system accounts;
+     - h.  Notifies account managers:
+       - 1.  When accounts are no longer required;
+       - 2.  When users are terminated or transferred; and
+       - 3.  When individual information system usage or need-to-know changes;
+     - i.  Authorizes access to the information system based on:
+       - 1.  A valid access authorization;
+       - 2.  Intended system usage; and
+       - 3.  Other attributes as required by the organization or associated missions/business functions;
+     - j.  Reviews accounts for compliance with account management requirements [Assignment: organization-defined frequency]; and
+     - k.  Establishes a process for reissuing shared/group account credentials (if deployed) when individuals are removed from the group.
 AC-2 (1):
   family: AC
   name: Automated System Account Management
@@ -70,9 +70,9 @@ AC-2 (7):
   name: Role-Based Schemes
   description: |-
     The organization:
-       (7)(a).  Establishes and administers privileged user accounts in accordance with a role-based access scheme that organizes allowed information system access and privileges into roles;
-       (7)(b).  Monitors privileged role assignments; and
-       (7)(c).  Takes [Assignment: organization-defined actions] when privileged role assignments are no longer appropriate.
+     -  (7)(a).  Establishes and administers privileged user accounts in accordance with a role-based access scheme that organizes allowed information system access and privileges into roles;
+     -  (7)(b).  Monitors privileged role assignments; and
+     -  (7)(c).  Takes [Assignment: organization-defined actions] when privileged role assignments are no longer appropriate.
 AC-2 (8):
   family: AC
   name: Dynamic Account Creation
@@ -100,8 +100,8 @@ AC-2 (12):
   name: Account Monitoring / Atypical Usage
   description: |-
     The organization:
-       (12)(a).  Monitors information system accounts for [Assignment: organization-defined atypical usage]; and
-       (12)(b).  Reports atypical usage of information system accounts to [Assignment: organization-defined personnel or roles].
+     -  (12)(a).  Monitors information system accounts for [Assignment: organization-defined atypical usage]; and
+     -  (12)(b).  Reports atypical usage of information system accounts to [Assignment: organization-defined personnel or roles].
 AC-2 (13):
   family: AC
   name: Disable Accounts For High-Risk Individuals
@@ -127,24 +127,24 @@ AC-3 (3):
   name: Mandatory Access Control
   description: |-
     The information system enforces [Assignment: organization-defined mandatory access control policy] over all subjects and objects where the policy:
-       (3)(a).  Is uniformly enforced across all subjects and objects within the boundary of the information system;
-       (3)(b).  Specifies that a subject that has been granted access to information is constrained from doing any of the following;
-       (3)(b)(1).  Passing the information to unauthorized subjects or objects;
-       (3)(b)(2).  Granting its privileges to other subjects;
-       (3)(b)(3).  Changing one or more security attributes on subjects, objects, the information system, or information system components;
-       (3)(b)(4).  Choosing the security attributes and attribute values to be associated with newly created or modified objects; or
-       (3)(b)(5).  Changing the rules governing access control; and
-       (3)(c).  Specifies that [Assignment: organization-defined subjects] may explicitly be granted [Assignment: organization-defined privileges (i.e., they are trusted subjects)] such that they are not limited by some or all of the above constraints.
+     -  (3)(a).  Is uniformly enforced across all subjects and objects within the boundary of the information system;
+     -  (3)(b).  Specifies that a subject that has been granted access to information is constrained from doing any of the following;
+     -  (3)(b)(1).  Passing the information to unauthorized subjects or objects;
+     -  (3)(b)(2).  Granting its privileges to other subjects;
+     -  (3)(b)(3).  Changing one or more security attributes on subjects, objects, the information system, or information system components;
+     -  (3)(b)(4).  Choosing the security attributes and attribute values to be associated with newly created or modified objects; or
+     -  (3)(b)(5).  Changing the rules governing access control; and
+     -  (3)(c).  Specifies that [Assignment: organization-defined subjects] may explicitly be granted [Assignment: organization-defined privileges (i.e., they are trusted subjects)] such that they are not limited by some or all of the above constraints.
 AC-3 (4):
   family: AC
   name: Discretionary Access Control
   description: |-
     The information system enforces [Assignment: organization-defined discretionary access control policy] over defined subjects and objects where the policy specifies that a subject that has been granted access to information can do one or more of the following:
-       (4)(a).  Pass the  information to any other subjects or objects;
-       (4)(b).  Grant its privileges to other subjects;
-       (4)(c).  Change security attributes on subjects, objects, the information system, or the information system's components;
-       (4)(d).  Choose the security attributes to be associated with newly created or revised objects; or
-       (4)(e).  Change the rules governing access control.
+     -  (4)(a).  Pass the  information to any other subjects or objects;
+     -  (4)(b).  Grant its privileges to other subjects;
+     -  (4)(c).  Change security attributes on subjects, objects, the information system, or the information system's components;
+     -  (4)(d).  Choose the security attributes to be associated with newly created or revised objects; or
+     -  (4)(e).  Change the rules governing access control.
 AC-3 (5):
   family: AC
   name: Security-Relevant Information
@@ -172,8 +172,8 @@ AC-3 (9):
   name: Controlled Release
   description: |-
     The information system does not release information outside of the established system boundary unless:
-       (9)(a).  The receiving [Assignment: organization-defined information system or system component] provides [Assignment: organization-defined security safeguards]; and
-       (9)(b).  [Assignment: organization-defined security safeguards] are used to validate the appropriateness of the information designated for release.
+     -  (9)(a).  The receiving [Assignment: organization-defined information system or system component] provides [Assignment: organization-defined security safeguards]; and
+     -  (9)(b).  [Assignment: organization-defined security safeguards] are used to validate the appropriateness of the information designated for release.
 AC-3 (10):
   family: AC
   name: Audited Override Of Access Control Mechanisms
@@ -320,9 +320,9 @@ AC-5:
   name: Separation Of Duties
   description: |-
     The organization:
-      a.  Separates [Assignment: organization-defined duties of individuals];
-      b.  Documents separation of duties of individuals; and
-      c.  Defines information system access authorizations to support separation of duties.
+     - a.  Separates [Assignment: organization-defined duties of individuals];
+     - b.  Documents separation of duties of individuals; and
+     - c.  Defines information system access authorizations to support separation of duties.
 AC-6:
   family: AC
   name: Least Privilege
@@ -370,8 +370,8 @@ AC-6 (7):
   name: Review Of User Privileges
   description: |-
     The organization:
-       (7)(a).  Reviews [Assignment: organization-defined frequency] the privileges assigned to [Assignment: organization-defined roles or classes of users] to validate the need for such privileges; and
-       (7)(b).  Reassigns or removes privileges, if necessary, to correctly reflect organizational mission/business needs.
+     -  (7)(a).  Reviews [Assignment: organization-defined frequency] the privileges assigned to [Assignment: organization-defined roles or classes of users] to validate the need for such privileges; and
+     -  (7)(b).  Reassigns or removes privileges, if necessary, to correctly reflect organizational mission/business needs.
 AC-6 (8):
   family: AC
   name: Privilege Levels For Code Execution
@@ -392,8 +392,8 @@ AC-7:
   name: Unsuccessful Logon Attempts
   description: |-
     The information system:
-      a.  Enforces a limit of [Assignment: organization-defined number] consecutive invalid logon attempts by a user during a [Assignment: organization-defined time period]; and
-      b.  Automatically [Selection: locks the account/node for an [Assignment: organization-defined time period]; locks the account/node until released by an administrator; delays next logon prompt according to [Assignment: organization-defined delay algorithm]] when the maximum number of unsuccessful attempts is exceeded.
+     - a.  Enforces a limit of [Assignment: organization-defined number] consecutive invalid logon attempts by a user during a [Assignment: organization-defined time period]; and
+     - b.  Automatically [Selection: locks the account/node for an [Assignment: organization-defined time period]; locks the account/node until released by an administrator; delays next logon prompt according to [Assignment: organization-defined delay algorithm]] when the maximum number of unsuccessful attempts is exceeded.
 AC-7 (1):
   family: AC
   name: Automatic Account Lock
@@ -410,16 +410,16 @@ AC-8:
   name: System Use Notification
   description: |-
     The information system:
-      a.  Displays to users [Assignment: organization-defined system use notification message or banner] before granting access to the system that provides privacy and security notices consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance and states that:
-        1.  Users are accessing a U.S. Government information system;
-        2.  Information system usage may be monitored, recorded, and subject to audit;
-        3.  Unauthorized use of the information system is prohibited and subject to criminal and civil penalties; and
-        4.  Use of the information system indicates consent to monitoring and recording;
-      b.  Retains the notification message or banner on the screen until users acknowledge the usage conditions and take explicit actions to log on to or further access the information system; and
-      c.  For publicly accessible systems:
-        1.  Displays system use information [Assignment: organization-defined conditions], before granting further access;
-        2.  Displays references, if any, to monitoring, recording, or auditing that are consistent with privacy accommodations for such systems that generally prohibit those activities; and
-        3.  Includes a description of the authorized uses of the system.
+     - a.  Displays to users [Assignment: organization-defined system use notification message or banner] before granting access to the system that provides privacy and security notices consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance and states that:
+       - 1.  Users are accessing a U.S. Government information system;
+       - 2.  Information system usage may be monitored, recorded, and subject to audit;
+       - 3.  Unauthorized use of the information system is prohibited and subject to criminal and civil penalties; and
+       - 4.  Use of the information system indicates consent to monitoring and recording;
+     - b.  Retains the notification message or banner on the screen until users acknowledge the usage conditions and take explicit actions to log on to or further access the information system; and
+     - c.  For publicly accessible systems:
+       - 1.  Displays system use information [Assignment: organization-defined conditions], before granting further access;
+       - 2.  Displays references, if any, to monitoring, recording, or auditing that are consistent with privacy accommodations for such systems that generally prohibit those activities; and
+       - 3.  Includes a description of the authorized uses of the system.
 AC-9:
   family: AC
   name: Previous Logon (Access) Notification
@@ -460,8 +460,8 @@ AC-11:
   name: Session Lock
   description: |-
     The information system:
-      a.  Prevents further access to the system by initiating a session lock after [Assignment: organization-defined time period] of inactivity or upon receiving a request from a user; and
-      b.  Retains the session lock until the user reestablishes access using established identification and authentication procedures.
+     - a.  Prevents further access to the system by initiating a session lock after [Assignment: organization-defined time period] of inactivity or upon receiving a request from a user; and
+     - b.  Retains the session lock until the user reestablishes access using established identification and authentication procedures.
 AC-11 (1):
   family: AC
   name: Pattern-Hiding Displays
@@ -478,8 +478,8 @@ AC-12 (1):
   name: User-Initiated Logouts / Message Displays
   description: |-
     The information system:
-       (1)(a).  Provides a logout capability for user-initiated communications sessions whenever authentication is used to gain access to [Assignment: organization-defined information resources]; and
-       (1)(b).  Displays an explicit logout message to users indicating the reliable termination of authenticated communications sessions.
+     -  (1)(a).  Provides a logout capability for user-initiated communications sessions whenever authentication is used to gain access to [Assignment: organization-defined information resources]; and
+     -  (1)(b).  Displays an explicit logout message to users indicating the reliable termination of authenticated communications sessions.
 AC-13:
   family: AC
   name: Supervision And Review - Access Control
@@ -489,8 +489,8 @@ AC-14:
   name: Permitted Actions Without Identification Or Authentication
   description: |-
     The organization:
-      a.  Identifies [Assignment: organization-defined user actions] that can be performed on the information system without identification or authentication consistent with organizational missions/business functions; and
-      b.  Documents and provides supporting rationale in the security plan for the information system, user actions not requiring identification or authentication.
+     - a.  Identifies [Assignment: organization-defined user actions] that can be performed on the information system without identification or authentication consistent with organizational missions/business functions; and
+     - b.  Documents and provides supporting rationale in the security plan for the information system, user actions not requiring identification or authentication.
 AC-14 (1):
   family: AC
   name: Necessary Uses
@@ -504,10 +504,10 @@ AC-16:
   name: Security Attributes
   description: |-
     The organization:
-      a.  Provides the means to associate [Assignment: organization-defined types of security attributes] having [Assignment: organization-defined security attribute values] with information in storage, in process, and/or in transmission;
-      b.  Ensures that the security attribute associations are made and retained with the information;
-      c.  Establishes the permitted [Assignment: organization-defined security attributes] for [Assignment: organization-defined information systems]; and
-      d.  Determines the permitted [Assignment: organization-defined values or ranges] for each of the established security attributes.
+     - a.  Provides the means to associate [Assignment: organization-defined types of security attributes] having [Assignment: organization-defined security attribute values] with information in storage, in process, and/or in transmission;
+     - b.  Ensures that the security attribute associations are made and retained with the information;
+     - c.  Establishes the permitted [Assignment: organization-defined security attributes] for [Assignment: organization-defined information systems]; and
+     - d.  Determines the permitted [Assignment: organization-defined values or ranges] for each of the established security attributes.
 AC-16 (1):
   family: AC
   name: Dynamic Attribute Association
@@ -575,8 +575,8 @@ AC-17:
   name: Remote Access
   description: |-
     The organization:
-      a.  Establishes and documents usage restrictions, configuration/connection requirements, and implementation guidance for each type of remote access allowed; and
-      b.  Authorizes remote access to the information system prior to allowing such connections.
+     - a.  Establishes and documents usage restrictions, configuration/connection requirements, and implementation guidance for each type of remote access allowed; and
+     - b.  Authorizes remote access to the information system prior to allowing such connections.
 AC-17 (1):
   family: AC
   name: Automated Monitoring / Control
@@ -596,8 +596,8 @@ AC-17 (4):
   name: Privileged Commands / Access
   description: |-
     The organization:
-       (4)(a).  Authorizes the execution of privileged commands and access to security-relevant information via remote access only for [Assignment: organization-defined needs]; and
-       (4)(b).  Documents the rationale for such access in the security plan for the information system.
+     -  (4)(a).  Authorizes the execution of privileged commands and access to security-relevant information via remote access only for [Assignment: organization-defined needs]; and
+     -  (4)(b).  Documents the rationale for such access in the security plan for the information system.
 AC-17 (5):
   family: AC
   name: Monitoring For Unauthorized Connections
@@ -626,8 +626,8 @@ AC-18:
   name: Wireless Access
   description: |-
     The organization:
-      a.  Establishes usage restrictions, configuration/connection requirements, and implementation guidance for wireless access; and
-      b.  Authorizes wireless access to the information system prior to allowing such connections.
+     - a.  Establishes usage restrictions, configuration/connection requirements, and implementation guidance for wireless access; and
+     - b.  Authorizes wireless access to the information system prior to allowing such connections.
 AC-18 (1):
   family: AC
   name: Authentication And Encryption
@@ -659,8 +659,8 @@ AC-19:
   name: Access Control For Mobile Devices
   description: |-
     The organization:
-      a.  Establishes usage restrictions, configuration requirements, connection requirements, and implementation guidance for organization-controlled mobile devices; and
-      b.  Authorizes the connection of mobile devices to organizational information systems.
+     - a.  Establishes usage restrictions, configuration requirements, connection requirements, and implementation guidance for organization-controlled mobile devices; and
+     - b.  Authorizes the connection of mobile devices to organizational information systems.
 AC-19 (1):
   family: AC
   name: Use Of  Writable / Portable Storage Devices
@@ -678,13 +678,13 @@ AC-19 (4):
   name: Restrictions For Classified Information
   description: |-
     The organization:
-       (4)(a).  Prohibits the use of unclassified mobile devices in facilities containing information systems processing, storing, or transmitting classified information unless specifically permitted by the authorizing official; and
-       (4)(b).  Enforces the following restrictions on individuals permitted by the authorizing official to use unclassified mobile devices in facilities containing information systems processing, storing, or transmitting classified information:
-       (4)(b)(1).  Connection of unclassified mobile devices to classified information systems is prohibited;
-       (4)(b)(2).  Connection of unclassified mobile devices to unclassified information systems requires approval from the authorizing official;
-       (4)(b)(3).  Use of internal or external modems or wireless interfaces within the unclassified mobile devices is prohibited; and
-       (4)(b)(4).  Unclassified mobile devices and the information stored on those devices are subject to random reviews and inspections by [Assignment: organization-defined security officials], and if classified information is found, the incident handling policy is followed.
-       (4)(c).  Restricts the connection of classified mobile devices to classified information systems in accordance with [Assignment: organization-defined security policies].
+     -  (4)(a).  Prohibits the use of unclassified mobile devices in facilities containing information systems processing, storing, or transmitting classified information unless specifically permitted by the authorizing official; and
+     -  (4)(b).  Enforces the following restrictions on individuals permitted by the authorizing official to use unclassified mobile devices in facilities containing information systems processing, storing, or transmitting classified information:
+     -  (4)(b)(1).  Connection of unclassified mobile devices to classified information systems is prohibited;
+     -  (4)(b)(2).  Connection of unclassified mobile devices to unclassified information systems requires approval from the authorizing official;
+     -  (4)(b)(3).  Use of internal or external modems or wireless interfaces within the unclassified mobile devices is prohibited; and
+     -  (4)(b)(4).  Unclassified mobile devices and the information stored on those devices are subject to random reviews and inspections by [Assignment: organization-defined security officials], and if classified information is found, the incident handling policy is followed.
+     -  (4)(c).  Restricts the connection of classified mobile devices to classified information systems in accordance with [Assignment: organization-defined security policies].
 AC-19 (5):
   family: AC
   name: Full Device / Container-Based  Encryption
@@ -696,15 +696,15 @@ AC-20:
   name: Use Of External Information Systems
   description: |-
     The organization establishes terms and conditions, consistent with any trust relationships established with other organizations owning, operating, and/or maintaining external information systems, allowing authorized individuals to:
-      a.  Access the information system from external information systems; and
-      b.  Process, store, or transmit organization-controlled information using external information systems.
+     - a.  Access the information system from external information systems; and
+     - b.  Process, store, or transmit organization-controlled information using external information systems.
 AC-20 (1):
   family: AC
   name: Limits On Authorized Use
   description: |-
     The organization permits authorized individuals to use an external information system to access the information system or to process, store, or transmit organization-controlled information only when the organization:
-       (1)(a).  Verifies the implementation of required security controls on the external system as specified in the organization's information security policy and security plan; or
-       (1)(b).  Retains approved information system connection or processing agreements with the organizational entity hosting the external information system.
+     -  (1)(a).  Verifies the implementation of required security controls on the external system as specified in the organization's information security policy and security plan; or
+     -  (1)(b).  Retains approved information system connection or processing agreements with the organizational entity hosting the external information system.
 AC-20 (2):
   family: AC
   name: Portable Storage Devices
@@ -726,8 +726,8 @@ AC-21:
   name: Information Sharing
   description: |-
     The organization:
-      a.  Facilitates information sharing by enabling authorized users to determine whether access authorizations assigned to the sharing partner match the access restrictions on the information for [Assignment: organization-defined information sharing circumstances where user discretion is required]; and
-      b.  Employs [Assignment: organization-defined automated mechanisms or manual processes] to assist users in making information sharing/collaboration decisions.
+     - a.  Facilitates information sharing by enabling authorized users to determine whether access authorizations assigned to the sharing partner match the access restrictions on the information for [Assignment: organization-defined information sharing circumstances where user discretion is required]; and
+     - b.  Employs [Assignment: organization-defined automated mechanisms or manual processes] to assist users in making information sharing/collaboration decisions.
 AC-21 (1):
   family: AC
   name: Automated Decision Support
@@ -744,10 +744,10 @@ AC-22:
   name: Publicly Accessible Content
   description: |-
     The organization:
-      a.  Designates individuals authorized to post information onto a publicly accessible information system;
-      b.  Trains authorized individuals to ensure that publicly accessible information does not contain nonpublic information;
-      c.  Reviews the proposed content of information prior to posting onto the publicly accessible information system to ensure that nonpublic information is not included; and
-      d.  Reviews the content on the publicly accessible information system for nonpublic information [Assignment: organization-defined frequency] and removes such information, if discovered.
+     - a.  Designates individuals authorized to post information onto a publicly accessible information system;
+     - b.  Trains authorized individuals to ensure that publicly accessible information does not contain nonpublic information;
+     - c.  Reviews the proposed content of information prior to posting onto the publicly accessible information system to ensure that nonpublic information is not included; and
+     - d.  Reviews the content on the publicly accessible information system for nonpublic information [Assignment: organization-defined frequency] and removes such information, if discovered.
 AC-23:
   family: AC
   name: Data Mining Protection
@@ -784,20 +784,20 @@ AT-1:
   name: Security Awareness And Training Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A security awareness and training policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the security awareness and training policy and associated security awareness and training controls; and
-      b.  Reviews and updates the current:
-        1.  Security awareness and training policy [Assignment: organization-defined frequency]; and
-        2.  Security awareness and training procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A security awareness and training policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the security awareness and training policy and associated security awareness and training controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Security awareness and training policy [Assignment: organization-defined frequency]; and
+       - 2.  Security awareness and training procedures [Assignment: organization-defined frequency].
 AT-2:
   family: AT
   name: Security Awareness Training
   description: |-
     The organization provides basic security awareness training to information system users (including managers, senior executives, and contractors):
-      a.  As part of initial training for new users;
-      b.  When required by information system changes; and
-      c.  [Assignment: organization-defined frequency] thereafter.
+     - a.  As part of initial training for new users;
+     - b.  When required by information system changes; and
+     - c.  [Assignment: organization-defined frequency] thereafter.
 AT-2 (1):
   family: AT
   name: Practical Exercises
@@ -813,9 +813,9 @@ AT-3:
   name: Role-Based Security Training
   description: |-
     The organization provides role-based security training to personnel with assigned security roles and responsibilities:
-      a.  Before authorizing access to the information system or performing assigned duties;
-      b.  When required by information system changes; and
-      c.  [Assignment: organization-defined frequency] thereafter.
+     - a.  Before authorizing access to the information system or performing assigned duties;
+     - b.  When required by information system changes; and
+     - c.  [Assignment: organization-defined frequency] thereafter.
 AT-3 (1):
   family: AT
   name: Environmental Controls
@@ -844,8 +844,8 @@ AT-4:
   name: Security Training Records
   description: |-
     The organization:
-      a.  Documents and monitors individual information system security training activities including basic security awareness training and specific information system security training; and
-      b.  Retains individual training records for [Assignment: organization-defined time period].
+     - a.  Documents and monitors individual information system security training activities including basic security awareness training and specific information system security training; and
+     - b.  Retains individual training records for [Assignment: organization-defined time period].
 AT-5:
   family: AT
   name: Contacts With Security Groups And Associations
@@ -855,21 +855,21 @@ AU-1:
   name: Audit And Accountability Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  An audit and accountability policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the audit and accountability policy and associated audit and accountability controls; and
-      b.  Reviews and updates the current:
-        1.  Audit and accountability policy [Assignment: organization-defined frequency]; and
-        2.  Audit and accountability procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  An audit and accountability policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the audit and accountability policy and associated audit and accountability controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Audit and accountability policy [Assignment: organization-defined frequency]; and
+       - 2.  Audit and accountability procedures [Assignment: organization-defined frequency].
 AU-2:
   family: AU
   name: Audit Events
   description: |-
     The organization:
-      a.  Determines that the information system is capable of auditing the following events: [Assignment: organization-defined auditable events];
-      b.  Coordinates the security audit function with other organizational entities requiring audit-related information to enhance mutual support and to help guide the selection of auditable events;
-      c.  Provides a rationale for why the auditable events are deemed to be adequate to support after-the-fact investigations of security incidents; and
-      d.  Determines that the following events are to be audited within the information system: [Assignment: organization-defined audited events (the subset of the auditable events defined in AU-2 a.) along with the frequency of (or situation requiring) auditing for each identified event].
+     - a.  Determines that the information system is capable of auditing the following events: [Assignment: organization-defined auditable events];
+     - b.  Coordinates the security audit function with other organizational entities requiring audit-related information to enhance mutual support and to help guide the selection of auditable events;
+     - c.  Provides a rationale for why the auditable events are deemed to be adequate to support after-the-fact investigations of security incidents; and
+     - d.  Determines that the following events are to be audited within the information system: [Assignment: organization-defined audited events (the subset of the auditable events defined in AU-2 a.) along with the frequency of (or situation requiring) auditing for each identified event].
 AU-2 (1):
   family: AU
   name: Compilation Of Audit Records From Multiple Sources
@@ -921,8 +921,8 @@ AU-5:
   name: Response To Audit Processing Failures
   description: |-
     The information system:
-      a.  Alerts [Assignment: organization-defined personnel or roles] in the event of an audit processing failure; and
-      b.  Takes the following additional actions: [Assignment: organization-defined actions to be taken (e.g., shut down information system, overwrite oldest audit records, stop generating audit records)].
+     - a.  Alerts [Assignment: organization-defined personnel or roles] in the event of an audit processing failure; and
+     - b.  Takes the following additional actions: [Assignment: organization-defined actions to be taken (e.g., shut down information system, overwrite oldest audit records, stop generating audit records)].
 AU-5 (1):
   family: AU
   name: Audit Storage Capacity
@@ -955,8 +955,8 @@ AU-6:
   name: Audit Review, Analysis, And Reporting
   description: |-
     The organization:
-      a.  Reviews and analyzes information system audit records [Assignment: organization-defined frequency] for indications of [Assignment: organization-defined inappropriate or unusual activity]; and
-      b.  Reports findings to [Assignment: organization-defined personnel or roles].
+     - a.  Reviews and analyzes information system audit records [Assignment: organization-defined frequency] for indications of [Assignment: organization-defined inappropriate or unusual activity]; and
+     - b.  Reports findings to [Assignment: organization-defined personnel or roles].
 AU-6 (1):
   family: AU
   name: Process Integration
@@ -1019,8 +1019,8 @@ AU-7:
   name: Audit Reduction And Report Generation
   description: |-
     The information system provides an audit reduction and report generation capability that:
-      a.  Supports on-demand audit review, analysis, and reporting requirements and after-the-fact investigations of security incidents; and
-      b.  Does not alter the original content or time ordering of audit records.
+     - a.  Supports on-demand audit review, analysis, and reporting requirements and after-the-fact investigations of security incidents; and
+     - b.  Does not alter the original content or time ordering of audit records.
 AU-7 (1):
   family: AU
   name: Automatic Processing
@@ -1038,15 +1038,15 @@ AU-8:
   name: Time Stamps
   description: |-
     The information system:
-      a.  Uses internal system clocks to generate time stamps for audit records; and
-      b.  Records time stamps for audit records that can be mapped to Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT) and meets [Assignment: organization-defined granularity of time measurement].
+     - a.  Uses internal system clocks to generate time stamps for audit records; and
+     - b.  Records time stamps for audit records that can be mapped to Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT) and meets [Assignment: organization-defined granularity of time measurement].
 AU-8 (1):
   family: AU
   name: Synchronization With Authoritative Time Source
   description: |-
     The information system:
-       (1)(a).  Compares the internal information system clocks [Assignment: organization-defined frequency] with [Assignment: organization-defined authoritative time source]; and
-       (1)(b).  Synchronizes the internal system clocks to the authoritative time source when the time difference is greater than [Assignment: organization-defined time period].
+     -  (1)(a).  Compares the internal information system clocks [Assignment: organization-defined frequency] with [Assignment: organization-defined authoritative time source]; and
+     -  (1)(b).  Synchronizes the internal system clocks to the authoritative time source when the time difference is greater than [Assignment: organization-defined time period].
 AU-8 (2):
   family: AU
   name: Secondary Authoritative Time Source
@@ -1100,15 +1100,15 @@ AU-10 (1):
   name: Association Of Identities
   description: |-
     The information system:
-       (1)(a).  Binds the identity of the information producer with the information to [Assignment: organization-defined strength of binding]; and
-       (1)(b).  Provides the means for authorized individuals to determine the identity of the producer of the information.
+     -  (1)(a).  Binds the identity of the information producer with the information to [Assignment: organization-defined strength of binding]; and
+     -  (1)(b).  Provides the means for authorized individuals to determine the identity of the producer of the information.
 AU-10 (2):
   family: AU
   name: Validate Binding Of Information Producer Identity
   description: |-
     The information system:
-       (2)(a).  Validates the binding of the information producer identity to the information at [Assignment: organization-defined frequency]; and
-       (2)(b).  Performs [Assignment: organization-defined actions] in the event of a validation error.
+     -  (2)(a).  Validates the binding of the information producer identity to the information at [Assignment: organization-defined frequency]; and
+     -  (2)(b).  Performs [Assignment: organization-defined actions] in the event of a validation error.
 AU-10 (3):
   family: AU
   name: Chain Of Custody
@@ -1119,8 +1119,8 @@ AU-10 (4):
   name: Validate Binding Of Information Reviewer Identity
   description: |-
     The information system:
-       (4)(a).  Validates the binding of the information reviewer identity to the information at the transfer or release points prior to release/transfer between [Assignment: organization-defined security domains]; and
-       (4)(b).  Performs [Assignment: organization-defined actions] in the event of a validation error.
+     -  (4)(a).  Validates the binding of the information reviewer identity to the information at the transfer or release points prior to release/transfer between [Assignment: organization-defined security domains]; and
+     -  (4)(b).  Performs [Assignment: organization-defined actions] in the event of a validation error.
 AU-10 (5):
   family: AU
   name: Digital Signatures
@@ -1143,9 +1143,9 @@ AU-12:
   name: Audit Generation
   description: |-
     The information system:
-      a.  Provides audit record generation capability for the auditable events defined in AU-2 a. at [Assignment: organization-defined information system components];
-      b.  Allows [Assignment: organization-defined personnel or roles] to select which auditable events are to be audited by specific components of the information system; and
-      c.  Generates audit records for the events defined in AU-2 d. with the content defined in AU-3.
+     - a.  Provides audit record generation capability for the auditable events defined in AU-2 a. at [Assignment: organization-defined information system components];
+     - b.  Allows [Assignment: organization-defined personnel or roles] to select which auditable events are to be audited by specific components of the information system; and
+     - c.  Generates audit records for the events defined in AU-2 d. with the content defined in AU-3.
 AU-12 (1):
   family: AU
   name: System-Wide / Time-Correlated Audit Trail
@@ -1230,24 +1230,24 @@ CA-1:
   name: Security Assessment And Authorization Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A security assessment and authorization policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the security assessment and authorization policy and associated security assessment and authorization controls; and
-      b.  Reviews and updates the current:
-        1.  Security assessment and authorization policy [Assignment: organization-defined frequency]; and
-        2.  Security assessment and authorization procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A security assessment and authorization policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the security assessment and authorization policy and associated security assessment and authorization controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Security assessment and authorization policy [Assignment: organization-defined frequency]; and
+       - 2.  Security assessment and authorization procedures [Assignment: organization-defined frequency].
 CA-2:
   family: CA
   name: Security Assessments
   description: |-
     The organization:
-      a.  Develops a security assessment plan that describes the scope of the assessment including:
-        1.  Security controls and control enhancements under assessment;
-        2.  Assessment procedures to be used to determine security control effectiveness; and
-        3.  Assessment environment, assessment team, and assessment roles and responsibilities;
-      b.  Assesses the security controls in the information system and its environment of operation [Assignment: organization-defined frequency] to determine the extent to which the controls are implemented correctly, operating as intended, and producing the desired outcome with respect to meeting established security requirements;
-      c.  Produces a security assessment report that documents the results of the assessment; and
-      d.  Provides the results of the security control assessment to [Assignment: organization-defined individuals or roles].
+     - a.  Develops a security assessment plan that describes the scope of the assessment including:
+       - 1.  Security controls and control enhancements under assessment;
+       - 2.  Assessment procedures to be used to determine security control effectiveness; and
+       - 3.  Assessment environment, assessment team, and assessment roles and responsibilities;
+     - b.  Assesses the security controls in the information system and its environment of operation [Assignment: organization-defined frequency] to determine the extent to which the controls are implemented correctly, operating as intended, and producing the desired outcome with respect to meeting established security requirements;
+     - c.  Produces a security assessment report that documents the results of the assessment; and
+     - d.  Provides the results of the security control assessment to [Assignment: organization-defined individuals or roles].
 CA-2 (1):
   family: CA
   name: Independent Assessors
@@ -1273,9 +1273,9 @@ CA-3:
   name: System Interconnections
   description: |-
     The organization:
-      a.  Authorizes connections from the information system to other information systems through the use of Interconnection Security Agreements;
-      b.  Documents, for each interconnection, the interface characteristics, security requirements, and the nature of the information communicated; and
-      c.  Reviews and updates Interconnection Security Agreements [Assignment: organization-defined frequency].
+     - a.  Authorizes connections from the information system to other information systems through the use of Interconnection Security Agreements;
+     - b.  Documents, for each interconnection, the interface characteristics, security requirements, and the nature of the information communicated; and
+     - c.  Reviews and updates Interconnection Security Agreements [Assignment: organization-defined frequency].
 CA-3 (1):
   family: CA
   name: Unclassified National Security System Connections
@@ -1315,8 +1315,8 @@ CA-5:
   name: Plan Of Action And Milestones
   description: |-
     The organization:
-      a.  Develops a plan of action and milestones for the information system to document the organization's planned remedial actions to correct weaknesses or deficiencies noted during the assessment of the security controls and to reduce or eliminate known vulnerabilities in the system; and
-      b.  Updates existing plan of action and milestones [Assignment: organization-defined frequency] based on the findings from security controls assessments, security impact analyses, and continuous monitoring activities.
+     - a.  Develops a plan of action and milestones for the information system to document the organization's planned remedial actions to correct weaknesses or deficiencies noted during the assessment of the security controls and to reduce or eliminate known vulnerabilities in the system; and
+     - b.  Updates existing plan of action and milestones [Assignment: organization-defined frequency] based on the findings from security controls assessments, security impact analyses, and continuous monitoring activities.
 CA-5 (1):
   family: CA
   name: Automation Support For Accuracy / Currency
@@ -1328,21 +1328,21 @@ CA-6:
   name: Security Authorization
   description: |-
     The organization:
-      a.  Assigns a senior-level executive or manager as the authorizing official for the information system;
-      b.  Ensures that the authorizing official authorizes the information system for processing before commencing operations; and
-      c.  Updates the security authorization [Assignment: organization-defined frequency].
+     - a.  Assigns a senior-level executive or manager as the authorizing official for the information system;
+     - b.  Ensures that the authorizing official authorizes the information system for processing before commencing operations; and
+     - c.  Updates the security authorization [Assignment: organization-defined frequency].
 CA-7:
   family: CA
   name: Continuous Monitoring
   description: |-
     The organization develops a continuous monitoring strategy and implements a continuous monitoring program that includes:
-      a.  Establishment of [Assignment: organization-defined metrics] to be monitored;
-      b.  Establishment of [Assignment: organization-defined frequencies] for monitoring and [Assignment: organization-defined frequencies] for assessments supporting such monitoring;
-      c.  Ongoing security control assessments in accordance with the organizational continuous monitoring strategy;
-      d.  Ongoing security status monitoring of organization-defined metrics in accordance with the organizational continuous monitoring strategy;
-      e.  Correlation and analysis of security-related information generated by assessments and monitoring;
-      f.  Response actions to address results of the analysis of security-related information; and
-      g.  Reporting the security status of organization and the information system to [Assignment: organization-defined personnel or roles] [Assignment: organization-defined frequency].
+     - a.  Establishment of [Assignment: organization-defined metrics] to be monitored;
+     - b.  Establishment of [Assignment: organization-defined frequencies] for monitoring and [Assignment: organization-defined frequencies] for assessments supporting such monitoring;
+     - c.  Ongoing security control assessments in accordance with the organizational continuous monitoring strategy;
+     - d.  Ongoing security status monitoring of organization-defined metrics in accordance with the organizational continuous monitoring strategy;
+     - e.  Correlation and analysis of security-related information generated by assessments and monitoring;
+     - f.  Response actions to address results of the analysis of security-related information; and
+     - g.  Reporting the security status of organization and the information system to [Assignment: organization-defined personnel or roles] [Assignment: organization-defined frequency].
 CA-7 (1):
   family: CA
   name: Independent Assessment
@@ -1382,8 +1382,8 @@ CA-9:
   name: Internal System Connections
   description: |-
     The organization:
-      a.  Authorizes internal connections of [Assignment: organization-defined information system components or classes of components] to the information system; and
-      b.  Documents, for each internal connection, the interface characteristics, security requirements, and the nature of the information communicated.
+     - a.  Authorizes internal connections of [Assignment: organization-defined information system components or classes of components] to the information system; and
+     - b.  Documents, for each internal connection, the interface characteristics, security requirements, and the nature of the information communicated.
 CA-9 (1):
   family: CA
   name: Security Compliance Checks
@@ -1394,12 +1394,12 @@ CM-1:
   name: Configuration Management Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A configuration management policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the configuration management policy and associated configuration management controls; and
-      b.  Reviews and updates the current:
-        1.  Configuration management policy [Assignment: organization-defined frequency]; and
-        2.  Configuration management procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A configuration management policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the configuration management policy and associated configuration management controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Configuration management policy [Assignment: organization-defined frequency]; and
+       - 2.  Configuration management procedures [Assignment: organization-defined frequency].
 CM-2:
   family: CM
   name: Baseline Configuration
@@ -1410,9 +1410,9 @@ CM-2 (1):
   name: Reviews And Updates
   description: |-
     The organization reviews and updates the baseline configuration of the information system:
-       (1)(a).  [Assignment: organization-defined frequency];
-       (1)(b).  When required due to [Assignment organization-defined circumstances]; and
-       (1)(c).  As an integral part of information system component installations and upgrades.
+     -  (1)(a).  [Assignment: organization-defined frequency];
+     -  (1)(b).  When required due to [Assignment organization-defined circumstances]; and
+     -  (1)(c).  As an integral part of information system component installations and upgrades.
 CM-2 (2):
   family: CM
   name: Automation Support For Accuracy / Currency
@@ -1443,31 +1443,31 @@ CM-2 (7):
   name: Configure Systems, Components, Or Devices For High-Risk Areas
   description: |-
     The organization:
-       (7)(a).  Issues [Assignment: organization-defined information systems, system components, or devices] with [Assignment: organization-defined configurations] to individuals traveling to locations that the organization deems to be of significant risk; and
-       (7)(b).  Applies [Assignment: organization-defined security safeguards] to the devices when the individuals return.
+     -  (7)(a).  Issues [Assignment: organization-defined information systems, system components, or devices] with [Assignment: organization-defined configurations] to individuals traveling to locations that the organization deems to be of significant risk; and
+     -  (7)(b).  Applies [Assignment: organization-defined security safeguards] to the devices when the individuals return.
 CM-3:
   family: CM
   name: Configuration Change Control
   description: |-
     The organization:
-      a.  Determines the types of changes to the information system that are configuration-controlled;
-      b.  Reviews proposed configuration-controlled changes to the information system and approves or disapproves such changes with explicit consideration for security impact analyses;
-      c.  Documents configuration change decisions associated with the information system;
-      d.  Implements approved configuration-controlled changes to the information system;
-      e.  Retains records of configuration-controlled changes to the information system for [Assignment: organization-defined time period];
-      f.  Audits and reviews activities associated with configuration-controlled changes to the information system; and
-      g.  Coordinates and provides oversight for configuration change control activities through [Assignment: organization-defined configuration change control element (e.g., committee, board)] that convenes [Selection (one or more): [Assignment: organization-defined frequency]; [Assignment: organization-defined configuration change conditions]].
+     - a.  Determines the types of changes to the information system that are configuration-controlled;
+     - b.  Reviews proposed configuration-controlled changes to the information system and approves or disapproves such changes with explicit consideration for security impact analyses;
+     - c.  Documents configuration change decisions associated with the information system;
+     - d.  Implements approved configuration-controlled changes to the information system;
+     - e.  Retains records of configuration-controlled changes to the information system for [Assignment: organization-defined time period];
+     - f.  Audits and reviews activities associated with configuration-controlled changes to the information system; and
+     - g.  Coordinates and provides oversight for configuration change control activities through [Assignment: organization-defined configuration change control element (e.g., committee, board)] that convenes [Selection (one or more): [Assignment: organization-defined frequency]; [Assignment: organization-defined configuration change conditions]].
 CM-3 (1):
   family: CM
   name: Automated Document / Notification / Prohibition Of Changes
   description: |-
     The organization employs automated mechanisms to:
-       (1)(a).  Document proposed changes to the information system;
-       (1)(b).  Notify [Assignment: organized-defined approval authorities] of proposed changes to the information system and request change approval;
-       (1)(c).  Highlight proposed changes to the information system that have not been approved or disapproved by [Assignment: organization-defined time period];
-       (1)(d).  Prohibit changes to the information system until designated approvals are received;
-       (1)(e).  Document all changes to the information system; and
-       (1)(f).  Notify [Assignment: organization-defined personnel] when approved changes to the information system are completed.
+     -  (1)(a).  Document proposed changes to the information system;
+     -  (1)(b).  Notify [Assignment: organized-defined approval authorities] of proposed changes to the information system and request change approval;
+     -  (1)(c).  Highlight proposed changes to the information system that have not been approved or disapproved by [Assignment: organization-defined time period];
+     -  (1)(d).  Prohibit changes to the information system until designated approvals are received;
+     -  (1)(e).  Document all changes to the information system; and
+     -  (1)(f).  Notify [Assignment: organization-defined personnel] when approved changes to the information system are completed.
 CM-3 (2):
   family: CM
   name: Test / Validate / Document Changes
@@ -1550,8 +1550,8 @@ CM-5 (5):
   name: Limit Production / Operational Privileges
   description: |-
     The organization:
-       (5)(a).  Limits privileges to change information system components and system-related information within a production or operational environment; and
-       (5)(b).  Reviews and reevaluates privileges [Assignment: organization-defined frequency].
+     -  (5)(a).  Limits privileges to change information system components and system-related information within a production or operational environment; and
+     -  (5)(b).  Reviews and reevaluates privileges [Assignment: organization-defined frequency].
 CM-5 (6):
   family: CM
   name: Limit Library Privileges
@@ -1566,10 +1566,10 @@ CM-6:
   name: Configuration Settings
   description: |-
     The organization:
-      a.  Establishes and documents configuration settings for information technology products employed within the information system using [Assignment: organization-defined security configuration checklists] that reflect the most restrictive mode consistent with operational requirements;
-      b.  Implements the configuration settings;
-      c.  Identifies, documents, and approves any deviations from established configuration settings for [Assignment: organization-defined information system components] based on [Assignment: organization-defined operational requirements]; and
-      d.  Monitors and controls changes to the configuration settings in accordance with organizational policies and procedures.
+     - a.  Establishes and documents configuration settings for information technology products employed within the information system using [Assignment: organization-defined security configuration checklists] that reflect the most restrictive mode consistent with operational requirements;
+     - b.  Implements the configuration settings;
+     - c.  Identifies, documents, and approves any deviations from established configuration settings for [Assignment: organization-defined information system components] based on [Assignment: organization-defined operational requirements]; and
+     - d.  Monitors and controls changes to the configuration settings in accordance with organizational policies and procedures.
 CM-6 (1):
   family: CM
   name: Automated Central Management / Application / Verification
@@ -1595,15 +1595,15 @@ CM-7:
   name: Least Functionality
   description: |-
     The organization:
-      a.  Configures the information system to provide only essential capabilities; and
-      b.  Prohibits or restricts the use of the following functions, ports, protocols, and/or services: [Assignment: organization-defined prohibited or restricted functions, ports, protocols, and/or services].
+     - a.  Configures the information system to provide only essential capabilities; and
+     - b.  Prohibits or restricts the use of the following functions, ports, protocols, and/or services: [Assignment: organization-defined prohibited or restricted functions, ports, protocols, and/or services].
 CM-7 (1):
   family: CM
   name: Periodic Review
   description: |-
     The organization:
-       (1)(a).  Reviews the information system [Assignment: organization-defined frequency] to identify unnecessary and/or nonsecure functions, ports, protocols, and services; and
-       (1)(b).  Disables [Assignment: organization-defined functions, ports, protocols, and services within the information system deemed to be unnecessary and/or nonsecure].
+     -  (1)(a).  Reviews the information system [Assignment: organization-defined frequency] to identify unnecessary and/or nonsecure functions, ports, protocols, and services; and
+     -  (1)(b).  Disables [Assignment: organization-defined functions, ports, protocols, and services within the information system deemed to be unnecessary and/or nonsecure].
 CM-7 (2):
   family: CM
   name: Prevent Program Execution
@@ -1621,28 +1621,28 @@ CM-7 (4):
   name: Unauthorized Software / Blacklisting
   description: |-
     The organization:
-       (4)(a).  Identifies [Assignment: organization-defined software programs not authorized to execute on the information system];
-       (4)(b).  Employs an allow-all, deny-by-exception policy to prohibit the execution of unauthorized software programs on the information system; and
-       (4)(c).  Reviews and updates the list of unauthorized software programs [Assignment: organization-defined frequency].
+     -  (4)(a).  Identifies [Assignment: organization-defined software programs not authorized to execute on the information system];
+     -  (4)(b).  Employs an allow-all, deny-by-exception policy to prohibit the execution of unauthorized software programs on the information system; and
+     -  (4)(c).  Reviews and updates the list of unauthorized software programs [Assignment: organization-defined frequency].
 CM-7 (5):
   family: CM
   name: Authorized Software / Whitelisting
   description: |-
     The organization:
-       (5)(a).  Identifies [Assignment: organization-defined software programs authorized to execute on the information system];
-       (5)(b).  Employs a deny-all, permit-by-exception policy to allow the execution of authorized software programs on the information system; and
-       (5)(c).  Reviews and updates the list of authorized software programs [Assignment: organization-defined frequency].
+     -  (5)(a).  Identifies [Assignment: organization-defined software programs authorized to execute on the information system];
+     -  (5)(b).  Employs a deny-all, permit-by-exception policy to allow the execution of authorized software programs on the information system; and
+     -  (5)(c).  Reviews and updates the list of authorized software programs [Assignment: organization-defined frequency].
 CM-8:
   family: CM
   name: Information System Component Inventory
   description: |-
     The organization:
-      a.  Develops and documents an inventory of information system components that:
-        1.  Accurately reflects the current information system;
-        2.  Includes all components within the authorization boundary of the information system;
-        3.  Is at the level of granularity deemed necessary for tracking and reporting; and
-        4.  Includes [Assignment: organization-defined information deemed necessary to achieve effective information system component accountability]; and
-      b.  Reviews and updates the information system component inventory [Assignment: organization-defined frequency].
+     - a.  Develops and documents an inventory of information system components that:
+       - 1.  Accurately reflects the current information system;
+       - 2.  Includes all components within the authorization boundary of the information system;
+       - 3.  Is at the level of granularity deemed necessary for tracking and reporting; and
+       - 4.  Includes [Assignment: organization-defined information deemed necessary to achieve effective information system component accountability]; and
+     - b.  Reviews and updates the information system component inventory [Assignment: organization-defined frequency].
 CM-8 (1):
   family: CM
   name: Updates During Installations / Removals
@@ -1659,8 +1659,8 @@ CM-8 (3):
   name: Automated Unauthorized Component Detection
   description: |-
     The organization:
-       (3)(a).  Employs automated mechanisms [Assignment: organization-defined frequency] to detect the presence of unauthorized hardware, software, and firmware components within the information system; and
-       (3)(b).  Takes the following actions when unauthorized components are detected: [Selection (one or more): disables network access by such components; isolates the components; notifies [Assignment: organization-defined personnel or roles]].
+     -  (3)(a).  Employs automated mechanisms [Assignment: organization-defined frequency] to detect the presence of unauthorized hardware, software, and firmware components within the information system; and
+     -  (3)(b).  Takes the following actions when unauthorized components are detected: [Selection (one or more): disables network access by such components; isolates the components; notifies [Assignment: organization-defined personnel or roles]].
 CM-8 (4):
   family: CM
   name: Accountability Information
@@ -1694,17 +1694,17 @@ CM-8 (9):
   name: Assignment Of Components To Systems
   description: |-
     The organization:
-       (9)(a).  Assigns [Assignment: organization-defined acquired information system components] to an information system; and
-       (9)(b).  Receives an acknowledgement from the information system owner of this assignment.
+     -  (9)(a).  Assigns [Assignment: organization-defined acquired information system components] to an information system; and
+     -  (9)(b).  Receives an acknowledgement from the information system owner of this assignment.
 CM-9:
   family: CM
   name: Configuration Management Plan
   description: |-
     The organization develops, documents, and implements a configuration management plan for the information system that:
-      a.  Addresses roles, responsibilities, and configuration management processes and procedures;
-      b.  Establishes a process for identifying configuration items throughout the system development life cycle and for managing the configuration of the configuration items;
-      c.  Defines the configuration items for the information system and places the configuration items under configuration management; and
-      d.  Protects the configuration management plan from unauthorized disclosure and modification.
+     - a.  Addresses roles, responsibilities, and configuration management processes and procedures;
+     - b.  Establishes a process for identifying configuration items throughout the system development life cycle and for managing the configuration of the configuration items;
+     - c.  Defines the configuration items for the information system and places the configuration items under configuration management; and
+     - d.  Protects the configuration management plan from unauthorized disclosure and modification.
 CM-9 (1):
   family: CM
   name: Assignment Of Responsibility
@@ -1716,9 +1716,9 @@ CM-10:
   name: Software Usage Restrictions
   description: |-
     The organization:
-      a.  Uses software and associated documentation in accordance with contract agreements and copyright laws;
-      b.  Tracks the use of software and associated documentation protected by quantity licenses to control copying and distribution; and
-      c.  Controls and documents the use of peer-to-peer file sharing technology to ensure that this capability is not used for the unauthorized distribution, display, performance, or reproduction of copyrighted work.
+     - a.  Uses software and associated documentation in accordance with contract agreements and copyright laws;
+     - b.  Tracks the use of software and associated documentation protected by quantity licenses to control copying and distribution; and
+     - c.  Controls and documents the use of peer-to-peer file sharing technology to ensure that this capability is not used for the unauthorized distribution, display, performance, or reproduction of copyrighted work.
 CM-10 (1):
   family: CM
   name: Open Source Software
@@ -1729,9 +1729,9 @@ CM-11:
   name: User-Installed Software
   description: |-
     The organization:
-      a.  Establishes [Assignment: organization-defined policies] governing the installation of software by users;
-      b.  Enforces software installation policies through [Assignment: organization-defined methods]; and
-      c.  Monitors policy compliance at [Assignment: organization-defined frequency].
+     - a.  Establishes [Assignment: organization-defined policies] governing the installation of software by users;
+     - b.  Enforces software installation policies through [Assignment: organization-defined methods]; and
+     - c.  Monitors policy compliance at [Assignment: organization-defined frequency].
 CM-11 (1):
   family: CM
   name: Alerts For Unauthorized Installations
@@ -1747,30 +1747,30 @@ CP-1:
   name: Contingency Planning Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A contingency planning policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the contingency planning policy and associated contingency planning controls; and
-      b.  Reviews and updates the current:
-        1.  Contingency planning policy [Assignment: organization-defined frequency]; and
-        2.  Contingency planning procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A contingency planning policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the contingency planning policy and associated contingency planning controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Contingency planning policy [Assignment: organization-defined frequency]; and
+       - 2.  Contingency planning procedures [Assignment: organization-defined frequency].
 CP-2:
   family: CP
   name: Contingency Plan
   description: |-
     The organization:
-      a.  Develops a contingency plan for the information system that:
-        1.  Identifies essential missions and business functions and associated contingency requirements;
-        2.  Provides recovery objectives, restoration priorities, and metrics;
-        3.  Addresses contingency roles, responsibilities, assigned individuals with contact information;
-        4.  Addresses maintaining essential missions and business functions despite an information system disruption, compromise, or failure;
-        5.  Addresses eventual, full information system restoration without deterioration of the security safeguards originally planned and implemented; and
-        6.  Is reviewed and approved by [Assignment: organization-defined personnel or roles];
-      b.  Distributes copies of the contingency plan to [Assignment: organization-defined key contingency personnel (identified by name and/or by role) and organizational elements];
-      c.  Coordinates contingency planning activities with incident handling activities;
-      d.  Reviews the contingency plan for the information system [Assignment: organization-defined frequency];
-      e.  Updates the contingency plan to address changes to the organization, information system, or environment of operation and problems encountered during contingency plan implementation, execution, or testing;
-      f.  Communicates contingency plan changes to [Assignment: organization-defined key contingency personnel (identified by name and/or by role) and organizational elements]; and
-      g.  Protects the contingency plan from unauthorized disclosure and modification.
+     - a.  Develops a contingency plan for the information system that:
+       - 1.  Identifies essential missions and business functions and associated contingency requirements;
+       - 2.  Provides recovery objectives, restoration priorities, and metrics;
+       - 3.  Addresses contingency roles, responsibilities, assigned individuals with contact information;
+       - 4.  Addresses maintaining essential missions and business functions despite an information system disruption, compromise, or failure;
+       - 5.  Addresses eventual, full information system restoration without deterioration of the security safeguards originally planned and implemented; and
+       - 6.  Is reviewed and approved by [Assignment: organization-defined personnel or roles];
+     - b.  Distributes copies of the contingency plan to [Assignment: organization-defined key contingency personnel (identified by name and/or by role) and organizational elements];
+     - c.  Coordinates contingency planning activities with incident handling activities;
+     - d.  Reviews the contingency plan for the information system [Assignment: organization-defined frequency];
+     - e.  Updates the contingency plan to address changes to the organization, information system, or environment of operation and problems encountered during contingency plan implementation, execution, or testing;
+     - f.  Communicates contingency plan changes to [Assignment: organization-defined key contingency personnel (identified by name and/or by role) and organizational elements]; and
+     - g.  Protects the contingency plan from unauthorized disclosure and modification.
 CP-2 (1):
   family: CP
   name: Coordinate With Related Plans
@@ -1824,9 +1824,9 @@ CP-3:
   name: Contingency Training
   description: |-
     The organization provides contingency training to information system users consistent with assigned roles and responsibilities:
-      a.  Within [Assignment: organization-defined time period] of assuming a contingency role or responsibility;
-      b.  When required by information system changes; and
-      c.  [Assignment: organization-defined frequency] thereafter.
+     - a.  Within [Assignment: organization-defined time period] of assuming a contingency role or responsibility;
+     - b.  When required by information system changes; and
+     - c.  [Assignment: organization-defined frequency] thereafter.
 CP-3 (1):
   family: CP
   name: Simulated Events
@@ -1842,9 +1842,9 @@ CP-4:
   name: Contingency Plan Testing
   description: |-
     The organization:
-      a.  Tests the contingency plan for the information system [Assignment: organization-defined frequency] using [Assignment: organization-defined tests] to determine the effectiveness of the plan and the organizational readiness to execute the plan;
-      b.  Reviews the contingency plan test results; and
-      c.  Initiates corrective actions, if needed.
+     - a.  Tests the contingency plan for the information system [Assignment: organization-defined frequency] using [Assignment: organization-defined tests] to determine the effectiveness of the plan and the organizational readiness to execute the plan;
+     - b.  Reviews the contingency plan test results; and
+     - c.  Initiates corrective actions, if needed.
 CP-4 (1):
   family: CP
   name: Coordinate With Related Plans
@@ -1855,8 +1855,8 @@ CP-4 (2):
   name: Alternate Processing Site
   description: |-
     The organization tests the contingency plan at the alternate processing site:
-       (2)(a).  To familiarize contingency personnel with the facility and available resources; and
-       (2)(b).  To evaluate the capabilities of the alternate processing site to support contingency operations.
+     -  (2)(a).  To familiarize contingency personnel with the facility and available resources; and
+     -  (2)(b).  To evaluate the capabilities of the alternate processing site to support contingency operations.
 CP-4 (3):
   family: CP
   name: Automated Testing
@@ -1876,8 +1876,8 @@ CP-6:
   name: Alternate Storage Site
   description: |-
     The organization:
-      a.  Establishes an alternate storage site including necessary agreements to permit the storage and retrieval of information system backup information; and
-      b.  Ensures that the alternate storage site provides information security safeguards equivalent to that of the primary site.
+     - a.  Establishes an alternate storage site including necessary agreements to permit the storage and retrieval of information system backup information; and
+     - b.  Ensures that the alternate storage site provides information security safeguards equivalent to that of the primary site.
 CP-6 (1):
   family: CP
   name: Separation From Primary Site
@@ -1899,9 +1899,9 @@ CP-7:
   name: Alternate Processing Site
   description: |-
     The organization:
-      a.  Establishes an alternate processing site including necessary agreements to permit the transfer and resumption of [Assignment: organization-defined information system operations] for essential missions/business functions within [Assignment: organization-defined time period consistent with recovery time and recovery point objectives] when the primary processing capabilities are unavailable;
-      b.  Ensures that equipment and supplies required to transfer and resume operations are available at the alternate processing site or contracts are in place to support delivery to the site within the organization-defined time period for transfer/resumption; and
-      c.  Ensures that the alternate processing site provides information security safeguards equivalent to those of the primary site.
+     - a.  Establishes an alternate processing site including necessary agreements to permit the transfer and resumption of [Assignment: organization-defined information system operations] for essential missions/business functions within [Assignment: organization-defined time period consistent with recovery time and recovery point objectives] when the primary processing capabilities are unavailable;
+     - b.  Ensures that equipment and supplies required to transfer and resume operations are available at the alternate processing site or contracts are in place to support delivery to the site within the organization-defined time period for transfer/resumption; and
+     - c.  Ensures that the alternate processing site provides information security safeguards equivalent to those of the primary site.
 CP-7 (1):
   family: CP
   name: Separation From Primary Site
@@ -1948,8 +1948,8 @@ CP-8 (1):
   name: Priority Of Service Provisions
   description: |-
     The organization:
-       (1)(a).  Develops primary and alternate telecommunications service agreements that contain priority-of-service provisions in accordance with organizational availability requirements (including recovery time objectives); and
-       (1)(b).  Requests Telecommunications Service Priority for all telecommunications services used for national security emergency preparedness in the event that the primary and/or alternate telecommunications services are provided by a common carrier.
+     -  (1)(a).  Develops primary and alternate telecommunications service agreements that contain priority-of-service provisions in accordance with organizational availability requirements (including recovery time objectives); and
+     -  (1)(b).  Requests Telecommunications Service Priority for all telecommunications services used for national security emergency preparedness in the event that the primary and/or alternate telecommunications services are provided by a common carrier.
 CP-8 (2):
   family: CP
   name: Single Points Of Failure
@@ -1967,9 +1967,9 @@ CP-8 (4):
   name: Provider Contingency Plan
   description: |-
     The organization:
-       (4)(a).  Requires primary and alternate telecommunications service providers to have contingency plans;
-       (4)(b).  Reviews provider contingency plans to ensure that the plans meet organizational contingency requirements; and
-       (4)(c).  Obtains evidence of contingency testing/training by providers [Assignment: organization-defined frequency].
+     -  (4)(a).  Requires primary and alternate telecommunications service providers to have contingency plans;
+     -  (4)(b).  Reviews provider contingency plans to ensure that the plans meet organizational contingency requirements; and
+     -  (4)(c).  Obtains evidence of contingency testing/training by providers [Assignment: organization-defined frequency].
 CP-8 (5):
   family: CP
   name: Alternate Telecommunication Service Testing
@@ -1980,10 +1980,10 @@ CP-9:
   name: Information System Backup
   description: |-
     The organization:
-      a.  Conducts backups of user-level information contained in the information system [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives];
-      b.  Conducts backups of system-level information contained in the information system [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives];
-      c.  Conducts backups of information system documentation including security-related documentation [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives]; and
-      d.  Protects the confidentiality, integrity, and availability of backup information at storage locations.
+     - a.  Conducts backups of user-level information contained in the information system [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives];
+     - b.  Conducts backups of system-level information contained in the information system [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives];
+     - c.  Conducts backups of information system documentation including security-related documentation [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives]; and
+     - d.  Protects the confidentiality, integrity, and availability of backup information at storage locations.
 CP-9 (1):
   family: CP
   name: Testing For Reliability / Integrity
@@ -2080,12 +2080,12 @@ IA-1:
   name: Identification And Authentication Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  An identification and authentication policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the identification and authentication policy and associated identification and authentication controls; and
-      b.  Reviews and updates the current:
-        1.  Identification and authentication policy [Assignment: organization-defined frequency]; and
-        2.  Identification and authentication procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  An identification and authentication policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the identification and authentication policy and associated identification and authentication controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Identification and authentication policy [Assignment: organization-defined frequency]; and
+       - 2.  Identification and authentication procedures [Assignment: organization-defined frequency].
 IA-2:
   family: IA
   name: Identification And Authentication (Organizational Users)
@@ -2184,8 +2184,8 @@ IA-3 (3):
   name: Dynamic Address Allocation
   description: |-
     The organization:
-       (3)(a).  Standardizes dynamic address allocation lease information and the lease duration assigned to devices in accordance with [Assignment: organization-defined lease information and lease duration]; and
-       (3)(b).  Audits lease information when assigned to a device.
+     -  (3)(a).  Standardizes dynamic address allocation lease information and the lease duration assigned to devices in accordance with [Assignment: organization-defined lease information and lease duration]; and
+     -  (3)(b).  Audits lease information when assigned to a device.
 IA-3 (4):
   family: IA
   name: Device Attestation
@@ -2197,11 +2197,11 @@ IA-4:
   name: Identifier Management
   description: |-
     The organization manages information system identifiers by:
-      a.  Receiving authorization from [Assignment: organization-defined personnel or roles] to assign an individual, group, role, or device identifier;
-      b.  Selecting an identifier that identifies an individual, group, role, or device;
-      c.  Assigning the identifier to the intended individual, group, role, or device;
-      d.  Preventing reuse of identifiers for [Assignment: organization-defined time period]; and
-      e.  Disabling the identifier after [Assignment: organization-defined time period of inactivity].
+     - a.  Receiving authorization from [Assignment: organization-defined personnel or roles] to assign an individual, group, role, or device identifier;
+     - b.  Selecting an identifier that identifies an individual, group, role, or device;
+     - c.  Assigning the identifier to the intended individual, group, role, or device;
+     - d.  Preventing reuse of identifiers for [Assignment: organization-defined time period]; and
+     - e.  Disabling the identifier after [Assignment: organization-defined time period of inactivity].
 IA-4 (1):
   family: IA
   name: Prohibit Account Identifiers As Public Identifiers
@@ -2243,36 +2243,36 @@ IA-5:
   name: Authenticator Management
   description: |-
     The organization manages information system authenticators by:
-      a.  Verifying, as part of the initial authenticator distribution, the identity of the individual, group, role, or device receiving the authenticator;
-      b.  Establishing initial authenticator content for authenticators defined by the organization;
-      c.  Ensuring that authenticators have sufficient strength of mechanism for their intended use;
-      d.  Establishing and implementing administrative procedures for initial authenticator distribution, for lost/compromised or damaged authenticators, and for revoking authenticators;
-      e.  Changing default content of authenticators prior to information system installation;
-      f.  Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators;
-      g.  Changing/refreshing authenticators [Assignment: organization-defined time period by authenticator type];
-      h.  Protecting authenticator content from unauthorized disclosure and modification;
-      i.  Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators; and
-      j.  Changing authenticators for group/role accounts when membership to those accounts changes.
+     - a.  Verifying, as part of the initial authenticator distribution, the identity of the individual, group, role, or device receiving the authenticator;
+     - b.  Establishing initial authenticator content for authenticators defined by the organization;
+     - c.  Ensuring that authenticators have sufficient strength of mechanism for their intended use;
+     - d.  Establishing and implementing administrative procedures for initial authenticator distribution, for lost/compromised or damaged authenticators, and for revoking authenticators;
+     - e.  Changing default content of authenticators prior to information system installation;
+     - f.  Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators;
+     - g.  Changing/refreshing authenticators [Assignment: organization-defined time period by authenticator type];
+     - h.  Protecting authenticator content from unauthorized disclosure and modification;
+     - i.  Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators; and
+     - j.  Changing authenticators for group/role accounts when membership to those accounts changes.
 IA-5 (1):
   family: IA
   name: Password-Based Authentication
   description: |-
     The information system, for password-based authentication:
-       (1)(a).  Enforces minimum password complexity of [Assignment: organization-defined requirements for case sensitivity, number of characters, mix of upper-case letters, lower-case letters, numbers, and special characters, including minimum requirements for each type];
-       (1)(b).  Enforces at least the following number of changed characters when new passwords are created: [Assignment: organization-defined number];
-       (1)(c).  Stores and transmits only cryptographically-protected passwords;
-       (1)(d).  Enforces password minimum and maximum lifetime restrictions of [Assignment: organization-defined numbers for lifetime minimum, lifetime maximum];
-       (1)(e).  Prohibits password reuse for [Assignment: organization-defined number] generations; and
-       (1)(f).  Allows the use of a temporary password for system logons with an immediate change to a permanent password.
+     -  (1)(a).  Enforces minimum password complexity of [Assignment: organization-defined requirements for case sensitivity, number of characters, mix of upper-case letters, lower-case letters, numbers, and special characters, including minimum requirements for each type];
+     -  (1)(b).  Enforces at least the following number of changed characters when new passwords are created: [Assignment: organization-defined number];
+     -  (1)(c).  Stores and transmits only cryptographically-protected passwords;
+     -  (1)(d).  Enforces password minimum and maximum lifetime restrictions of [Assignment: organization-defined numbers for lifetime minimum, lifetime maximum];
+     -  (1)(e).  Prohibits password reuse for [Assignment: organization-defined number] generations; and
+     -  (1)(f).  Allows the use of a temporary password for system logons with an immediate change to a permanent password.
 IA-5 (2):
   family: IA
   name: Pki-Based Authentication
   description: |-
     The information system, for PKI-based authentication:
-       (2)(a).  Validates certifications by constructing and verifying a certification path to an accepted trust anchor including checking certificate status information;
-       (2)(b).  Enforces authorized access to the corresponding private key;
-       (2)(c).  Maps the authenticated identity to the account of the individual or group; and
-       (2)(d).  Implements a local cache of revocation data to support path discovery and validation in case of inability to access revocation information via the network.
+     -  (2)(a).  Validates certifications by constructing and verifying a certification path to an accepted trust anchor including checking certificate status information;
+     -  (2)(b).  Enforces authorized access to the corresponding private key;
+     -  (2)(c).  Maps the authenticated identity to the account of the individual or group; and
+     -  (2)(d).  Implements a local cache of revocation data to support path discovery and validation in case of inability to access revocation information via the network.
 IA-5 (3):
   family: IA
   name: In-Person Or Trusted Third-Party Registration
@@ -2420,20 +2420,20 @@ IR-1:
   name: Incident Response Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  An incident response policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the incident response policy and associated incident response controls; and
-      b.  Reviews and updates the current:
-        1.  Incident response policy [Assignment: organization-defined frequency]; and
-        2.  Incident response procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  An incident response policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the incident response policy and associated incident response controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Incident response policy [Assignment: organization-defined frequency]; and
+       - 2.  Incident response procedures [Assignment: organization-defined frequency].
 IR-2:
   family: IR
   name: Incident Response Training
   description: |-
     The organization provides incident response training to information system users consistent with assigned roles and responsibilities:
-      a.  Within [Assignment: organization-defined time period] of assuming an incident response role or responsibility;
-      b.  When required by information system changes; and
-      c.  [Assignment: organization-defined frequency] thereafter.
+     - a.  Within [Assignment: organization-defined time period] of assuming an incident response role or responsibility;
+     - b.  When required by information system changes; and
+     - c.  [Assignment: organization-defined frequency] thereafter.
 IR-2 (1):
   family: IR
   name: Simulated Events
@@ -2465,9 +2465,9 @@ IR-4:
   name: Incident Handling
   description: |-
     The organization:
-      a.  Implements an incident handling capability for security incidents that includes preparation, detection and analysis, containment, eradication, and recovery;
-      b.  Coordinates incident handling activities with contingency planning activities; and
-      c.  Incorporates lessons learned from ongoing incident handling activities into incident response procedures, training, and testing, and implements the resulting changes accordingly.
+     - a.  Implements an incident handling capability for security incidents that includes preparation, detection and analysis, containment, eradication, and recovery;
+     - b.  Coordinates incident handling activities with contingency planning activities; and
+     - c.  Incorporates lessons learned from ongoing incident handling activities into incident response procedures, training, and testing, and implements the resulting changes accordingly.
 IR-4 (1):
   family: IR
   name: Automated Incident Handling Processes
@@ -2540,8 +2540,8 @@ IR-6:
   name: Incident Reporting
   description: |-
     The organization:
-      a.  Requires personnel to report suspected security incidents to the organizational incident response capability within [Assignment: organization-defined time period]; and
-      b.  Reports security incident information to [Assignment: organization-defined authorities].
+     - a.  Requires personnel to report suspected security incidents to the organizational incident response capability within [Assignment: organization-defined time period]; and
+     - b.  Reports security incident information to [Assignment: organization-defined authorities].
 IR-6 (1):
   family: IR
   name: Automated Reporting
@@ -2576,38 +2576,38 @@ IR-7 (2):
   name: Coordination With External Providers
   description: |-
     The organization:
-       (2)(a).  Establishes a direct, cooperative relationship between its incident response capability and external providers of information system protection capability; and
-       (2)(b).  Identifies organizational incident response team members to the external providers.
+     -  (2)(a).  Establishes a direct, cooperative relationship between its incident response capability and external providers of information system protection capability; and
+     -  (2)(b).  Identifies organizational incident response team members to the external providers.
 IR-8:
   family: IR
   name: Incident Response Plan
   description: |-
     The organization:
-      a.  Develops an incident response plan that:
-        1.  Provides the organization with a roadmap for implementing its incident response capability;
-        2.  Describes the structure and organization of the incident response capability;
-        3.  Provides a high-level approach for how the incident response capability fits into the overall organization;
-        4.  Meets the unique requirements of the organization, which relate to mission, size, structure, and functions;
-        5.  Defines reportable incidents;
-        6.  Provides metrics for measuring the incident response capability within the organization;
-        7.  Defines the resources and management support needed to effectively maintain and mature an incident response capability; and
-        8.  Is reviewed and approved by [Assignment: organization-defined personnel or roles];
-      b.  Distributes copies of the incident response plan to [Assignment: organization-defined incident response personnel (identified by name and/or by role) and organizational elements];
-      c.  Reviews the incident response plan [Assignment: organization-defined frequency];
-      d.  Updates the incident response plan to address system/organizational changes or problems encountered during plan implementation, execution, or testing;
-      e.  Communicates incident response plan changes to [Assignment: organization-defined incident response personnel (identified by name and/or by role) and organizational elements]; and
-      f.  Protects the incident response plan from unauthorized disclosure and modification.
+     - a.  Develops an incident response plan that:
+       - 1.  Provides the organization with a roadmap for implementing its incident response capability;
+       - 2.  Describes the structure and organization of the incident response capability;
+       - 3.  Provides a high-level approach for how the incident response capability fits into the overall organization;
+       - 4.  Meets the unique requirements of the organization, which relate to mission, size, structure, and functions;
+       - 5.  Defines reportable incidents;
+       - 6.  Provides metrics for measuring the incident response capability within the organization;
+       - 7.  Defines the resources and management support needed to effectively maintain and mature an incident response capability; and
+       - 8.  Is reviewed and approved by [Assignment: organization-defined personnel or roles];
+     - b.  Distributes copies of the incident response plan to [Assignment: organization-defined incident response personnel (identified by name and/or by role) and organizational elements];
+     - c.  Reviews the incident response plan [Assignment: organization-defined frequency];
+     - d.  Updates the incident response plan to address system/organizational changes or problems encountered during plan implementation, execution, or testing;
+     - e.  Communicates incident response plan changes to [Assignment: organization-defined incident response personnel (identified by name and/or by role) and organizational elements]; and
+     - f.  Protects the incident response plan from unauthorized disclosure and modification.
 IR-9:
   family: IR
   name: Information Spillage Response
   description: |-
     The organization responds to information spills by:
-      a.  Identifying the specific information involved in the information system contamination;
-      b.  Alerting [Assignment: organization-defined personnel or roles] of the information spill using a method of communication not associated with the spill;
-      c.  Isolating the contaminated information system or system component;
-      d.  Eradicating the information from the contaminated information system or component;
-      e.  Identifying other information systems or system components that may have been subsequently contaminated; and
-      f.  Performing other [Assignment: organization-defined actions].
+     - a.  Identifying the specific information involved in the information system contamination;
+     - b.  Alerting [Assignment: organization-defined personnel or roles] of the information spill using a method of communication not associated with the spill;
+     - c.  Isolating the contaminated information system or system component;
+     - d.  Eradicating the information from the contaminated information system or component;
+     - e.  Identifying other information systems or system components that may have been subsequently contaminated; and
+     - f.  Performing other [Assignment: organization-defined actions].
 IR-9 (1):
   family: IR
   name: Responsible Personnel
@@ -2640,23 +2640,23 @@ MA-1:
   name: System Maintenance Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A system maintenance policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the system maintenance policy and associated system maintenance controls; and
-      b.  Reviews and updates the current:
-        1.  System maintenance policy [Assignment: organization-defined frequency]; and
-        2.  System maintenance procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A system maintenance policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the system maintenance policy and associated system maintenance controls; and
+     - b.  Reviews and updates the current:
+       - 1.  System maintenance policy [Assignment: organization-defined frequency]; and
+       - 2.  System maintenance procedures [Assignment: organization-defined frequency].
 MA-2:
   family: MA
   name: Controlled Maintenance
   description: |-
     The organization:
-      a.  Schedules, performs, documents, and reviews records of maintenance and repairs on information system components in accordance with manufacturer or vendor specifications and/or organizational requirements;
-      b.  Approves and monitors all maintenance activities, whether performed on site or remotely and whether the equipment is serviced on site or removed to another location;
-      c.  Requires that [Assignment: organization-defined personnel or roles] explicitly approve the removal of the information system or system components from organizational facilities for off-site maintenance or repairs;
-      d.  Sanitizes equipment to remove all information from associated media prior to removal from organizational facilities for off-site maintenance or repairs;
-      e.  Checks all potentially impacted security controls to verify that the controls are still functioning properly following maintenance or repair actions; and
-      f.  Includes [Assignment: organization-defined maintenance-related information] in organizational maintenance records.
+     - a.  Schedules, performs, documents, and reviews records of maintenance and repairs on information system components in accordance with manufacturer or vendor specifications and/or organizational requirements;
+     - b.  Approves and monitors all maintenance activities, whether performed on site or remotely and whether the equipment is serviced on site or removed to another location;
+     - c.  Requires that [Assignment: organization-defined personnel or roles] explicitly approve the removal of the information system or system components from organizational facilities for off-site maintenance or repairs;
+     - d.  Sanitizes equipment to remove all information from associated media prior to removal from organizational facilities for off-site maintenance or repairs;
+     - e.  Checks all potentially impacted security controls to verify that the controls are still functioning properly following maintenance or repair actions; and
+     - f.  Includes [Assignment: organization-defined maintenance-related information] in organizational maintenance records.
 MA-2 (1):
   family: MA
   name: Record Content
@@ -2666,8 +2666,8 @@ MA-2 (2):
   name: Automated Maintenance Activities
   description: |-
     The organization:
-       (2)(a).  Employs automated mechanisms to schedule, conduct, and document maintenance and repairs; and
-       (2)(b).  Produces up-to date, accurate, and complete records of all maintenance and repair actions requested, scheduled, in process, and completed.
+     -  (2)(a).  Employs automated mechanisms to schedule, conduct, and document maintenance and repairs; and
+     -  (2)(b).  Produces up-to date, accurate, and complete records of all maintenance and repair actions requested, scheduled, in process, and completed.
 MA-3:
   family: MA
   name: Maintenance Tools
@@ -2688,10 +2688,10 @@ MA-3 (3):
   name: Prevent Unauthorized Removal
   description: |-
     The organization prevents the unauthorized removal of maintenance equipment containing organizational information by:
-       (3)(a).  Verifying that there is no organizational information contained on the equipment;
-       (3)(b).  Sanitizing or destroying the equipment;
-       (3)(c).  Retaining the equipment within the facility; or
-       (3)(d).  Obtaining an exemption from [Assignment: organization-defined personnel or roles] explicitly authorizing removal of the equipment from the facility.
+     -  (3)(a).  Verifying that there is no organizational information contained on the equipment;
+     -  (3)(b).  Sanitizing or destroying the equipment;
+     -  (3)(c).  Retaining the equipment within the facility; or
+     -  (3)(d).  Obtaining an exemption from [Assignment: organization-defined personnel or roles] explicitly authorizing removal of the equipment from the facility.
 MA-3 (4):
   family: MA
   name: Restricted Tool Use
@@ -2702,18 +2702,18 @@ MA-4:
   name: Nonlocal Maintenance
   description: |-
     The organization:
-      a.  Approves and monitors nonlocal maintenance and diagnostic activities;
-      b.  Allows the use of nonlocal maintenance and diagnostic tools only as consistent with organizational policy and documented in the security plan for the information system;
-      c.  Employs strong authenticators in the establishment of nonlocal maintenance and diagnostic sessions;
-      d.  Maintains records for nonlocal maintenance and diagnostic activities; and
-      e.  Terminates session and network connections when nonlocal maintenance is completed.
+     - a.  Approves and monitors nonlocal maintenance and diagnostic activities;
+     - b.  Allows the use of nonlocal maintenance and diagnostic tools only as consistent with organizational policy and documented in the security plan for the information system;
+     - c.  Employs strong authenticators in the establishment of nonlocal maintenance and diagnostic sessions;
+     - d.  Maintains records for nonlocal maintenance and diagnostic activities; and
+     - e.  Terminates session and network connections when nonlocal maintenance is completed.
 MA-4 (1):
   family: MA
   name: Auditing And Review
   description: |-
     The organization:
-       (1)(a).  Audits nonlocal maintenance and diagnostic sessions [Assignment: organization-defined audit events]; and
-       (1)(b).  Reviews the records of the maintenance and diagnostic sessions.
+     -  (1)(a).  Audits nonlocal maintenance and diagnostic sessions [Assignment: organization-defined audit events]; and
+     -  (1)(b).  Reviews the records of the maintenance and diagnostic sessions.
 MA-4 (2):
   family: MA
   name: Document Nonlocal Maintenance
@@ -2725,24 +2725,24 @@ MA-4 (3):
   name: Comparable Security / Sanitization
   description: |-
     The organization:
-       (3)(a).  Requires that nonlocal maintenance and diagnostic services be performed from an information system that implements a security capability comparable to the capability implemented on the system being serviced; or
-       (3)(b).  Removes the component to be serviced from the information system prior to nonlocal maintenance or diagnostic services, sanitizes the component (with regard to organizational information) before removal from organizational facilities, and after the service is performed, inspects and sanitizes the component (with regard to potentially malicious software) before reconnecting the component to the information system.
+     -  (3)(a).  Requires that nonlocal maintenance and diagnostic services be performed from an information system that implements a security capability comparable to the capability implemented on the system being serviced; or
+     -  (3)(b).  Removes the component to be serviced from the information system prior to nonlocal maintenance or diagnostic services, sanitizes the component (with regard to organizational information) before removal from organizational facilities, and after the service is performed, inspects and sanitizes the component (with regard to potentially malicious software) before reconnecting the component to the information system.
 MA-4 (4):
   family: MA
   name: Authentication / Separation Of Maintenance Sessions
   description: |-
     The organization protects nonlocal maintenance sessions by:
-       (4)(a).  Employing [Assignment: organization-defined authenticators that are replay resistant]; and
-       (4)(b).  Separating the maintenance sessions from other network sessions with the information system by either:
-       (4)(b)(1).  Physically separated communications paths; or
-       (4)(b)(2).  Logically separated communications paths based upon encryption.
+     -  (4)(a).  Employing [Assignment: organization-defined authenticators that are replay resistant]; and
+     -  (4)(b).  Separating the maintenance sessions from other network sessions with the information system by either:
+     -  (4)(b)(1).  Physically separated communications paths; or
+     -  (4)(b)(2).  Logically separated communications paths based upon encryption.
 MA-4 (5):
   family: MA
   name: Approvals And Notifications
   description: |-
     The organization:
-       (5)(a).  Requires the approval of each nonlocal maintenance session by [Assignment: organization-defined personnel or roles]; and
-       (5)(b).  Notifies [Assignment: organization-defined personnel or roles] of the date and time of planned nonlocal maintenance.
+     -  (5)(a).  Requires the approval of each nonlocal maintenance session by [Assignment: organization-defined personnel or roles]; and
+     -  (5)(b).  Notifies [Assignment: organization-defined personnel or roles] of the date and time of planned nonlocal maintenance.
 MA-4 (6):
   family: MA
   name: Cryptographic Protection
@@ -2758,18 +2758,18 @@ MA-5:
   name: Maintenance Personnel
   description: |-
     The organization:
-      a.  Establishes a process for maintenance personnel authorization and maintains a list of authorized maintenance organizations or personnel;
-      b.  Ensures that non-escorted personnel performing maintenance on the information system have required access authorizations; and
-      c.  Designates organizational personnel with required access authorizations and technical competence to supervise the maintenance activities of personnel who do not possess the required access authorizations.
+     - a.  Establishes a process for maintenance personnel authorization and maintains a list of authorized maintenance organizations or personnel;
+     - b.  Ensures that non-escorted personnel performing maintenance on the information system have required access authorizations; and
+     - c.  Designates organizational personnel with required access authorizations and technical competence to supervise the maintenance activities of personnel who do not possess the required access authorizations.
 MA-5 (1):
   family: MA
   name: Individuals Without Appropriate Access
   description: |-
     The organization:
-       (1)(a).  Implements procedures for the use of maintenance personnel that lack appropriate security clearances or are not U.S. citizens, that include the following requirements:
-       (1)(a)(1).  Maintenance personnel who do not have needed access authorizations, clearances, or formal access approvals are escorted and supervised during the performance of maintenance and diagnostic activities on the information system by approved organizational personnel who are fully cleared, have appropriate access authorizations, and are technically qualified;
-       (1)(a)(2).  Prior to initiating maintenance or diagnostic activities by personnel who do not have needed access authorizations, clearances or formal access approvals, all volatile information storage components within the information system are sanitized and all nonvolatile storage media are removed or physically disconnected from the system and secured; and
-       (1)(b).  Develops and implements alternate security safeguards in the event an information system component cannot be sanitized, removed, or disconnected from the system.
+     -  (1)(a).  Implements procedures for the use of maintenance personnel that lack appropriate security clearances or are not U.S. citizens, that include the following requirements:
+     -  (1)(a)(1).  Maintenance personnel who do not have needed access authorizations, clearances, or formal access approvals are escorted and supervised during the performance of maintenance and diagnostic activities on the information system by approved organizational personnel who are fully cleared, have appropriate access authorizations, and are technically qualified;
+     -  (1)(a)(2).  Prior to initiating maintenance or diagnostic activities by personnel who do not have needed access authorizations, clearances or formal access approvals, all volatile information storage components within the information system are sanitized and all nonvolatile storage media are removed or physically disconnected from the system and secured; and
+     -  (1)(b).  Develops and implements alternate security safeguards in the event an information system component cannot be sanitized, removed, or disconnected from the system.
 MA-5 (2):
   family: MA
   name: Security Clearances For Classified Systems
@@ -2789,8 +2789,8 @@ MA-5 (4):
   name: Foreign Nationals
   description: |-
     The organization ensures that:
-       (4)(a).  Cleared foreign nationals (i.e., foreign nationals with appropriate security clearances), are used to conduct maintenance and diagnostic activities on classified information systems only when the systems are jointly owned and operated by the United States and foreign allied governments, or owned and operated solely by foreign allied governments; and
-       (4)(b).  Approvals, consents, and detailed operational conditions regarding the use of foreign nationals to conduct maintenance and diagnostic activities on classified information systems are fully documented within Memoranda of Agreements.
+     -  (4)(a).  Cleared foreign nationals (i.e., foreign nationals with appropriate security clearances), are used to conduct maintenance and diagnostic activities on classified information systems only when the systems are jointly owned and operated by the United States and foreign allied governments, or owned and operated solely by foreign allied governments; and
+     -  (4)(b).  Approvals, consents, and detailed operational conditions regarding the use of foreign nationals to conduct maintenance and diagnostic activities on classified information systems are fully documented within Memoranda of Agreements.
 MA-5 (5):
   family: MA
   name: Nonsystem-Related Maintenance
@@ -2823,12 +2823,12 @@ MP-1:
   name: Media Protection Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A media protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the media protection policy and associated media protection controls; and
-      b.  Reviews and updates the current:
-        1.  Media protection policy [Assignment: organization-defined frequency]; and
-        2.  Media protection procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A media protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the media protection policy and associated media protection controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Media protection policy [Assignment: organization-defined frequency]; and
+       - 2.  Media protection procedures [Assignment: organization-defined frequency].
 MP-2:
   family: MP
   name: Media Access
@@ -2848,15 +2848,15 @@ MP-3:
   name: Media Marking
   description: |-
     The organization:
-      a.  Marks information system media indicating the distribution limitations, handling caveats, and applicable security markings (if any) of the information; and
-      b.  Exempts [Assignment: organization-defined types of information system media] from marking as long as the media remain within [Assignment: organization-defined controlled areas].
+     - a.  Marks information system media indicating the distribution limitations, handling caveats, and applicable security markings (if any) of the information; and
+     - b.  Exempts [Assignment: organization-defined types of information system media] from marking as long as the media remain within [Assignment: organization-defined controlled areas].
 MP-4:
   family: MP
   name: Media Storage
   description: |-
     The organization:
-      a.  Physically controls and securely stores [Assignment: organization-defined types of digital and/or non-digital media] within [Assignment: organization-defined controlled areas]; and
-      b.  Protects information system media until the media are destroyed or sanitized using approved equipment, techniques, and procedures.
+     - a.  Physically controls and securely stores [Assignment: organization-defined types of digital and/or non-digital media] within [Assignment: organization-defined controlled areas]; and
+     - b.  Protects information system media until the media are destroyed or sanitized using approved equipment, techniques, and procedures.
 MP-4 (1):
   family: MP
   name: Cryptographic Protection
@@ -2871,10 +2871,10 @@ MP-5:
   name: Media Transport
   description: |-
     The organization:
-      a.  Protects and controls [Assignment: organization-defined types of information system media] during transport outside of controlled areas using [Assignment: organization-defined security safeguards];
-      b.  Maintains accountability for information system media during transport outside of controlled areas;
-      c.  Documents activities associated with the transport of information system media; and
-      d.  Restricts the activities associated with the transport of information system media to authorized personnel.
+     - a.  Protects and controls [Assignment: organization-defined types of information system media] during transport outside of controlled areas using [Assignment: organization-defined security safeguards];
+     - b.  Maintains accountability for information system media during transport outside of controlled areas;
+     - c.  Documents activities associated with the transport of information system media; and
+     - d.  Restricts the activities associated with the transport of information system media to authorized personnel.
 MP-5 (1):
   family: MP
   name: Protection Outside Of Controlled Areas
@@ -2899,8 +2899,8 @@ MP-6:
   name: Media Sanitization
   description: |-
     The organization:
-      a.  Sanitizes [Assignment: organization-defined information system media] prior to disposal, release out of organizational control, or release for reuse using [Assignment: organization-defined sanitization techniques and procedures] in accordance with applicable federal and organizational standards and policies; and
-      b.  Employs sanitization mechanisms with the strength and integrity commensurate with the security category or classification of the information.
+     - a.  Sanitizes [Assignment: organization-defined information system media] prior to disposal, release out of organizational control, or release for reuse using [Assignment: organization-defined sanitization techniques and procedures] in accordance with applicable federal and organizational standards and policies; and
+     - b.  Employs sanitization mechanisms with the strength and integrity commensurate with the security category or classification of the information.
 MP-6 (1):
   family: MP
   name: Review / Approve / Track / Document / Verify
@@ -2965,10 +2965,10 @@ MP-8:
   name: Media Downgrading
   description: |-
     The organization:
-      a.  Establishes [Assignment: organization-defined information system media downgrading process] that includes employing downgrading mechanisms with [Assignment: organization-defined strength and integrity];
-      b.  Ensures that the information system media downgrading process is commensurate with the security category and/or classification level of the information to be removed and the access authorizations of the potential recipients of the downgraded information;
-      c.  Identifies [Assignment: organization-defined information system media requiring downgrading]; and
-      d.  Downgrades the identified information system media using the established process.
+     - a.  Establishes [Assignment: organization-defined information system media downgrading process] that includes employing downgrading mechanisms with [Assignment: organization-defined strength and integrity];
+     - b.  Ensures that the information system media downgrading process is commensurate with the security category and/or classification level of the information to be removed and the access authorizations of the potential recipients of the downgraded information;
+     - c.  Identifies [Assignment: organization-defined information system media requiring downgrading]; and
+     - d.  Downgrades the identified information system media using the established process.
 MP-8 (1):
   family: MP
   name: Documentation Of Process
@@ -2997,21 +2997,21 @@ PE-1:
   name: Physical And Environmental Protection Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A physical and environmental protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the physical and environmental protection policy and associated physical and environmental protection controls; and
-      b.  Reviews and updates the current:
-        1.  Physical and environmental protection  policy [Assignment: organization-defined frequency]; and
-        2.  Physical and environmental protection procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A physical and environmental protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the physical and environmental protection policy and associated physical and environmental protection controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Physical and environmental protection  policy [Assignment: organization-defined frequency]; and
+       - 2.  Physical and environmental protection procedures [Assignment: organization-defined frequency].
 PE-2:
   family: PE
   name: Physical Access Authorizations
   description: |-
     The organization:
-      a.  Develops, approves, and maintains a list of individuals with authorized access to the facility where the information system resides;
-      b.  Issues authorization credentials for facility access;
-      c.  Reviews the access list detailing authorized facility access by individuals [Assignment: organization-defined frequency]; and
-      d.  Removes individuals from the facility access list when access is no longer required.
+     - a.  Develops, approves, and maintains a list of individuals with authorized access to the facility where the information system resides;
+     - b.  Issues authorization credentials for facility access;
+     - c.  Reviews the access list detailing authorized facility access by individuals [Assignment: organization-defined frequency]; and
+     - d.  Removes individuals from the facility access list when access is no longer required.
 PE-2 (1):
   family: PE
   name: Access By Position / Role
@@ -3036,15 +3036,15 @@ PE-3:
   name: Physical Access Control
   description: |-
     The organization:
-      a.  Enforces physical access authorizations at [Assignment: organization-defined entry/exit points to the facility where the information system resides] by;
-        1.  Verifying individual access authorizations before granting access to the facility; and
-        2.  Controlling ingress/egress to the facility using [Selection (one or more): [Assignment: organization-defined physical access control systems/devices]; guards];
-      b.  Maintains physical access audit logs for [Assignment: organization-defined entry/exit points];
-      c.  Provides [Assignment: organization-defined security safeguards] to control access to areas within the facility officially designated as publicly accessible;
-      d.  Escorts visitors and monitors visitor activity [Assignment: organization-defined circumstances requiring visitor escorts and monitoring];
-      e.  Secures keys, combinations, and other physical access devices;
-      f.  Inventories [Assignment: organization-defined physical access devices] every [Assignment: organization-defined frequency]; and
-      g.  Changes combinations and keys [Assignment: organization-defined frequency] and/or when keys are lost, combinations are compromised, or individuals are transferred or terminated.
+     - a.  Enforces physical access authorizations at [Assignment: organization-defined entry/exit points to the facility where the information system resides] by;
+       - 1.  Verifying individual access authorizations before granting access to the facility; and
+       - 2.  Controlling ingress/egress to the facility using [Selection (one or more): [Assignment: organization-defined physical access control systems/devices]; guards];
+     - b.  Maintains physical access audit logs for [Assignment: organization-defined entry/exit points];
+     - c.  Provides [Assignment: organization-defined security safeguards] to control access to areas within the facility officially designated as publicly accessible;
+     - d.  Escorts visitors and monitors visitor activity [Assignment: organization-defined circumstances requiring visitor escorts and monitoring];
+     - e.  Secures keys, combinations, and other physical access devices;
+     - f.  Inventories [Assignment: organization-defined physical access devices] every [Assignment: organization-defined frequency]; and
+     - g.  Changes combinations and keys [Assignment: organization-defined frequency] and/or when keys are lost, combinations are compromised, or individuals are transferred or terminated.
 PE-3 (1):
   family: PE
   name: Information System Access
@@ -3099,15 +3099,15 @@ PE-5 (1):
   name: Access To Output By Authorized Individuals
   description: |-
     The organization:
-       (1)(a).  Controls physical access to output from [Assignment: organization-defined output devices]; and
-       (1)(b).  Ensures that only authorized individuals receive output from the device.
+     -  (1)(a).  Controls physical access to output from [Assignment: organization-defined output devices]; and
+     -  (1)(b).  Ensures that only authorized individuals receive output from the device.
 PE-5 (2):
   family: PE
   name: Access To Output By Individual Identity
   description: |-
     The information system:
-       (2)(a).  Controls physical access to output from [Assignment: organization-defined output devices]; and
-       (2)(b).  Links individual identity to receipt of the output from the device.
+     -  (2)(a).  Controls physical access to output from [Assignment: organization-defined output devices]; and
+     -  (2)(b).  Links individual identity to receipt of the output from the device.
 PE-5 (3):
   family: PE
   name: Marking Output Devices
@@ -3119,9 +3119,9 @@ PE-6:
   name: Monitoring Physical Access
   description: |-
     The organization:
-      a.  Monitors physical access to the facility where the information system resides to detect and respond to physical security incidents;
-      b.  Reviews physical access logs [Assignment: organization-defined frequency] and upon occurrence of [Assignment: organization-defined events or potential indications of events]; and
-      c.  Coordinates results of reviews and investigations with the organizational incident response capability.
+     - a.  Monitors physical access to the facility where the information system resides to detect and respond to physical security incidents;
+     - b.  Reviews physical access logs [Assignment: organization-defined frequency] and upon occurrence of [Assignment: organization-defined events or potential indications of events]; and
+     - c.  Coordinates results of reviews and investigations with the organizational incident response capability.
 PE-6 (1):
   family: PE
   name: Intrusion Alarms / Surveillance Equipment
@@ -3155,8 +3155,8 @@ PE-8:
   name: Visitor Access Records
   description: |-
     The organization:
-      a.  Maintains visitor access records to the facility where the information system resides for [Assignment: organization-defined time period]; and
-      b.  Reviews visitor access records [Assignment: organization-defined frequency].
+     - a.  Maintains visitor access records to the facility where the information system resides for [Assignment: organization-defined time period]; and
+     - b.  Reviews visitor access records [Assignment: organization-defined frequency].
 PE-8 (1):
   family: PE
   name: Automated Records Maintenance / Review
@@ -3186,9 +3186,9 @@ PE-10:
   name: Emergency Shutoff
   description: |-
     The organization:
-      a.  Provides the capability of shutting off power to the information system or individual system components in emergency situations;
-      b.  Places emergency shutoff switches or devices in [Assignment: organization-defined location by information system or system component] to facilitate safe and easy access for personnel; and
-      c.  Protects emergency power shutoff capability from unauthorized activation.
+     - a.  Provides the capability of shutting off power to the information system or individual system components in emergency situations;
+     - b.  Places emergency shutoff switches or devices in [Assignment: organization-defined location by information system or system component] to facilitate safe and easy access for personnel; and
+     - c.  Protects emergency power shutoff capability from unauthorized activation.
 PE-10 (1):
   family: PE
   name: Accidental / Unauthorized Activation
@@ -3211,9 +3211,9 @@ PE-11 (2):
   name: Long-Term Alternate Power Supply - Self-Contained
   description: |-
     The organization provides a long-term alternate power supply for the information system that is:
-       (2)(a).  Self-contained;
-       (2)(b).  Not reliant on external power generation; and
-       (2)(c).  Capable of maintaining [Selection: minimally required operational capability; full operational capability] in the event of an extended loss of the primary power source.
+     -  (2)(a).  Self-contained;
+     -  (2)(b).  Not reliant on external power generation; and
+     -  (2)(c).  Capable of maintaining [Selection: minimally required operational capability; full operational capability] in the event of an extended loss of the primary power source.
 PE-12:
   family: PE
   name: Emergency Lighting
@@ -3262,8 +3262,8 @@ PE-14:
   name: Temperature And Humidity Controls
   description: |-
     The organization:
-      a.  Maintains temperature and humidity levels within the facility where the information system resides at [Assignment: organization-defined acceptable levels]; and
-      b.  Monitors temperature and humidity levels [Assignment: organization-defined frequency].
+     - a.  Maintains temperature and humidity levels within the facility where the information system resides at [Assignment: organization-defined acceptable levels]; and
+     - b.  Monitors temperature and humidity levels [Assignment: organization-defined frequency].
 PE-14 (1):
   family: PE
   name: Automatic Controls
@@ -3298,9 +3298,9 @@ PE-17:
   name: Alternate Work Site
   description: |-
     The organization:
-      a.  Employs [Assignment: organization-defined security controls] at alternate work sites;
-      b.  Assesses as feasible, the effectiveness of security controls at alternate work sites; and
-      c.  Provides a means for employees to communicate with information security personnel in case of security incidents or problems.
+     - a.  Employs [Assignment: organization-defined security controls] at alternate work sites;
+     - b.  Assesses as feasible, the effectiveness of security controls at alternate work sites; and
+     - c.  Provides a means for employees to communicate with information security personnel in case of security incidents or problems.
 PE-18:
   family: PE
   name: Location Of Information System Components
@@ -3331,38 +3331,38 @@ PE-20:
   name: Asset Monitoring And Tracking
   description: |-
     The organization:
-      a.  Employs [Assignment: organization-defined asset location technologies] to track and monitor the location and movement of [Assignment: organization-defined assets] within [Assignment: organization-defined controlled areas]; and
-      b.  Ensures that asset location technologies are employed in accordance with applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance.
+     - a.  Employs [Assignment: organization-defined asset location technologies] to track and monitor the location and movement of [Assignment: organization-defined assets] within [Assignment: organization-defined controlled areas]; and
+     - b.  Ensures that asset location technologies are employed in accordance with applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance.
 PL-1:
   family: PL
   name: Security Planning Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A security planning policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the security planning policy and associated security planning controls; and
-      b.  Reviews and updates the current:
-        1.  Security planning policy [Assignment: organization-defined frequency]; and
-        2.  Security planning procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A security planning policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the security planning policy and associated security planning controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Security planning policy [Assignment: organization-defined frequency]; and
+       - 2.  Security planning procedures [Assignment: organization-defined frequency].
 PL-2:
   family: PL
   name: System Security Plan
   description: |-
     The organization:
-      a.  Develops a security plan for the information system that:
-        1.  Is consistent with the organization's enterprise architecture;
-        2.  Explicitly defines the authorization boundary for the system;
-        3.  Describes the operational context of the information system in terms of missions and business processes;
-        4.  Provides the security categorization of the information system including supporting rationale;
-        5.  Describes the operational environment for the information system and relationships with or connections to other information systems;
-        6.  Provides an overview of the security requirements for the system;
-        7.  Identifies any relevant overlays, if applicable;
-        8.  Describes the security controls in place or planned for meeting those requirements including a rationale for the tailoring decisions; and
-        9.  Is reviewed and approved by the authorizing official or designated representative prior to plan implementation;
-      b.  Distributes copies of the security plan and communicates subsequent changes to the plan to [Assignment: organization-defined personnel or roles];
-      c.  Reviews the security plan for the information system [Assignment: organization-defined frequency];
-      d.  Updates the plan to address changes to the information system/environment of operation or problems identified during plan implementation or security control assessments; and
-      e.  Protects the security plan from unauthorized disclosure and modification.
+     - a.  Develops a security plan for the information system that:
+       - 1.  Is consistent with the organization's enterprise architecture;
+       - 2.  Explicitly defines the authorization boundary for the system;
+       - 3.  Describes the operational context of the information system in terms of missions and business processes;
+       - 4.  Provides the security categorization of the information system including supporting rationale;
+       - 5.  Describes the operational environment for the information system and relationships with or connections to other information systems;
+       - 6.  Provides an overview of the security requirements for the system;
+       - 7.  Identifies any relevant overlays, if applicable;
+       - 8.  Describes the security controls in place or planned for meeting those requirements including a rationale for the tailoring decisions; and
+       - 9.  Is reviewed and approved by the authorizing official or designated representative prior to plan implementation;
+     - b.  Distributes copies of the security plan and communicates subsequent changes to the plan to [Assignment: organization-defined personnel or roles];
+     - c.  Reviews the security plan for the information system [Assignment: organization-defined frequency];
+     - d.  Updates the plan to address changes to the information system/environment of operation or problems identified during plan implementation or security control assessments; and
+     - e.  Protects the security plan from unauthorized disclosure and modification.
 PL-2 (1):
   family: PL
   name: Concept Of Operations
@@ -3387,10 +3387,10 @@ PL-4:
   name: Rules Of Behavior
   description: |-
     The organization:
-      a.  Establishes and makes readily available to individuals requiring access to the information system, the rules that describe their responsibilities and expected behavior with regard to information and information system usage;
-      b.  Receives a signed acknowledgment from such individuals, indicating that they have read, understand, and agree to abide by the rules of behavior, before authorizing access to information and the information system;
-      c.  Reviews and updates the rules of behavior [Assignment: organization-defined frequency]; and
-      d.  Requires individuals who have signed a previous version of the rules of behavior to read and re-sign when the rules of behavior are revised/updated.
+     - a.  Establishes and makes readily available to individuals requiring access to the information system, the rules that describe their responsibilities and expected behavior with regard to information and information system usage;
+     - b.  Receives a signed acknowledgment from such individuals, indicating that they have read, understand, and agree to abide by the rules of behavior, before authorizing access to information and the information system;
+     - c.  Reviews and updates the rules of behavior [Assignment: organization-defined frequency]; and
+     - d.  Requires individuals who have signed a previous version of the rules of behavior to read and re-sign when the rules of behavior are revised/updated.
 PL-4 (1):
   family: PL
   name: Social Media And Networking Restrictions
@@ -3410,26 +3410,26 @@ PL-7:
   name: Security Concept Of Operations
   description: |-
     The organization:
-      a.  Develops a security Concept of Operations (CONOPS) for the information system containing at a minimum, how the organization intends to operate the system from the perspective of information security; and
-      b.  Reviews and updates the CONOPS [Assignment: organization-defined frequency].
+     - a.  Develops a security Concept of Operations (CONOPS) for the information system containing at a minimum, how the organization intends to operate the system from the perspective of information security; and
+     - b.  Reviews and updates the CONOPS [Assignment: organization-defined frequency].
 PL-8:
   family: PL
   name: Information Security Architecture
   description: |-
     The organization:
-      a.  Develops an information security architecture for the information system that:
-        1.  Describes the overall philosophy, requirements, and approach to be taken with regard to protecting the confidentiality, integrity, and availability of organizational information;
-        2.  Describes how the information security architecture is integrated into and supports the enterprise architecture; and
-        3.  Describes any information security assumptions about, and dependencies on, external services;
-      b.  Reviews and updates the information security architecture [Assignment: organization-defined frequency] to reflect updates in the enterprise architecture; and
-      c.  Ensures that planned information security architecture changes are reflected in the security plan, the security Concept of Operations (CONOPS), and organizational procurements/acquisitions.
+     - a.  Develops an information security architecture for the information system that:
+       - 1.  Describes the overall philosophy, requirements, and approach to be taken with regard to protecting the confidentiality, integrity, and availability of organizational information;
+       - 2.  Describes how the information security architecture is integrated into and supports the enterprise architecture; and
+       - 3.  Describes any information security assumptions about, and dependencies on, external services;
+     - b.  Reviews and updates the information security architecture [Assignment: organization-defined frequency] to reflect updates in the enterprise architecture; and
+     - c.  Ensures that planned information security architecture changes are reflected in the security plan, the security Concept of Operations (CONOPS), and organizational procurements/acquisitions.
 PL-8 (1):
   family: PL
   name: Defense-In-Depth
   description: |-
     The organization designs its security architecture using a defense-in-depth approach that:
-       (1)(a).  Allocates [Assignment: organization-defined security safeguards] to [Assignment: organization-defined locations and architectural layers]; and
-       (1)(b).  Ensures that the allocated security safeguards operate in a coordinated and mutually reinforcing manner.
+     -  (1)(a).  Allocates [Assignment: organization-defined security safeguards] to [Assignment: organization-defined locations and architectural layers]; and
+     -  (1)(b).  Ensures that the allocated security safeguards operate in a coordinated and mutually reinforcing manner.
 PL-8 (2):
   family: PL
   name: Supplier Diversity
@@ -3446,14 +3446,14 @@ PM-1:
   name: Information Security Program Plan
   description: |-
     The organization:
-      a.  Develops and disseminates an organization-wide information security program plan that:
-        1.  Provides an overview of the requirements for the security program and a description of the security program management controls and common controls in place or planned for meeting those requirements;
-        2.  Includes the identification and assignment of roles, responsibilities, management commitment, coordination among organizational entities, and compliance;
-        3.  Reflects coordination among organizational entities responsible for the different aspects of information security (i.e., technical, physical, personnel, cyber-physical); and
-        4.  Is approved by a senior official with responsibility and accountability for the risk being incurred to organizational operations (including mission, functions, image, and reputation), organizational assets, individuals, other organizations, and the Nation;
-      b.  Reviews the organization-wide information security program plan [Assignment: organization-defined frequency];
-      c.  Updates the plan to address organizational changes and problems identified during plan implementation or security control assessments; and
-      d.  Protects the information security program plan from unauthorized disclosure and modification.
+     - a.  Develops and disseminates an organization-wide information security program plan that:
+       - 1.  Provides an overview of the requirements for the security program and a description of the security program management controls and common controls in place or planned for meeting those requirements;
+       - 2.  Includes the identification and assignment of roles, responsibilities, management commitment, coordination among organizational entities, and compliance;
+       - 3.  Reflects coordination among organizational entities responsible for the different aspects of information security (i.e., technical, physical, personnel, cyber-physical); and
+       - 4.  Is approved by a senior official with responsibility and accountability for the risk being incurred to organizational operations (including mission, functions, image, and reputation), organizational assets, individuals, other organizations, and the Nation;
+     - b.  Reviews the organization-wide information security program plan [Assignment: organization-defined frequency];
+     - c.  Updates the plan to address organizational changes and problems identified during plan implementation or security control assessments; and
+     - d.  Protects the information security program plan from unauthorized disclosure and modification.
 PM-2:
   family: PM
   name: Senior Information Security Officer
@@ -3465,19 +3465,19 @@ PM-3:
   name: Information Security Resources
   description: |-
     The organization:
-      a.  Ensures that all capital planning and investment requests include the resources needed to implement the information security program and documents all exceptions to this requirement;
-      b.  Employs a business case/Exhibit 300/Exhibit 53 to record the resources required; and
-      c.  Ensures that information security resources are available for expenditure as planned.
+     - a.  Ensures that all capital planning and investment requests include the resources needed to implement the information security program and documents all exceptions to this requirement;
+     - b.  Employs a business case/Exhibit 300/Exhibit 53 to record the resources required; and
+     - c.  Ensures that information security resources are available for expenditure as planned.
 PM-4:
   family: PM
   name: Plan Of Action And Milestones Process
   description: |-
     The organization:
-      a.  Implements a process for ensuring that plans of action and milestones for the security program and associated organizational information systems:
-        1.  Are developed and maintained;
-        2.  Document the remedial information security actions to adequately respond to risk to organizational operations and assets, individuals, other organizations, and the Nation; and
-        3.  Are reported in accordance with OMB FISMA reporting requirements.
-      b.  Reviews plans of action and milestones for consistency with the organizational risk management strategy and organization-wide priorities for risk response actions.
+     - a.  Implements a process for ensuring that plans of action and milestones for the security program and associated organizational information systems:
+       - 1.  Are developed and maintained;
+       - 2.  Document the remedial information security actions to adequately respond to risk to organizational operations and assets, individuals, other organizations, and the Nation; and
+       - 3.  Are reported in accordance with OMB FISMA reporting requirements.
+     - b.  Reviews plans of action and milestones for consistency with the organizational risk management strategy and organization-wide priorities for risk response actions.
 PM-5:
   family: PM
   name: Information System Inventory
@@ -3505,24 +3505,24 @@ PM-9:
   name: Risk Management Strategy
   description: |-
     The organization:
-      a.  Develops a comprehensive strategy to manage risk to organizational operations and assets, individuals, other organizations, and the Nation associated with the operation and use of information systems;
-      b.  Implements the risk management strategy consistently across the organization; and
-      c.  Reviews and updates the risk management strategy [Assignment: organization-defined frequency] or as required, to address organizational changes.
+     - a.  Develops a comprehensive strategy to manage risk to organizational operations and assets, individuals, other organizations, and the Nation associated with the operation and use of information systems;
+     - b.  Implements the risk management strategy consistently across the organization; and
+     - c.  Reviews and updates the risk management strategy [Assignment: organization-defined frequency] or as required, to address organizational changes.
 PM-10:
   family: PM
   name: Security Authorization Process
   description: |-
     The organization:
-      a.  Manages (i.e., documents, tracks, and reports) the security state of organizational information systems and the environments in which those systems operate through security authorization processes;
-      b.  Designates individuals to fulfill specific roles and responsibilities within the organizational risk management process; and
-      c.  Fully integrates the security authorization processes into an organization-wide risk management program.
+     - a.  Manages (i.e., documents, tracks, and reports) the security state of organizational information systems and the environments in which those systems operate through security authorization processes;
+     - b.  Designates individuals to fulfill specific roles and responsibilities within the organizational risk management process; and
+     - c.  Fully integrates the security authorization processes into an organization-wide risk management program.
 PM-11:
   family: PM
   name: Mission/Business Process Definition
   description: |-
     The organization:
-      a.  Defines mission/business processes with consideration for information security and the resulting risk to organizational operations, organizational assets, individuals, other organizations, and the Nation; and
-      b.  Determines information protection needs arising from the defined mission/business processes and revises the processes as necessary, until achievable protection needs are obtained.
+     - a.  Defines mission/business processes with consideration for information security and the resulting risk to organizational operations, organizational assets, individuals, other organizations, and the Nation; and
+     - b.  Determines information protection needs arising from the defined mission/business processes and revises the processes as necessary, until achievable protection needs are obtained.
 PM-12:
   family: PM
   name: Insider Threat Program
@@ -3538,18 +3538,18 @@ PM-14:
   name: Testing, Training, And Monitoring
   description: |-
     The organization:
-      a.  Implements a process for ensuring that organizational plans for conducting security testing, training, and monitoring activities associated with organizational information systems:
-        1.  Are developed and maintained; and
-        2.  Continue to be executed in a timely manner;
-      b.  Reviews testing, training, and monitoring plans for consistency with the organizational risk management strategy and organization-wide priorities for risk response actions.
+     - a.  Implements a process for ensuring that organizational plans for conducting security testing, training, and monitoring activities associated with organizational information systems:
+       - 1.  Are developed and maintained; and
+       - 2.  Continue to be executed in a timely manner;
+     - b.  Reviews testing, training, and monitoring plans for consistency with the organizational risk management strategy and organization-wide priorities for risk response actions.
 PM-15:
   family: PM
   name: Contacts With Security Groups And Associations
   description: |-
     The organization establishes and institutionalizes contact with selected groups and associations within the security community:
-      a.  To facilitate ongoing security education and training for organizational personnel;
-      b.  To maintain currency with recommended security practices, techniques, and technologies; and
-      c.  To share current security-related information including threats, vulnerabilities, and incidents.
+     - a.  To facilitate ongoing security education and training for organizational personnel;
+     - b.  To maintain currency with recommended security practices, techniques, and technologies; and
+     - c.  To share current security-related information including threats, vulnerabilities, and incidents.
 PM-16:
   family: PM
   name: Threat Awareness Program
@@ -3560,27 +3560,27 @@ PS-1:
   name: Personnel Security Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A personnel security policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the personnel security policy and associated personnel security controls; and
-      b.  Reviews and updates the current:
-        1.  Personnel security policy [Assignment: organization-defined frequency]; and
-        2.  Personnel security procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A personnel security policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the personnel security policy and associated personnel security controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Personnel security policy [Assignment: organization-defined frequency]; and
+       - 2.  Personnel security procedures [Assignment: organization-defined frequency].
 PS-2:
   family: PS
   name: Position Risk Designation
   description: |-
     The organization:
-      a.  Assigns a risk designation to all organizational positions;
-      b.  Establishes screening criteria for individuals filling those positions; and
-      c.  Reviews and updates position risk designations [Assignment: organization-defined frequency].
+     - a.  Assigns a risk designation to all organizational positions;
+     - b.  Establishes screening criteria for individuals filling those positions; and
+     - c.  Reviews and updates position risk designations [Assignment: organization-defined frequency].
 PS-3:
   family: PS
   name: Personnel Screening
   description: |-
     The organization:
-      a.  Screens individuals prior to authorizing access to the information system; and
-      b.  Rescreens individuals according to [Assignment: organization-defined conditions requiring rescreening and, where rescreening is so indicated, the frequency of such rescreening].
+     - a.  Screens individuals prior to authorizing access to the information system; and
+     - b.  Rescreens individuals according to [Assignment: organization-defined conditions requiring rescreening and, where rescreening is so indicated, the frequency of such rescreening].
 PS-3 (1):
   family: PS
   name: Classified Information
@@ -3600,26 +3600,26 @@ PS-3 (3):
   name: Information With Special Protection Measures
   description: |-
     The organization ensures that individuals accessing an information system processing, storing, or transmitting information requiring special protection:
-       (3)(a).  Have valid access authorizations that are demonstrated by assigned official government duties; and
-       (3)(b).  Satisfy [Assignment: organization-defined additional personnel screening criteria].
+     -  (3)(a).  Have valid access authorizations that are demonstrated by assigned official government duties; and
+     -  (3)(b).  Satisfy [Assignment: organization-defined additional personnel screening criteria].
 PS-4:
   family: PS
   name: Personnel Termination
   description: |-
     The organization, upon termination of individual employment:
-      a.  Disables information system access within [Assignment: organization-defined time period];
-      b.  Terminates/revokes any authenticators/credentials associated with the individual;
-      c.  Conducts exit interviews that include a discussion of [Assignment: organization-defined information security topics];
-      d.  Retrieves all security-related organizational information system-related property;
-      e.  Retains access to organizational information and information systems formerly controlled by terminated individual; and
-      f.  Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period].
+     - a.  Disables information system access within [Assignment: organization-defined time period];
+     - b.  Terminates/revokes any authenticators/credentials associated with the individual;
+     - c.  Conducts exit interviews that include a discussion of [Assignment: organization-defined information security topics];
+     - d.  Retrieves all security-related organizational information system-related property;
+     - e.  Retains access to organizational information and information systems formerly controlled by terminated individual; and
+     - f.  Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period].
 PS-4 (1):
   family: PS
   name: Post-Employment Requirements
   description: |-
     The organization:
-       (1)(a).  Notifies terminated individuals of applicable, legally binding post-employment requirements for the protection of organizational information; and
-       (1)(b).  Requires terminated individuals to sign an acknowledgment of post-employment requirements as part of the organizational termination process.
+     -  (1)(a).  Notifies terminated individuals of applicable, legally binding post-employment requirements for the protection of organizational information; and
+     -  (1)(b).  Requires terminated individuals to sign an acknowledgment of post-employment requirements as part of the organizational termination process.
 PS-4 (2):
   family: PS
   name: Automated Notification
@@ -3630,20 +3630,20 @@ PS-5:
   name: Personnel Transfer
   description: |-
     The organization:
-      a.  Reviews and confirms ongoing operational need for current logical and physical access authorizations to information systems/facilities when individuals are reassigned or transferred to other positions within the organization;
-      b.  Initiates [Assignment: organization-defined transfer or reassignment actions] within [Assignment: organization-defined time period following the formal transfer action];
-      c.  Modifies access authorization as needed to correspond with any changes in operational need due to reassignment or transfer; and
-      d.  Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period].
+     - a.  Reviews and confirms ongoing operational need for current logical and physical access authorizations to information systems/facilities when individuals are reassigned or transferred to other positions within the organization;
+     - b.  Initiates [Assignment: organization-defined transfer or reassignment actions] within [Assignment: organization-defined time period following the formal transfer action];
+     - c.  Modifies access authorization as needed to correspond with any changes in operational need due to reassignment or transfer; and
+     - d.  Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period].
 PS-6:
   family: PS
   name: Access Agreements
   description: |-
     The organization:
-      a.  Develops and documents access agreements for organizational information systems;
-      b.  Reviews and updates the access agreements [Assignment: organization-defined frequency]; and
-      c.  Ensures that individuals requiring access to organizational information and information systems:
-        1.  Sign appropriate access agreements prior to being granted access; and
-        2.  Re-sign access agreements to maintain access to organizational information systems when access agreements have been updated or [Assignment: organization-defined frequency].
+     - a.  Develops and documents access agreements for organizational information systems;
+     - b.  Reviews and updates the access agreements [Assignment: organization-defined frequency]; and
+     - c.  Ensures that individuals requiring access to organizational information and information systems:
+       - 1.  Sign appropriate access agreements prior to being granted access; and
+       - 2.  Re-sign access agreements to maintain access to organizational information systems when access agreements have been updated or [Assignment: organization-defined frequency].
 PS-6 (1):
   family: PS
   name: Information Requiring Special Protection
@@ -3653,62 +3653,62 @@ PS-6 (2):
   name: Classified Information Requiring Special Protection
   description: |-
     The organization ensures that access to classified information requiring special protection is granted only to individuals who:
-       (2)(a).  Have a valid access authorization that is demonstrated by assigned official government duties;
-       (2)(b).  Satisfy associated personnel security criteria; and
-       (2)(c).  Have read, understood, and signed a nondisclosure agreement.
+     -  (2)(a).  Have a valid access authorization that is demonstrated by assigned official government duties;
+     -  (2)(b).  Satisfy associated personnel security criteria; and
+     -  (2)(c).  Have read, understood, and signed a nondisclosure agreement.
 PS-6 (3):
   family: PS
   name: Post-Employment Requirements
   description: |-
     The organization:
-       (3)(a).  Notifies individuals of applicable, legally binding post-employment requirements for protection of organizational information; and
-       (3)(b).  Requires individuals to sign an acknowledgment of these requirements, if applicable, as part of granting initial access to covered information.
+     -  (3)(a).  Notifies individuals of applicable, legally binding post-employment requirements for protection of organizational information; and
+     -  (3)(b).  Requires individuals to sign an acknowledgment of these requirements, if applicable, as part of granting initial access to covered information.
 PS-7:
   family: PS
   name: Third-Party Personnel Security
   description: |-
     The organization:
-      a.  Establishes personnel security requirements including security roles and responsibilities for third-party providers;
-      b.  Requires third-party providers to comply with personnel security policies and procedures established by the organization;
-      c.  Documents personnel security requirements;
-      d.  Requires third-party providers to notify [Assignment: organization-defined personnel or roles] of any personnel transfers or terminations of third-party personnel who possess organizational credentials and/or badges, or who have information system privileges within [Assignment: organization-defined time period]; and
-      e.  Monitors provider compliance.
+     - a.  Establishes personnel security requirements including security roles and responsibilities for third-party providers;
+     - b.  Requires third-party providers to comply with personnel security policies and procedures established by the organization;
+     - c.  Documents personnel security requirements;
+     - d.  Requires third-party providers to notify [Assignment: organization-defined personnel or roles] of any personnel transfers or terminations of third-party personnel who possess organizational credentials and/or badges, or who have information system privileges within [Assignment: organization-defined time period]; and
+     - e.  Monitors provider compliance.
 PS-8:
   family: PS
   name: Personnel Sanctions
   description: |-
     The organization:
-      a.  Employs a formal sanctions process for individuals failing to comply with established information security policies and procedures; and
-      b.  Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period] when a formal employee sanctions process is initiated, identifying the individual sanctioned and the reason for the sanction.
+     - a.  Employs a formal sanctions process for individuals failing to comply with established information security policies and procedures; and
+     - b.  Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period] when a formal employee sanctions process is initiated, identifying the individual sanctioned and the reason for the sanction.
 RA-1:
   family: RA
   name: Risk Assessment Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A risk assessment policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the risk assessment policy and associated risk assessment controls; and
-      b.  Reviews and updates the current:
-        1.  Risk assessment policy [Assignment: organization-defined frequency]; and
-        2.  Risk assessment procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A risk assessment policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the risk assessment policy and associated risk assessment controls; and
+     - b.  Reviews and updates the current:
+       - 1.  Risk assessment policy [Assignment: organization-defined frequency]; and
+       - 2.  Risk assessment procedures [Assignment: organization-defined frequency].
 RA-2:
   family: RA
   name: Security Categorization
   description: |-
     The organization:
-      a.  Categorizes information and the information system in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance;
-      b.  Documents the security categorization results (including supporting rationale) in the security plan for the information system; and
-      c.  Ensures that the authorizing official or authorizing official designated representative reviews and approves the security categorization decision.
+     - a.  Categorizes information and the information system in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance;
+     - b.  Documents the security categorization results (including supporting rationale) in the security plan for the information system; and
+     - c.  Ensures that the authorizing official or authorizing official designated representative reviews and approves the security categorization decision.
 RA-3:
   family: RA
   name: Risk Assessment
   description: |-
     The organization:
-      a.  Conducts an assessment of risk, including the likelihood and magnitude of harm, from the unauthorized access, use, disclosure, disruption, modification, or destruction of the information system and the information it processes, stores, or transmits;
-      b.  Documents risk assessment results in [Selection: security plan; risk assessment report; [Assignment: organization-defined document]];
-      c.  Reviews risk assessment results [Assignment: organization-defined frequency];
-      d.  Disseminates risk assessment results to [Assignment: organization-defined personnel or roles]; and
-      e.  Updates the risk assessment [Assignment: organization-defined frequency] or whenever there are significant changes to the information system or environment of operation (including the identification of new threats and vulnerabilities), or other conditions that may impact the security state of the system.
+     - a.  Conducts an assessment of risk, including the likelihood and magnitude of harm, from the unauthorized access, use, disclosure, disruption, modification, or destruction of the information system and the information it processes, stores, or transmits;
+     - b.  Documents risk assessment results in [Selection: security plan; risk assessment report; [Assignment: organization-defined document]];
+     - c.  Reviews risk assessment results [Assignment: organization-defined frequency];
+     - d.  Disseminates risk assessment results to [Assignment: organization-defined personnel or roles]; and
+     - e.  Updates the risk assessment [Assignment: organization-defined frequency] or whenever there are significant changes to the information system or environment of operation (including the identification of new threats and vulnerabilities), or other conditions that may impact the security state of the system.
 RA-4:
   family: RA
   name: Risk Assessment Update
@@ -3718,14 +3718,14 @@ RA-5:
   name: Vulnerability Scanning
   description: |-
     The organization:
-      a.  Scans for vulnerabilities in the information system and hosted applications [Assignment: organization-defined frequency and/or randomly in accordance with organization-defined process] and when new vulnerabilities potentially affecting the system/applications are identified and reported;
-      b.  Employs vulnerability scanning tools and techniques that facilitate interoperability among tools and automate parts of the vulnerability management process by using standards for:
-        1.  Enumerating platforms, software flaws, and improper configurations;
-        2.  Formatting checklists and test procedures; and
-        3.  Measuring vulnerability impact;
-      c.  Analyzes vulnerability scan reports and results from security control assessments;
-      d.  Remediates legitimate vulnerabilities [Assignment: organization-defined response times] in accordance with an organizational assessment of risk; and
-      e.  Shares information obtained from the vulnerability scanning process and security control assessments with [Assignment: organization-defined personnel or roles] to help eliminate similar vulnerabilities in other information systems (i.e., systemic weaknesses or deficiencies).
+     - a.  Scans for vulnerabilities in the information system and hosted applications [Assignment: organization-defined frequency and/or randomly in accordance with organization-defined process] and when new vulnerabilities potentially affecting the system/applications are identified and reported;
+     - b.  Employs vulnerability scanning tools and techniques that facilitate interoperability among tools and automate parts of the vulnerability management process by using standards for:
+       - 1.  Enumerating platforms, software flaws, and improper configurations;
+       - 2.  Formatting checklists and test procedures; and
+       - 3.  Measuring vulnerability impact;
+     - c.  Analyzes vulnerability scan reports and results from security control assessments;
+     - d.  Remediates legitimate vulnerabilities [Assignment: organization-defined response times] in accordance with an organizational assessment of risk; and
+     - e.  Shares information obtained from the vulnerability scanning process and security control assessments with [Assignment: organization-defined personnel or roles] to help eliminate similar vulnerabilities in other information systems (i.e., systemic weaknesses or deficiencies).
 RA-5 (1):
   family: RA
   name: Update Tool Capability
@@ -3791,41 +3791,41 @@ SA-1:
   name: System And Services Acquisition Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A system and services acquisition policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the system and services acquisition policy and associated system and services acquisition controls; and
-      b.  Reviews and updates the current:
-        1.  System and services acquisition policy [Assignment: organization-defined frequency]; and
-        2.  System and services acquisition procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A system and services acquisition policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the system and services acquisition policy and associated system and services acquisition controls; and
+     - b.  Reviews and updates the current:
+       - 1.  System and services acquisition policy [Assignment: organization-defined frequency]; and
+       - 2.  System and services acquisition procedures [Assignment: organization-defined frequency].
 SA-2:
   family: SA
   name: Allocation Of Resources
   description: |-
     The organization:
-      a.  Determines information security requirements for the information system or information system service in mission/business process planning;
-      b.  Determines, documents, and allocates the resources required to protect the information system or information system service as part of its capital planning and investment control process; and
-      c.  Establishes a discrete line item for information security in organizational programming and budgeting documentation.
+     - a.  Determines information security requirements for the information system or information system service in mission/business process planning;
+     - b.  Determines, documents, and allocates the resources required to protect the information system or information system service as part of its capital planning and investment control process; and
+     - c.  Establishes a discrete line item for information security in organizational programming and budgeting documentation.
 SA-3:
   family: SA
   name: System Development Life Cycle
   description: |-
     The organization:
-      a.  Manages the information system using [Assignment: organization-defined system development life cycle] that incorporates information security considerations;
-      b.  Defines and documents information security roles and responsibilities throughout the system development life cycle;
-      c.  Identifies individuals having information security roles and responsibilities; and
-      d.  Integrates the organizational information security risk management process into system development life cycle activities.
+     - a.  Manages the information system using [Assignment: organization-defined system development life cycle] that incorporates information security considerations;
+     - b.  Defines and documents information security roles and responsibilities throughout the system development life cycle;
+     - c.  Identifies individuals having information security roles and responsibilities; and
+     - d.  Integrates the organizational information security risk management process into system development life cycle activities.
 SA-4:
   family: SA
   name: Acquisition Process
   description: |-
     The organization includes the following requirements, descriptions, and criteria, explicitly or by reference, in the acquisition contract for the information system, system component, or information system service in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, guidelines, and organizational mission/business needs:
-      a.  Security functional requirements;
-      b.  Security strength requirements;
-      c.  Security assurance requirements;
-      d.  Security-related documentation requirements;
-      e.  Requirements for protecting security-related documentation;
-      f.  Description of the information system development environment and environment in which the system is intended to operate; and
-      g.  Acceptance criteria.
+     - a.  Security functional requirements;
+     - b.  Security strength requirements;
+     - c.  Security assurance requirements;
+     - d.  Security-related documentation requirements;
+     - e.  Requirements for protecting security-related documentation;
+     - f.  Description of the information system development environment and environment in which the system is intended to operate; and
+     - g.  Acceptance criteria.
 SA-4 (1):
   family: SA
   name: Functional Properties Of Security Controls
@@ -3859,22 +3859,22 @@ SA-4 (5):
   name: System / Component / Service Configurations
   description: |-
     The organization requires the developer of the information system, system component, or information system service to:
-       (5)(a).  Deliver the system, component, or service with [Assignment: organization-defined security configurations] implemented; and
-       (5)(b).  Use the configurations as the default for any subsequent system, component, or service reinstallation or upgrade.
+     -  (5)(a).  Deliver the system, component, or service with [Assignment: organization-defined security configurations] implemented; and
+     -  (5)(b).  Use the configurations as the default for any subsequent system, component, or service reinstallation or upgrade.
 SA-4 (6):
   family: SA
   name: Use Of Information Assurance Products
   description: |-
     The organization:
-       (6)(a).  Employs only government off-the-shelf (GOTS) or commercial off-the-shelf (COTS) information assurance (IA) and IA-enabled information technology products that compose an NSA-approved solution to protect classified information when the networks used to transmit the information are at a lower classification level than the information being transmitted; and
-       (6)(b).  Ensures that these products have been evaluated and/or validated by NSA or in accordance with NSA-approved procedures.
+     -  (6)(a).  Employs only government off-the-shelf (GOTS) or commercial off-the-shelf (COTS) information assurance (IA) and IA-enabled information technology products that compose an NSA-approved solution to protect classified information when the networks used to transmit the information are at a lower classification level than the information being transmitted; and
+     -  (6)(b).  Ensures that these products have been evaluated and/or validated by NSA or in accordance with NSA-approved procedures.
 SA-4 (7):
   family: SA
   name: Niap-Approved  Protection Profiles
   description: |-
     The organization:
-       (7)(a).  Limits the use of commercially provided information assurance (IA) and IA-enabled information technology products to those products that have been successfully evaluated against a National Information Assurance partnership (NIAP)-approved Protection Profile for a specific technology type, if such a profile exists; and
-       (7)(b).  Requires, if no NIAP-approved Protection Profile exists for a specific technology type but a commercially provided information technology product relies on cryptographic functionality to enforce its security policy, that the cryptographic module is FIPS-validated.
+     -  (7)(a).  Limits the use of commercially provided information assurance (IA) and IA-enabled information technology products to those products that have been successfully evaluated against a National Information Assurance partnership (NIAP)-approved Protection Profile for a specific technology type, if such a profile exists; and
+     -  (7)(b).  Requires, if no NIAP-approved Protection Profile exists for a specific technology type but a commercially provided information technology product relies on cryptographic functionality to enforce its security policy, that the cryptographic module is FIPS-validated.
 SA-4 (8):
   family: SA
   name: Continuous Monitoring Plan
@@ -3900,17 +3900,17 @@ SA-5:
   name: Information System Documentation
   description: |-
     The organization:
-      a.  Obtains administrator documentation for the information system, system component, or information system service that describes:
-        1.  Secure configuration, installation, and operation of the system, component, or service;
-        2.  Effective use and maintenance of security functions/mechanisms; and
-        3.  Known vulnerabilities regarding configuration and use of administrative (i.e., privileged) functions;
-      b.  Obtains user documentation for the information system, system component, or information system service that describes:
-        1.  User-accessible security functions/mechanisms and how to effectively use those security functions/mechanisms;
-        2.  Methods for user interaction, which enables individuals to use the system, component, or service in a more secure manner; and
-        3.  User responsibilities in maintaining the security of the system, component, or service;
-      c.  Documents attempts to obtain information system, system component, or information system service documentation when such documentation is either unavailable or nonexistent and takes [Assignment: organization-defined actions] in response;
-      d.  Protects documentation as required, in accordance with the risk management strategy; and
-      e.  Distributes documentation to [Assignment: organization-defined personnel or roles].
+     - a.  Obtains administrator documentation for the information system, system component, or information system service that describes:
+       - 1.  Secure configuration, installation, and operation of the system, component, or service;
+       - 2.  Effective use and maintenance of security functions/mechanisms; and
+       - 3.  Known vulnerabilities regarding configuration and use of administrative (i.e., privileged) functions;
+     - b.  Obtains user documentation for the information system, system component, or information system service that describes:
+       - 1.  User-accessible security functions/mechanisms and how to effectively use those security functions/mechanisms;
+       - 2.  Methods for user interaction, which enables individuals to use the system, component, or service in a more secure manner; and
+       - 3.  User responsibilities in maintaining the security of the system, component, or service;
+     - c.  Documents attempts to obtain information system, system component, or information system service documentation when such documentation is either unavailable or nonexistent and takes [Assignment: organization-defined actions] in response;
+     - d.  Protects documentation as required, in accordance with the risk management strategy; and
+     - e.  Distributes documentation to [Assignment: organization-defined personnel or roles].
 SA-5 (1):
   family: SA
   name: Functional Properties Of Security Controls
@@ -3950,16 +3950,16 @@ SA-9:
   name: External Information System Services
   description: |-
     The organization:
-      a.  Requires that providers of external information system services comply with organizational information security requirements and employ [Assignment: organization-defined security controls] in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance;
-      b.  Defines and documents government oversight and user roles and responsibilities with regard  to external information system services; and
-      c.  Employs [Assignment: organization-defined processes, methods, and techniques] to monitor security control compliance by external service providers on an ongoing basis.
+     - a.  Requires that providers of external information system services comply with organizational information security requirements and employ [Assignment: organization-defined security controls] in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance;
+     - b.  Defines and documents government oversight and user roles and responsibilities with regard  to external information system services; and
+     - c.  Employs [Assignment: organization-defined processes, methods, and techniques] to monitor security control compliance by external service providers on an ongoing basis.
 SA-9 (1):
   family: SA
   name: Risk Assessments / Organizational Approvals
   description: |-
     The organization:
-       (1)(a).  Conducts an organizational assessment of risk prior to the acquisition or outsourcing of dedicated information security services; and
-       (1)(b).  Ensures that the acquisition or outsourcing of dedicated information security services is approved by [Assignment: organization-defined personnel or roles].
+     -  (1)(a).  Conducts an organizational assessment of risk prior to the acquisition or outsourcing of dedicated information security services; and
+     -  (1)(b).  Ensures that the acquisition or outsourcing of dedicated information security services is approved by [Assignment: organization-defined personnel or roles].
 SA-9 (2):
   family: SA
   name: Identification Of Functions / Ports / Protocols / Services
@@ -3990,11 +3990,11 @@ SA-10:
   name: Developer Configuration Management
   description: |-
     The organization requires the developer of the information system, system component, or information system service to:
-      a.  Perform configuration management during system, component, or service [Selection (one or more): design; development; implementation; operation];
-      b.  Document, manage, and control the integrity of changes to [Assignment: organization-defined configuration items under configuration management];
-      c.  Implement only organization-approved changes to the system, component, or service;
-      d.  Document approved changes to the system, component, or service and the potential security impacts of such changes; and
-      e.  Track security flaws and flaw resolution within the system, component, or service and report findings to [Assignment: organization-defined personnel].
+     - a.  Perform configuration management during system, component, or service [Selection (one or more): design; development; implementation; operation];
+     - b.  Document, manage, and control the integrity of changes to [Assignment: organization-defined configuration items under configuration management];
+     - c.  Implement only organization-approved changes to the system, component, or service;
+     - d.  Document approved changes to the system, component, or service and the potential security impacts of such changes; and
+     - e.  Track security flaws and flaw resolution within the system, component, or service and report findings to [Assignment: organization-defined personnel].
 SA-10 (1):
   family: SA
   name: Software / Firmware Integrity Verification
@@ -4040,11 +4040,11 @@ SA-11:
   name: Developer Security Testing And Evaluation
   description: |-
     The organization requires the developer of the information system, system component, or information system service to:
-      a.  Create and implement a security assessment plan;
-      b.  Perform [Selection (one or more): unit; integration; system; regression] testing/evaluation at [Assignment: organization-defined depth and coverage];
-      c.  Produce evidence of the execution of the security assessment plan and the results of the security testing/evaluation;
-      d.  Implement a verifiable flaw remediation process; and
-      e.  Correct flaws identified during security testing/evaluation.
+     - a.  Create and implement a security assessment plan;
+     - b.  Perform [Selection (one or more): unit; integration; system; regression] testing/evaluation at [Assignment: organization-defined depth and coverage];
+     - c.  Produce evidence of the execution of the security assessment plan and the results of the security testing/evaluation;
+     - d.  Implement a verifiable flaw remediation process; and
+     - e.  Correct flaws identified during security testing/evaluation.
 SA-11 (1):
   family: SA
   name: Static Code Analysis
@@ -4063,8 +4063,8 @@ SA-11 (3):
   name: Independent Verification Of Assessment Plans / Evidence
   description: |-
     The organization:
-       (3)(a).  Requires an independent agent satisfying [Assignment: organization-defined independence criteria] to verify the correct implementation of the developer security assessment plan and the evidence produced during security testing/evaluation; and
-       (3)(b).  Ensures that the independent agent is either provided with sufficient information to complete the verification process or granted the authority to obtain such information.
+     -  (3)(a).  Requires an independent agent satisfying [Assignment: organization-defined independence criteria] to verify the correct implementation of the developer security assessment plan and the evidence produced during security testing/evaluation; and
+     -  (3)(b).  Ensures that the independent agent is either provided with sufficient information to complete the verification process or granted the authority to obtain such information.
 SA-11 (4):
   family: SA
   name: Manual Code Reviews
@@ -4197,8 +4197,8 @@ SA-13:
   name: Trustworthiness
   description: |-
     The organization:
-      a.  Describes the trustworthiness required in the [Assignment: organization-defined information system, information system component, or information system service] supporting its critical missions/business functions; and
-      b.  Implements [Assignment: organization-defined assurance overlay] to achieve such trustworthiness.
+     - a.  Describes the trustworthiness required in the [Assignment: organization-defined information system, information system component, or information system service] supporting its critical missions/business functions; and
+     - b.  Implements [Assignment: organization-defined assurance overlay] to achieve such trustworthiness.
 SA-14:
   family: SA
   name: Criticality Analysis
@@ -4216,19 +4216,19 @@ SA-15:
   name: Development Process, Standards, And Tools
   description: |-
     The organization:
-      a.  Requires the developer of the information system, system component, or information system service to follow a documented development process that:
-        1.  Explicitly addresses security requirements;
-        2.  Identifies the standards and tools used in the development process;
-        3.  Documents the specific tool options and tool configurations used in the development process; and
-        4.  Documents, manages, and ensures the integrity of changes to the process and/or tools used in development; and
-      b.  Reviews the development process, standards, tools, and tool options/configurations [Assignment: organization-defined frequency] to determine if the process, standards, tools, and tool options/configurations selected and employed can satisfy [Assignment: organization-defined security requirements].
+     - a.  Requires the developer of the information system, system component, or information system service to follow a documented development process that:
+       - 1.  Explicitly addresses security requirements;
+       - 2.  Identifies the standards and tools used in the development process;
+       - 3.  Documents the specific tool options and tool configurations used in the development process; and
+       - 4.  Documents, manages, and ensures the integrity of changes to the process and/or tools used in development; and
+     - b.  Reviews the development process, standards, tools, and tool options/configurations [Assignment: organization-defined frequency] to determine if the process, standards, tools, and tool options/configurations selected and employed can satisfy [Assignment: organization-defined security requirements].
 SA-15 (1):
   family: SA
   name: Quality Metrics
   description: |-
     The organization requires the developer of the information system, system component, or information system service to:
-       (1)(a).  Define quality metrics at the beginning of the development process; and
-       (1)(b).  Provide evidence of meeting the quality metrics [Selection (one or more): [Assignment: organization-defined frequency]; [Assignment: organization-defined program review milestones]; upon delivery].
+     -  (1)(a).  Define quality metrics at the beginning of the development process; and
+     -  (1)(b).  Provide evidence of meeting the quality metrics [Selection (one or more): [Assignment: organization-defined frequency]; [Assignment: organization-defined program review milestones]; upon delivery].
 SA-15 (2):
   family: SA
   name: Security Tracking Tools
@@ -4247,9 +4247,9 @@ SA-15 (4):
   name: Threat Modeling / Vulnerability Analysis
   description: |-
     The organization requires that developers perform threat modeling and a vulnerability analysis for the information system at [Assignment: organization-defined breadth/depth] that:
-       (4)(a).  Uses [Assignment: organization-defined information concerning impact, environment of operations, known or assumed threats, and acceptable risk levels];
-       (4)(b).  Employs [Assignment: organization-defined tools and methods]; and
-       (4)(c).  Produces evidence that meets [Assignment: organization-defined acceptance criteria].
+     -  (4)(a).  Uses [Assignment: organization-defined information concerning impact, environment of operations, known or assumed threats, and acceptable risk levels];
+     -  (4)(b).  Employs [Assignment: organization-defined tools and methods]; and
+     -  (4)(c).  Produces evidence that meets [Assignment: organization-defined acceptance criteria].
 SA-15 (5):
   family: SA
   name: Attack Surface Reduction
@@ -4267,10 +4267,10 @@ SA-15 (7):
   name: Automated Vulnerability Analysis
   description: |-
     The organization requires the developer of the information system, system component, or information system service to:
-       (7)(a).  Perform an automated vulnerability analysis using [Assignment: organization-defined tools];
-       (7)(b).  Determine the exploitation potential for discovered vulnerabilities;
-       (7)(c).  Determine potential risk mitigations for delivered vulnerabilities; and
-       (7)(d).  Deliver the outputs of the tools and results of the analysis to [Assignment: organization-defined personnel or roles].
+     -  (7)(a).  Perform an automated vulnerability analysis using [Assignment: organization-defined tools];
+     -  (7)(b).  Determine the exploitation potential for discovered vulnerabilities;
+     -  (7)(c).  Determine potential risk mitigations for delivered vulnerabilities; and
+     -  (7)(d).  Deliver the outputs of the tools and results of the analysis to [Assignment: organization-defined personnel or roles].
 SA-15 (8):
   family: SA
   name: Reuse Of Threat / Vulnerability Information
@@ -4308,50 +4308,50 @@ SA-17:
   name: Developer Security Architecture And Design
   description: |-
     The organization requires the developer of the information system, system component, or information system service to produce a design specification and security architecture that:
-      a.  Is consistent with and supportive of the organization's security architecture which is established within and is an integrated part of the organization's enterprise architecture;
-      b.  Accurately and completely describes the required security functionality, and the allocation of security controls among physical and logical components; and
-      c.  Expresses how individual security functions, mechanisms, and services work together to provide required security capabilities and a unified approach to protection.
+     - a.  Is consistent with and supportive of the organization's security architecture which is established within and is an integrated part of the organization's enterprise architecture;
+     - b.  Accurately and completely describes the required security functionality, and the allocation of security controls among physical and logical components; and
+     - c.  Expresses how individual security functions, mechanisms, and services work together to provide required security capabilities and a unified approach to protection.
 SA-17 (1):
   family: SA
   name: Formal Policy Model
   description: |-
     The organization requires the developer of the information system, system component, or information system service to:
-       (1)(a).  Produce, as an integral part of the development process, a formal policy model describing the [Assignment: organization-defined elements of organizational security policy] to be enforced; and
-       (1)(b).  Prove that the formal policy model is internally consistent and sufficient to enforce the defined elements of the organizational security policy when implemented.
+     -  (1)(a).  Produce, as an integral part of the development process, a formal policy model describing the [Assignment: organization-defined elements of organizational security policy] to be enforced; and
+     -  (1)(b).  Prove that the formal policy model is internally consistent and sufficient to enforce the defined elements of the organizational security policy when implemented.
 SA-17 (2):
   family: SA
   name: Security-Relevant Components
   description: |-
     The organization requires the developer of the information system, system component, or information system service to:
-       (2)(a).  Define security-relevant hardware, software, and firmware; and
-       (2)(b).  Provide a rationale that the definition for security-relevant hardware, software, and firmware is complete.
+     -  (2)(a).  Define security-relevant hardware, software, and firmware; and
+     -  (2)(b).  Provide a rationale that the definition for security-relevant hardware, software, and firmware is complete.
 SA-17 (3):
   family: SA
   name: Formal Correspondence
   description: |-
     The organization requires the developer of the information system, system component, or information system service to:
-       (3)(a).  Produce, as an integral part of the development process, a formal top-level specification that specifies the interfaces to security-relevant hardware, software, and firmware in terms of exceptions, error messages, and effects;
-       (3)(b).  Show via proof to the extent feasible with additional informal demonstration as necessary, that the formal top-level specification is consistent with the formal policy model;
-       (3)(c).  Show via informal demonstration, that the formal top-level specification completely covers the interfaces to security-relevant hardware, software, and firmware;
-       (3)(d).  Show that the formal top-level specification is an accurate description of the implemented security-relevant hardware, software, and firmware; and
-       (3)(e).  Describe the security-relevant hardware, software, and firmware mechanisms not addressed in the formal top-level specification but strictly internal to the security-relevant hardware, software, and firmware.
+     -  (3)(a).  Produce, as an integral part of the development process, a formal top-level specification that specifies the interfaces to security-relevant hardware, software, and firmware in terms of exceptions, error messages, and effects;
+     -  (3)(b).  Show via proof to the extent feasible with additional informal demonstration as necessary, that the formal top-level specification is consistent with the formal policy model;
+     -  (3)(c).  Show via informal demonstration, that the formal top-level specification completely covers the interfaces to security-relevant hardware, software, and firmware;
+     -  (3)(d).  Show that the formal top-level specification is an accurate description of the implemented security-relevant hardware, software, and firmware; and
+     -  (3)(e).  Describe the security-relevant hardware, software, and firmware mechanisms not addressed in the formal top-level specification but strictly internal to the security-relevant hardware, software, and firmware.
 SA-17 (4):
   family: SA
   name: Informal Correspondence
   description: |-
     The organization requires the developer of the information system, system component, or information system service to:
-       (4)(a).  Produce, as an integral part of the development process, an informal descriptive top-level specification that specifies the interfaces to security-relevant hardware, software, and firmware in terms of exceptions, error messages, and effects;
-       (4)(b).  Show via [Selection: informal demonstration, convincing argument with formal methods as feasible] that the descriptive top-level specification is consistent with the formal policy model;
-       (4)(c).  Show via informal demonstration, that the descriptive top-level specification completely  covers the interfaces to security-relevant hardware, software, and firmware;
-       (4)(d).  Show that the descriptive top-level specification is an accurate description of the interfaces to security-relevant hardware, software, and firmware; and
-       (4)(e).  Describe the security-relevant hardware, software, and firmware mechanisms not addressed in the descriptive top-level specification but strictly internal to the security-relevant hardware, software, and firmware.
+     -  (4)(a).  Produce, as an integral part of the development process, an informal descriptive top-level specification that specifies the interfaces to security-relevant hardware, software, and firmware in terms of exceptions, error messages, and effects;
+     -  (4)(b).  Show via [Selection: informal demonstration, convincing argument with formal methods as feasible] that the descriptive top-level specification is consistent with the formal policy model;
+     -  (4)(c).  Show via informal demonstration, that the descriptive top-level specification completely  covers the interfaces to security-relevant hardware, software, and firmware;
+     -  (4)(d).  Show that the descriptive top-level specification is an accurate description of the interfaces to security-relevant hardware, software, and firmware; and
+     -  (4)(e).  Describe the security-relevant hardware, software, and firmware mechanisms not addressed in the descriptive top-level specification but strictly internal to the security-relevant hardware, software, and firmware.
 SA-17 (5):
   family: SA
   name: Conceptually Simple Design
   description: |-
     The organization requires the developer of the information system, system component, or information system service to:
-       (5)(a).  Design and structure the security-relevant hardware, software, and firmware to use a complete, conceptually simple protection mechanism with precisely defined semantics; and
-       (5)(b).  Internally structure the security-relevant hardware, software, and firmware with specific regard for this mechanism.
+     -  (5)(a).  Design and structure the security-relevant hardware, software, and firmware to use a complete, conceptually simple protection mechanism with precisely defined semantics; and
+     -  (5)(b).  Internally structure the security-relevant hardware, software, and firmware with specific regard for this mechanism.
 SA-17 (6):
   family: SA
   name: Structure For Testing
@@ -4387,8 +4387,8 @@ SA-19:
   name: Component Authenticity
   description: |-
     The organization:
-      a.  Develops and implements anti-counterfeit policy and procedures that include the means to detect and prevent counterfeit components from entering the information system; and
-      b.  Reports counterfeit information system components to [Selection (one or more): source of counterfeit component; [Assignment: organization-defined external reporting organizations]; [Assignment: organization-defined personnel or roles]].
+     - a.  Develops and implements anti-counterfeit policy and procedures that include the means to detect and prevent counterfeit components from entering the information system; and
+     - b.  Reports counterfeit information system components to [Selection (one or more): source of counterfeit component; [Assignment: organization-defined external reporting organizations]; [Assignment: organization-defined personnel or roles]].
 SA-19 (1):
   family: SA
   name: Anti-Counterfeit Training
@@ -4421,8 +4421,8 @@ SA-21:
   name: Developer Screening
   description: |-
     The organization requires that the developer of [Assignment: organization-defined information system, system component, or information system service]:
-      a.  Have appropriate access authorizations as determined by assigned [Assignment: organization-defined official government duties]; and
-      b.  Satisfy [Assignment: organization-defined additional personnel screening criteria].
+     - a.  Have appropriate access authorizations as determined by assigned [Assignment: organization-defined official government duties]; and
+     - b.  Satisfy [Assignment: organization-defined additional personnel screening criteria].
 SA-21 (1):
   family: SA
   name: Validation Of Screening
@@ -4435,8 +4435,8 @@ SA-22:
   name: Unsupported System Components
   description: |-
     The organization:
-      a.  Replaces information system components when support for the components is no longer available from the developer, vendor, or manufacturer; and
-      b.  Provides justification and documents approval for the continued use of unsupported system components required to satisfy mission/business needs.
+     - a.  Replaces information system components when support for the components is no longer available from the developer, vendor, or manufacturer; and
+     - b.  Provides justification and documents approval for the continued use of unsupported system components required to satisfy mission/business needs.
 SA-22 (1):
   family: SA
   name: Alternative Sources For Continued Support
@@ -4448,12 +4448,12 @@ SC-1:
   name: System And Communications Protection Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A system and communications protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the system and communications protection policy and associated system and communications protection controls; and
-      b.  Reviews and updates the current:
-        1.  System and communications protection policy [Assignment: organization-defined frequency]; and
-        2.  System and communications protection procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A system and communications protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the system and communications protection policy and associated system and communications protection controls; and
+     - b.  Reviews and updates the current:
+       - 1.  System and communications protection policy [Assignment: organization-defined frequency]; and
+       - 2.  System and communications protection procedures [Assignment: organization-defined frequency].
 SC-2:
   family: SC
   name: Application Partitioning
@@ -4536,8 +4536,8 @@ SC-5 (3):
   name: Detection / Monitoring
   description: |-
     The organization:
-       (3)(a).  Employs [Assignment: organization-defined monitoring tools] to detect indicators of denial of service attacks against the information system; and
-       (3)(b).  Monitors [Assignment: organization-defined information system resources] to determine if sufficient resources exist to prevent effective denial of service attacks.
+     -  (3)(a).  Employs [Assignment: organization-defined monitoring tools] to detect indicators of denial of service attacks against the information system; and
+     -  (3)(b).  Monitors [Assignment: organization-defined information system resources] to determine if sufficient resources exist to prevent effective denial of service attacks.
 SC-6:
   family: SC
   name: Resource Availability
@@ -4549,9 +4549,9 @@ SC-7:
   name: Boundary Protection
   description: |-
     The information system:
-      a.  Monitors and controls communications at the external boundary of the system and at key internal boundaries within the system;
-      b.  Implements subnetworks for publicly accessible system components that are [Selection: physically; logically] separated from internal organizational networks; and
-      c.  Connects to external networks or information systems only through managed interfaces consisting of boundary protection devices arranged in accordance with an organizational security architecture.
+     - a.  Monitors and controls communications at the external boundary of the system and at key internal boundaries within the system;
+     - b.  Implements subnetworks for publicly accessible system components that are [Selection: physically; logically] separated from internal organizational networks; and
+     - c.  Connects to external networks or information systems only through managed interfaces consisting of boundary protection devices arranged in accordance with an organizational security architecture.
 SC-7 (1):
   family: SC
   name: Physically Separated Subnetworks
@@ -4570,11 +4570,11 @@ SC-7 (4):
   name: External Telecommunications Services
   description: |-
     The organization:
-       (4)(a).  Implements a managed interface for each external telecommunication service;
-       (4)(b).  Establishes a traffic flow policy for each managed interface;
-       (4)(c).  Protects the confidentiality and integrity of the information being transmitted across each interface;
-       (4)(d).  Documents each exception to the traffic flow policy with a supporting mission/business need and duration of that need; and
-       (4)(e).  Reviews exceptions to the traffic flow policy [Assignment: organization-defined frequency] and removes exceptions that are no longer supported by an explicit mission/business need.
+     -  (4)(a).  Implements a managed interface for each external telecommunication service;
+     -  (4)(b).  Establishes a traffic flow policy for each managed interface;
+     -  (4)(c).  Protects the confidentiality and integrity of the information being transmitted across each interface;
+     -  (4)(d).  Documents each exception to the traffic flow policy with a supporting mission/business need and duration of that need; and
+     -  (4)(e).  Reviews exceptions to the traffic flow policy [Assignment: organization-defined frequency] and removes exceptions that are no longer supported by an explicit mission/business need.
 SC-7 (5):
   family: SC
   name: Deny By Default / Allow By Exception
@@ -4602,8 +4602,8 @@ SC-7 (9):
   name: Restrict Threatening Outgoing Communications Traffic
   description: |-
     The information system:
-       (9)(a).  Detects and denies outgoing communications traffic posing a threat to external information systems; and
-       (9)(b).  Audits the identity of internal users associated with denied communications.
+     -  (9)(a).  Detects and denies outgoing communications traffic posing a threat to external information systems; and
+     -  (9)(b).  Audits the identity of internal users associated with denied communications.
 SC-7 (10):
   family: SC
   name: Prevent Unauthorized Exfiltration
@@ -4798,8 +4798,8 @@ SC-15:
   name: Collaborative Computing Devices
   description: |-
     The information system:
-      a.  Prohibits remote activation of collaborative computing devices with the following exceptions: [Assignment: organization-defined exceptions where remote activation is to be allowed]; and
-      b.  Provides an explicit indication of use to users physically present at the devices.
+     - a.  Prohibits remote activation of collaborative computing devices with the following exceptions: [Assignment: organization-defined exceptions where remote activation is to be allowed]; and
+     - b.  Provides an explicit indication of use to users physically present at the devices.
 SC-15 (1):
   family: SC
   name: Physical Disconnect
@@ -4842,9 +4842,9 @@ SC-18:
   name: Mobile Code
   description: |-
     The organization:
-      a.  Defines acceptable and unacceptable mobile code and mobile code technologies;
-      b.  Establishes usage restrictions and implementation guidance for acceptable mobile code and mobile code technologies; and
-      c.  Authorizes, monitors, and controls the use of mobile code within the information system.
+     - a.  Defines acceptable and unacceptable mobile code and mobile code technologies;
+     - b.  Establishes usage restrictions and implementation guidance for acceptable mobile code and mobile code technologies; and
+     - c.  Authorizes, monitors, and controls the use of mobile code within the information system.
 SC-18 (1):
   family: SC
   name: Identify Unacceptable Code / Take Corrective Actions
@@ -4878,15 +4878,15 @@ SC-19:
   name: Voice Over Internet Protocol
   description: |-
     The organization:
-      a.  Establishes usage restrictions and implementation guidance for Voice over Internet Protocol (VoIP) technologies based on the potential to cause damage to the information system if used maliciously; and
-      b.  Authorizes, monitors, and controls the use of VoIP within the information system.
+     - a.  Establishes usage restrictions and implementation guidance for Voice over Internet Protocol (VoIP) technologies based on the potential to cause damage to the information system if used maliciously; and
+     - b.  Authorizes, monitors, and controls the use of VoIP within the information system.
 SC-20:
   family: SC
   name: Secure Name / Address Resolution Service (Authoritative Source)
   description: |-
     The information system:
-      a.  Provides additional data origin authentication and integrity verification artifacts along with the authoritative name resolution data the system returns in response to external name/address resolution queries; and
-      b.  Provides the means to indicate the security status of child zones and (if the child supports secure resolution services) to enable verification of a chain of trust among parent and child domains, when operating as part of a distributed, hierarchical namespace.
+     - a.  Provides additional data origin authentication and integrity verification artifacts along with the authoritative name resolution data the system returns in response to external name/address resolution queries; and
+     - b.  Provides the means to indicate the security status of child zones and (if the child supports secure resolution services) to enable verification of a chain of trust among parent and child domains, when operating as part of a distributed, hierarchical namespace.
 SC-20 (1):
   family: SC
   name: Child Subspaces
@@ -5033,8 +5033,8 @@ SC-31:
   name: Covert Channel Analysis
   description: |-
     The organization:
-      a.  Performs a covert channel analysis to identify those aspects of communications within the information system that are potential avenues for covert [Selection (one or more): storage; timing] channels; and
-      b.  Estimates the maximum bandwidth of those channels.
+     - a.  Performs a covert channel analysis to identify those aspects of communications within the information system that are potential avenues for covert [Selection (one or more): storage; timing] channels; and
+     - b.  Estimates the maximum bandwidth of those channels.
 SC-31 (1):
   family: SC
   name: Test Covert Channels For Exploitability
@@ -5068,8 +5068,8 @@ SC-34:
   name: Non-Modifiable Executable Programs
   description: |-
     The information system at [Assignment: organization-defined information system components]:
-      a.  Loads and executes the operating environment from hardware-enforced, read-only media; and
-      b.  Loads and executes [Assignment: organization-defined applications] from hardware-enforced, read-only media.
+     - a.  Loads and executes the operating environment from hardware-enforced, read-only media; and
+     - b.  Loads and executes [Assignment: organization-defined applications] from hardware-enforced, read-only media.
 SC-34 (1):
   family: SC
   name: No Writable Storage
@@ -5087,8 +5087,8 @@ SC-34 (3):
   name: Hardware-Based Protection
   description: |-
     The organization:
-       (3)(a).  Employs hardware-based, write-protect for [Assignment: organization-defined information system firmware components]; and
-       (3)(b).  Implements specific procedures for [Assignment: organization-defined authorized individuals] to manually disable hardware write-protect for firmware modifications and re-enable the write-protect prior to returning to operational mode.
+     -  (3)(a).  Employs hardware-based, write-protect for [Assignment: organization-defined information system firmware components]; and
+     -  (3)(b).  Implements specific procedures for [Assignment: organization-defined authorized individuals] to manually disable hardware write-protect for firmware modifications and re-enable the write-protect prior to returning to operational mode.
 SC-35:
   family: SC
   name: Honeyclients
@@ -5181,8 +5181,8 @@ SC-42:
   name: Sensor Capability And Data
   description: |-
     The information system:
-      a.  Prohibits the remote activation of environmental sensing capabilities with the following exceptions: [Assignment: organization-defined exceptions where remote activation of sensors is allowed]; and
-      b.  Provides an explicit indication of sensor use to [Assignment: organization-defined class of users].
+     - a.  Prohibits the remote activation of environmental sensing capabilities with the following exceptions: [Assignment: organization-defined exceptions where remote activation of sensors is allowed]; and
+     - b.  Provides an explicit indication of sensor use to [Assignment: organization-defined class of users].
 SC-42 (1):
   family: SC
   name: Reporting To Authorized Individuals Or Roles
@@ -5206,8 +5206,8 @@ SC-43:
   name: Usage Restrictions
   description: |-
     The organization:
-      a.  Establishes usage restrictions and implementation guidance for [Assignment: organization-defined information system components] based on the potential to cause damage to the information system if used maliciously; and
-      b.  Authorizes, monitors, and controls the use of such components within the information system.
+     - a.  Establishes usage restrictions and implementation guidance for [Assignment: organization-defined information system components] based on the potential to cause damage to the information system if used maliciously; and
+     - b.  Authorizes, monitors, and controls the use of such components within the information system.
 SC-44:
   family: SC
   name: Detonation Chambers
@@ -5218,21 +5218,21 @@ SI-1:
   name: System And Information Integrity Policy And Procedures
   description: |-
     The organization:
-      a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
-        1.  A system and information integrity policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
-        2.  Procedures to facilitate the implementation of the system and information integrity policy and associated system and information integrity controls; and
-      b.  Reviews and updates the current:
-        1.  System and information integrity policy [Assignment: organization-defined frequency]; and
-        2.  System and information integrity procedures [Assignment: organization-defined frequency].
+     - a.  Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       - 1.  A system and information integrity policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       - 2.  Procedures to facilitate the implementation of the system and information integrity policy and associated system and information integrity controls; and
+     - b.  Reviews and updates the current:
+       - 1.  System and information integrity policy [Assignment: organization-defined frequency]; and
+       - 2.  System and information integrity procedures [Assignment: organization-defined frequency].
 SI-2:
   family: SI
   name: Flaw Remediation
   description: |-
     The organization:
-      a.  Identifies, reports, and corrects information system flaws;
-      b.  Tests software and firmware updates related to flaw remediation for effectiveness and potential side effects before installation;
-      c.  Installs security-relevant software and firmware updates within [Assignment: organization-defined time period] of the release of the updates; and
-      d.  Incorporates flaw remediation into the organizational configuration management process.
+     - a.  Identifies, reports, and corrects information system flaws;
+     - b.  Tests software and firmware updates related to flaw remediation for effectiveness and potential side effects before installation;
+     - c.  Installs security-relevant software and firmware updates within [Assignment: organization-defined time period] of the release of the updates; and
+     - d.  Incorporates flaw remediation into the organizational configuration management process.
 SI-2 (1):
   family: SI
   name: Central Management
@@ -5248,8 +5248,8 @@ SI-2 (3):
   name: Time To Remediate Flaws / Benchmarks For Corrective Actions
   description: |-
     The organization:
-       (3)(a).  Measures the time between flaw identification and flaw remediation; and
-       (3)(b).  Establishes [Assignment: organization-defined benchmarks] for taking corrective actions.
+     -  (3)(a).  Measures the time between flaw identification and flaw remediation; and
+     -  (3)(b).  Establishes [Assignment: organization-defined benchmarks] for taking corrective actions.
 SI-2 (4):
   family: SI
   name: Automated Patch Management Tools
@@ -5270,12 +5270,12 @@ SI-3:
   name: Malicious Code Protection
   description: |-
     The organization:
-      a.  Employs malicious code protection mechanisms at information system entry and exit points to detect and eradicate malicious code;
-      b.  Updates malicious code protection mechanisms whenever new releases are available in accordance with organizational configuration management policy and procedures;
-      c.  Configures malicious code protection mechanisms to:
-        1.  Perform periodic scans of the information system [Assignment: organization-defined frequency] and real-time scans of files from external sources at [Selection (one or more); endpoint; network entry/exit points] as the files are downloaded, opened, or executed in accordance with organizational security policy; and
-        2.  [Selection (one or more): block malicious code; quarantine malicious code;  send alert to administrator; [Assignment: organization-defined action]] in response to malicious code detection; and
-      d.  Addresses the receipt of false positives during malicious code detection and eradication and the resulting potential impact on the availability of the information system.
+     - a.  Employs malicious code protection mechanisms at information system entry and exit points to detect and eradicate malicious code;
+     - b.  Updates malicious code protection mechanisms whenever new releases are available in accordance with organizational configuration management policy and procedures;
+     - c.  Configures malicious code protection mechanisms to:
+       - 1.  Perform periodic scans of the information system [Assignment: organization-defined frequency] and real-time scans of files from external sources at [Selection (one or more); endpoint; network entry/exit points] as the files are downloaded, opened, or executed in accordance with organizational security policy; and
+       - 2.  [Selection (one or more): block malicious code; quarantine malicious code;  send alert to administrator; [Assignment: organization-defined action]] in response to malicious code detection; and
+     - d.  Addresses the receipt of false positives during malicious code detection and eradication and the resulting potential impact on the availability of the information system.
 SI-3 (1):
   family: SI
   name: Central Management
@@ -5303,8 +5303,8 @@ SI-3 (6):
   name: Testing / Verification
   description: |-
     The organization:
-       (6)(a).  Tests malicious code protection mechanisms [Assignment: organization-defined frequency] by introducing a known benign, non-spreading test case into the information system; and
-       (6)(b).  Verifies that both detection of the test case and associated incident reporting occur.
+     -  (6)(a).  Tests malicious code protection mechanisms [Assignment: organization-defined frequency] by introducing a known benign, non-spreading test case into the information system; and
+     -  (6)(b).  Verifies that both detection of the test case and associated incident reporting occur.
 SI-3 (7):
   family: SI
   name: Nonsignature-Based Detection
@@ -5329,24 +5329,24 @@ SI-3 (10):
   name: Malicious Code Analysis
   description: |-
     The organization:
-       (10)(a).  Employs [Assignment: organization-defined tools and techniques] to analyze the characteristics and behavior of malicious code; and
-       (10)(b).  Incorporates the results from malicious code analysis into organizational incident response and flaw remediation processes.
+     -  (10)(a).  Employs [Assignment: organization-defined tools and techniques] to analyze the characteristics and behavior of malicious code; and
+     -  (10)(b).  Incorporates the results from malicious code analysis into organizational incident response and flaw remediation processes.
 SI-4:
   family: SI
   name: Information System Monitoring
   description: |-
     The organization:
-      a.  Monitors the information system to detect:
-        1.  Attacks and indicators of potential attacks in accordance with [Assignment: organization-defined monitoring objectives]; and
-        2.  Unauthorized local, network, and remote connections;
-      b.  Identifies unauthorized use of the information system through [Assignment: organization-defined techniques and methods];
-      c.  Deploys monitoring devices:
-        1.  Strategically within the information system to collect organization-determined essential information; and
-        2.  At ad hoc locations within the system to track specific types of transactions of interest to the organization;
-      d.  Protects information obtained from intrusion-monitoring tools from unauthorized access, modification, and deletion;
-      e.  Heightens the level of information system monitoring activity whenever there is an indication of increased risk to organizational operations and assets, individuals, other organizations, or the Nation based on law enforcement information, intelligence information, or other credible sources of information;
-      f.  Obtains legal opinion with regard to information system monitoring activities in accordance with applicable federal laws, Executive Orders, directives, policies, or regulations; and
-      g.  Provides [Assignment: organization-defined information system monitoring information] to [Assignment: organization-defined personnel or roles] [Selection (one or more): as needed; [Assignment: organization-defined frequency]].
+     - a.  Monitors the information system to detect:
+       - 1.  Attacks and indicators of potential attacks in accordance with [Assignment: organization-defined monitoring objectives]; and
+       - 2.  Unauthorized local, network, and remote connections;
+     - b.  Identifies unauthorized use of the information system through [Assignment: organization-defined techniques and methods];
+     - c.  Deploys monitoring devices:
+       - 1.  Strategically within the information system to collect organization-determined essential information; and
+       - 2.  At ad hoc locations within the system to track specific types of transactions of interest to the organization;
+     - d.  Protects information obtained from intrusion-monitoring tools from unauthorized access, modification, and deletion;
+     - e.  Heightens the level of information system monitoring activity whenever there is an indication of increased risk to organizational operations and assets, individuals, other organizations, or the Nation based on law enforcement information, intelligence information, or other credible sources of information;
+     - f.  Obtains legal opinion with regard to information system monitoring activities in accordance with applicable federal laws, Executive Orders, directives, policies, or regulations; and
+     - g.  Provides [Assignment: organization-defined information system monitoring information] to [Assignment: organization-defined personnel or roles] [Selection (one or more): as needed; [Assignment: organization-defined frequency]].
 SI-4 (1):
   family: SI
   name: System-Wide Intrusion Detection System
@@ -5420,9 +5420,9 @@ SI-4 (13):
   name: Analyze Traffic / Event Patterns
   description: |-
     The organization:
-       (13)(a).  Analyzes communications traffic/event patterns for the information system;
-       (13)(b).  Develops profiles representing common traffic patterns and/or events; and
-       (13)(c).  Uses the traffic/event profiles in tuning system-monitoring devices to reduce the number of false positives and the number of false negatives.
+     -  (13)(a).  Analyzes communications traffic/event patterns for the information system;
+     -  (13)(b).  Develops profiles representing common traffic patterns and/or events; and
+     -  (13)(c).  Uses the traffic/event profiles in tuning system-monitoring devices to reduce the number of false positives and the number of false negatives.
 SI-4 (14):
   family: SI
   name: Wireless Intrusion Detection
@@ -5492,10 +5492,10 @@ SI-5:
   name: Security Alerts, Advisories, And Directives
   description: |-
     The organization:
-      a.  Receives information system security alerts, advisories, and directives from [Assignment: organization-defined external organizations] on an ongoing basis;
-      b.  Generates internal security alerts, advisories, and directives as deemed necessary;
-      c.  Disseminates security alerts, advisories, and directives to: [Selection (one or more): [Assignment: organization-defined personnel or roles]; [Assignment: organization-defined elements within the organization]; [Assignment: organization-defined external organizations]]; and
-      d.  Implements security directives in accordance with established time frames, or notifies the issuing organization of the degree of noncompliance.
+     - a.  Receives information system security alerts, advisories, and directives from [Assignment: organization-defined external organizations] on an ongoing basis;
+     - b.  Generates internal security alerts, advisories, and directives as deemed necessary;
+     - c.  Disseminates security alerts, advisories, and directives to: [Selection (one or more): [Assignment: organization-defined personnel or roles]; [Assignment: organization-defined elements within the organization]; [Assignment: organization-defined external organizations]]; and
+     - d.  Implements security directives in accordance with established time frames, or notifies the issuing organization of the degree of noncompliance.
 SI-5 (1):
   family: SI
   name: Automated Alerts And Advisories
@@ -5506,10 +5506,10 @@ SI-6:
   name: Security Function Verification
   description: |-
     The information system:
-      a.  Verifies the correct operation of [Assignment: organization-defined security functions];
-      b.  Performs this verification [Selection (one or more): [Assignment: organization-defined system transitional states]; upon command by user with appropriate privilege; [Assignment: organization-defined frequency]];
-      c.  Notifies [Assignment: organization-defined personnel or roles] of failed security verification tests; and
-      d.  [Selection (one or more): shuts the information system down; restarts the information system; [Assignment: organization-defined alternative action(s)]] when anomalies are discovered.
+     - a.  Verifies the correct operation of [Assignment: organization-defined security functions];
+     - b.  Performs this verification [Selection (one or more): [Assignment: organization-defined system transitional states]; upon command by user with appropriate privilege; [Assignment: organization-defined frequency]];
+     - c.  Notifies [Assignment: organization-defined personnel or roles] of failed security verification tests; and
+     - d.  [Selection (one or more): shuts the information system down; restarts the information system; [Assignment: organization-defined alternative action(s)]] when anomalies are discovered.
 SI-6 (1):
   family: SI
   name: Notification Of Failed Security Tests
@@ -5609,8 +5609,8 @@ SI-7 (14):
   name: Binary Or Machine Executable Code
   description: |-
     The organization:
-       (14)(a).  Prohibits the use of binary or machine-executable code from sources with limited or no warranty and without the provision of source code; and
-       (14)(b).  Provides exceptions to the source code requirement only for compelling mission/operational requirements and with the approval of the authorizing official.
+     -  (14)(a).  Prohibits the use of binary or machine-executable code from sources with limited or no warranty and without the provision of source code; and
+     -  (14)(b).  Provides exceptions to the source code requirement only for compelling mission/operational requirements and with the approval of the authorizing official.
 SI-7 (15):
   family: SI
   name: Code Authentication
@@ -5626,8 +5626,8 @@ SI-8:
   name: Spam Protection
   description: |-
     The organization:
-      a.  Employs spam protection mechanisms at information system entry and exit points to detect and take action on unsolicited messages; and
-      b.  Updates spam protection mechanisms when new releases are available in accordance with organizational configuration management policy and procedures.
+     - a.  Employs spam protection mechanisms at information system entry and exit points to detect and take action on unsolicited messages; and
+     - b.  Updates spam protection mechanisms when new releases are available in accordance with organizational configuration management policy and procedures.
 SI-8 (1):
   family: SI
   name: Central Management
@@ -5655,9 +5655,9 @@ SI-10 (1):
   name: Manual Override Capability
   description: |-
     The information system:
-       (1)(a).  Provides a manual override capability for input validation of [Assignment: organization-defined inputs];
-       (1)(b).  Restricts the use of the manual override capability to only [Assignment: organization-defined authorized individuals]; and
-       (1)(c).  Audits the use of the manual override capability.
+     -  (1)(a).  Provides a manual override capability for input validation of [Assignment: organization-defined inputs];
+     -  (1)(b).  Restricts the use of the manual override capability to only [Assignment: organization-defined authorized individuals]; and
+     -  (1)(c).  Audits the use of the manual override capability.
 SI-10 (2):
   family: SI
   name: Review / Resolution Of Errors
@@ -5684,8 +5684,8 @@ SI-11:
   name: Error Handling
   description: |-
     The information system:
-      a.  Generates error messages that provide information necessary for corrective actions without revealing information that could be exploited by adversaries; and
-      b.  Reveals error messages only to [Assignment: organization-defined personnel or roles].
+     - a.  Generates error messages that provide information necessary for corrective actions without revealing information that could be exploited by adversaries; and
+     - b.  Reveals error messages only to [Assignment: organization-defined personnel or roles].
 SI-12:
   family: SI
   name: Information Handling And Retention
@@ -5698,8 +5698,8 @@ SI-13:
   name: Predictable Failure Prevention
   description: |-
     The organization:
-      a.  Determines mean time to failure (MTTF) for [Assignment: organization-defined information system components] in specific environments of operation; and
-      b.  Provides substitute information system components and a means to exchange active and standby components at [Assignment: organization-defined MTTF substitution criteria].
+     - a.  Determines mean time to failure (MTTF) for [Assignment: organization-defined information system components] in specific environments of operation; and
+     - b.  Provides substitute information system components and a means to exchange active and standby components at [Assignment: organization-defined MTTF substitution criteria].
 SI-13 (1):
   family: SI
   name: Transferring Component Responsibilities
@@ -5721,8 +5721,8 @@ SI-13 (4):
   name: Standby Component Installation / Notification
   description: |-
     The organization, if information system component failures are detected:
-       (4)(a).  Ensures that the standby components are successfully and transparently installed within [Assignment: organization-defined time period]; and
-       (4)(b).  [Selection (one or more): activates [Assignment: organization-defined alarm]; automatically shuts down the information system].
+     -  (4)(a).  Ensures that the standby components are successfully and transparently installed within [Assignment: organization-defined time period]; and
+     -  (4)(b).  [Selection (one or more): activates [Assignment: organization-defined alarm]; automatically shuts down the information system].
 SI-13 (5):
   family: SI
   name: Failover Capability

--- a/utils/parser.go
+++ b/utils/parser.go
@@ -203,11 +203,11 @@ func parseDescription(family string, statements []XMLStatement) string {
 
 			if len(chars) > 1 {
 				for _, char := range chars[1:] {
-					description += fmt.Sprintf("    %s.  %s\n", char, s.Description)
+					description += fmt.Sprintf("   - %s.  %s\n", char, s.Description)
 
 				}
 			} else {
-				description += fmt.Sprintf("  %s.  %s\n", chars[0], s.Description)
+				description += fmt.Sprintf(" - %s.  %s\n", chars[0], s.Description)
 			}
 
 		} else {


### PR DESCRIPTION
# Problem statement
NIST published controls ([source](https://nvd.nist.gov/static/feeds/xml/sp80053/rev4/800-53-controls.xml)) are well structured and hierarchical. Our content here, however, is unstructured plain-text.

The plain-text looks nice in TXT editor, however rendering the controls elsewhere (web, word processor) leads into problems with padding, text overflows, alignment etc. Having the unstructured text in our yaml files leaves us with little options, but developing custom parser and re-formaters.

# Proposed Solution
Parse NIST structured and hierarchical text to standardized text format.

I considered putting here HTML, Markdown (.md), restructured text (.rst). But ultimately, I believe Markdown is the best fit.
 - First of all every modern ui framework nowdays offers methods to render markdown nicely
 - It makes only minor changes to our texts (just adds bullets to the bullet lists)

